### PR TITLE
修改一个数据

### DIFF
--- a/data/items/2017/04.json
+++ b/data/items/2017/04.json
@@ -148,8 +148,8 @@
       },
       {
         "site": "bilibili",
-        "id": "6054",
-        "begin": "2017-04-01T19:30:00.000Z",
+        "id": "5970",
+        "begin": "2017-04-02T03:30:00.000Z",
         "official": true,
         "premuiumOnly": false,
         "censored": false,


### PR DESCRIPTION
根据 http://bangumi.bilibili.com/jsonp/seasoninfo/5970.ver 修改了《进击的巨人 第二季》的 B 站 id 和开始时间。