### PR TITLE
v0.3 版本提案

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- 6
+- "12"
 cache:
   directories:
   - node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,19 +62,15 @@ dist/                                --> 存放构建后数据的目录
     "type": "tv", // 番组类型 [required]
     "lang": "ja", // 番组语言 [required]
     "officialSite": "http://re-zero-anime.jp/", // 官网 [required]
-    "begin": "2016-04-03T16:35:00.000Z", // tv/web：番组开始时间；movie：上映日期；ova：首话发售时间（未确定则置空） [required]
+    "begin": "2016-04-03T16:35:00.000Z", // tv/web：番组开始时间；movie：上映日期；ova：首话发售时间 [required]
     "end": "", // tv/web：番组完结时间；movie：无意义；ova：则为最终话发售时间（未确定则置空） [required]
-    "comment": "", // 备注 [required]
+    "comment": "", // 备注
     "sites": [ // 站点 [required]
         // 放送站点
         {
             "site": "bilibili", // 站点 name，请和最外层 sites 字段中的元数据对应 [required]
             "id": "3461", // 站点 id，可用于替换模板中相应的字段
             "url": "http://www.bilibili.com/sp/物语系列", // url，如果当前url不符合urlTemplate中的规则时使用，优先级高于id
-            "official": true, // 是否为官方放送（若不确定则为 null）。
-            "premuiumOnly": false, // 是否为收费观看（若不确定则为 null）。
-            "censored": false, // 是否有被和谐的情况存在（若不确定则为 null）。
-            "exist": true, // 是否有实际视频（若不确定则为 null）。
             "begin": "2016-04-03T17:35:00.000Z", // 放送开始时间。
             "comment": "" // 备注
         },
@@ -99,7 +95,7 @@ dist/                                --> 存放构建后数据的目录
     // 站点字段名，和番组数据中 sites 数组中元素的 site 字段名对应
     "bangumi": {
         "title": "番组计划", // 站点名称 [required]
-        "urlTemplate": "http://bangumi.tv/subject/{{id}}" // 站点 url 模板
+        "urlTemplate": "https://bangumi.tv/subject/{{id}}" // 站点 url 模板
     }
 }
 ```
@@ -108,21 +104,21 @@ dist/                                --> 存放构建后数据的目录
 
 通过站点的 `site` 字段获取到站点元数据中相应的 `urlTemplate`，并用相应的字段数据替换掉模板中用两层花括号包裹的占位符。
 
-例如：`id` 为 `12345`，`urlTemplate` 为 `http://www.a.com/?id={{id}}`，则替换后为 `http://www.a.com/?id=12345`
+例如：`id` 为 `12345`，`urlTemplate` 为 `https://www.a.com/?id={{id}}`，则替换后为 `https://www.a.com/?id=12345`
 
 各个放送站点的 url 均为专辑页面，以下列表中，突出部分为 id：
 
-* [http://www.acfun.cn/v/ab<kbd>1480039</kbd>](http://www.acfun.cn/v/ab1480039)
-* [https://bangumi.bilibili.com/anime/<kbd>5507</kbd>](https://bangumi.bilibili.com/anime/5507)
-* [http://www.iqiyi.com/<kbd>a_19rrh9uqb5</kbd>.html](http://www.iqiyi.com/a_19rrh9uqb5.html)
-* [http://movie.kankan.com/movie/<kbd>87458</kbd>](http://movie.kankan.com/movie/87458)
+* [https://www.acfun.cn/bangumi/aa<kbd>5022161</kbd>](https://www.acfun.cn/bangumi/aa5022161)
+* [https://www.bilibili.com/bangumi/media/md<kbd>5507</kbd>](https://www.bilibili.com/bangumi/media/md5507)
+* [https://www.iqiyi.com/<kbd>a_19rrh9uqb5</kbd>.html](https://www.iqiyi.com/a_19rrh9uqb5.html)
 * [https://www.le.com/comic/<kbd>10029954</kbd>.html](https://www.le.com/comic/10029954.html)
 * [https://www.mgtv.com/h/<kbd>301218</kbd>.html](https://www.mgtv.com/h/301218.html)
-* [http://ch.nicovideo.jp/<kbd>kemono-friends</kbd>](http://ch.nicovideo.jp/kemono-friends)
+* [https://ch.nicovideo.jp/<kbd>kemono-friends</kbd>](https://ch.nicovideo.jp/kemono-friends)
 * [http://v.pptv.com/page/<kbd>adq2NJwCcrATkfk</kbd>.html](http://v.pptv.com/page/adq2NJwCcrATkfk.html)
 * [https://tv.sohu.com/<kbd>s2011/yjdwb</kbd>](https://tv.sohu.com/s2011/yjdwb/)
 * [https://v.qq.com/detail/<kbd>g/gyf3u5vx0m42531</kbd>.html](https://v.qq.com/detail/g/gyf3u5vx0m42531.html)
 * [https://list.youku.com/show/id_z<kbd>4d8cce35815111e6b16e</kbd>.html](https://list.youku.com/show/id_z4d8cce35815111e6b16</kbd>.html)
+* [https://www.netflix.com/title/<kbd>81033445</kbd>](https://www.netflix.com/title/81033445)
 
 ## 验证
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://img.shields.io/travis/bangumi-data/bangumi-data/master.svg)](https://travis-ci.org/bangumi-data/bangumi-data)
 [![NPM Version](https://img.shields.io/npm/v/bangumi-data.svg)](https://www.npmjs.com/package/bangumi-data)
+[![](https://data.jsdelivr.com/v1/package/npm/bangumi-data/badge?style=rounded)](https://www.jsdelivr.com/package/npm/bangumi-data)
 [![Slack Welcome](https://img.shields.io/badge/Slack-welcome-yellow.svg)](https://bangumi-data.slack.com)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -16,6 +17,8 @@ npm install bangumi-data
 ```js
 const bangumiData = require('bangumi-data');
 ```
+
+或者通过 CDN `https://cdn.jsdelivr.net/npm/bangumi-data@0.3/dist/data.json` 获取 `v0.3.x` 的最新数据
 
 ## 帮助我们改进
 

--- a/data/items/1960/01.json
+++ b/data/items/1960/01.json
@@ -14,7 +14,6 @@
     "officialSite": "",
     "begin": "1960-01-15T16:00:00.000Z",
     "end": "1960-01-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1968/01.json
+++ b/data/items/1968/01.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1968-01-03T16:00:00.000Z",
     "end": "1969-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12tt",
-        "begin": "2015-10-29T08:31:41.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-29T08:31:41.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1968/03.json
+++ b/data/items/1968/03.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1968-03-30T16:00:00.000Z",
     "end": "1971-09-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "kyojin-no-hoshi",
-        "begin": "2012-12-24T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-24T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/1968/07.json
+++ b/data/items/1968/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1968-07-21T16:00:00.000Z",
     "end": "1968-07-21T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1968/09.json
+++ b/data/items/1968/09.json
@@ -12,7 +12,6 @@
     "officialSite": "",
     "begin": "1968-09-03T13:15:00.000Z",
     "end": "1969-03-25T13:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1968/10.json
+++ b/data/items/1968/10.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1968-10-07T07:00:00.000Z",
     "end": "1969-03-31T07:24:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1969/04.json
+++ b/data/items/1969/04.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/archive/kurenai.html",
     "begin": "1969-04-02T12:30:00.000Z",
     "end": "1969-09-24T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "1969-04-06T15:30:00.000Z",
     "end": "1969-09-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1969/10.json
+++ b/data/items/1969/10.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.fujitv.co.jp/sazaesan/",
     "begin": "1969-10-05T09:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2486",
-        "begin": "1969-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1969-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/tigermask/",
     "begin": "1969-10-02T14:00:00.000Z",
     "end": "1971-09-30T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/tatsunoko_gekijo/",
     "begin": "1969-10-05T22:30:00.000Z",
     "end": "1970-09-27T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -69,13 +61,8 @@
       },
       {
         "site": "bilibili",
-        "id": "20554",
-        "begin": "1969-10-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8272",
+        "begin": "1969-10-04T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1970/04.json
+++ b/data/items/1970/04.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1970-04-07T16:00:00.000Z",
     "end": "1971-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha4rcx",
-        "begin": "2016-12-05T06:24:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-05T06:24:50.000Z"
       },
       {
         "site": "bangumi",
@@ -42,7 +36,6 @@
     "officialSite": "",
     "begin": "1970-04-01T12:00:00.000Z",
     "end": "1971-09-29T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,13 +43,8 @@
       },
       {
         "site": "bilibili",
-        "id": "24332",
-        "begin": "1970-03-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "95252",
+        "begin": "1970-03-31T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1971/04.json
+++ b/data/items/1971/04.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1971-04-08T14:00:00.000Z",
     "end": "1971-09-30T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1971/09.json
+++ b/data/items/1971/09.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tms-e.com/search/index.php?pdt_no=4",
     "begin": "1971-09-25T22:58:00.000Z",
     "end": "1972-06-24T23:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "bakabon",
-        "begin": "2011-09-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-20T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/1971/10.json
+++ b/data/items/1971/10.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1971-10-07T10:00:00.000Z",
     "end": "1972-09-28T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12dh",
-        "begin": "2015-10-29T08:36:30.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-29T08:36:30.000Z"
       },
       {
         "site": "bangumi",
@@ -42,7 +36,6 @@
     "officialSite": "http://www.lupin-3rd.net/",
     "begin": "1971-10-24T03:00:00.000Z",
     "end": "1972-03-26T03:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,12 +44,7 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-1st",
-        "begin": "2011-09-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-20T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/1972/04.json
+++ b/data/items/1972/04.json
@@ -18,17 +18,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/triton/",
     "begin": "1972-04-01T03:35:00.000Z",
     "end": "1972-09-30T04:02:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6EI9uyOJibTeaGIA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1972/07.json
+++ b/data/items/1972/07.json
@@ -14,21 +14,10 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/devilman/",
     "begin": "1972-07-08T10:00:00.000Z",
     "end": "1972-03-31T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "24146"
-      },
-      {
-        "site": "bilibili",
-        "id": "2483",
-        "begin": "1972-07-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/1972/10.json
+++ b/data/items/1972/10.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1972-10-07T11:00:00.000Z",
     "end": "1974-09-28T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "dokonjou_gaeru",
-        "begin": "2012-02-16T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-02-16T06:00:00.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/archive/gatchaman.html",
     "begin": "1972-10-01T10:00:00.000Z",
     "end": "1974-09-29T07:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "6246",
-        "begin": "1972-09-30T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1972-09-30T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1972/12.json
+++ b/data/items/1972/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1972-12-03T10:00:00.000Z",
     "end": "1974-09-01T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "1972-12-17T16:00:00.000Z",
     "end": "1972-12-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,12 +38,7 @@
       {
         "site": "nicovideo",
         "id": "pankopa",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1973/01.json
+++ b/data/items/1973/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.mxtv.co.jp/rockychack/",
     "begin": "1973-01-07T22:30:00.000Z",
     "end": "1973-12-30T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,21 +30,10 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/babil2/",
     "begin": "1973-01-01T08:00:00.000Z",
     "end": "1973-09-24T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "37266"
-      },
-      {
-        "site": "bilibili",
-        "id": "2140",
-        "begin": "1972-12-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/1973/03.json
+++ b/data/items/1973/03.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1973-03-17T16:00:00.000Z",
     "end": "1973-03-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "pankopa-02",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1973/10.json
+++ b/data/items/1973/10.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1973-10-13T10:00:00.000Z",
     "end": "1974-03-30T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1dwl",
-        "begin": "2015-11-04T03:13:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-04T03:13:43.000Z"
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "http://www.mxtv.co.jp/samurai_g/",
     "begin": "1973-10-07T22:30:00.000Z",
     "end": "1974-09-15T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "",
     "begin": "1973-10-04T10:00:00.000Z",
     "end": "1974-03-28T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,7 +73,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/archive/cassyan.html",
     "begin": "1973-10-02T18:08:00.000Z",
     "end": "1974-06-25T18:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -89,13 +80,8 @@
       },
       {
         "site": "bilibili",
-        "id": "6401",
-        "begin": "2008-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10572",
+        "begin": "2008-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -111,7 +97,6 @@
     "officialSite": "",
     "begin": "1973-10-03T16:00:00.000Z",
     "end": "1974-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -120,12 +105,7 @@
       {
         "site": "nicovideo",
         "id": "karate",
-        "begin": "2012-02-21T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-02-21T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/1974/01.json
+++ b/data/items/1974/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.heidi.ne.jp/",
     "begin": "1974-01-06T01:20:00.000Z",
     "end": "1974-12-29T01:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IxjjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2480",
-        "begin": "1974-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1974-01-05T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1974/04.json
+++ b/data/items/1974/04.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1974-04-05T16:00:00.000Z",
     "end": "1974-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha4tnh",
-        "begin": "2016-12-05T06:26:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-05T06:26:31.000Z"
       },
       {
         "site": "bangumi",
@@ -42,7 +36,6 @@
     "officialSite": "http://cha-ken.com/",
     "begin": "1974-04-01T16:00:00.000Z",
     "end": "1974-06-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,12 +44,7 @@
       {
         "site": "bilibili",
         "id": "2481",
-        "begin": "1973-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1973-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -72,7 +60,6 @@
     "officialSite": "",
     "begin": "1974-04-06T22:00:00.000Z",
     "end": "1974-09-27T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1974/10.json
+++ b/data/items/1974/10.json
@@ -11,7 +11,6 @@
     "officialSite": "http://s.mxtv.jp/polymer/",
     "begin": "1974-10-04T10:00:00.000Z",
     "end": "1975-03-28T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -19,13 +18,8 @@
       },
       {
         "site": "bilibili",
-        "id": "6489",
-        "begin": "1974-09-30T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10612",
+        "begin": "1974-09-30T16:00:01.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://www.gyatoruzu.net/",
     "begin": "1974-10-05T15:30:00.000Z",
     "end": "1976-03-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://www.bandaivisual.co.jp/yamato/data/frame_saga.html",
     "begin": "1974-10-06T17:30:00.000Z",
     "end": "1975-03-30T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +62,7 @@
       {
         "site": "bilibili",
         "id": "2451",
-        "begin": "1974-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1974-10-05T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1975/01.json
+++ b/data/items/1975/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/843/",
     "begin": "1975-01-05T22:00:00.000Z",
     "end": "1975-12-28T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2983",
-        "begin": "1997-03-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-03-14T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1975/04.json
+++ b/data/items/1975/04.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1975-04-04T16:00:00.000Z",
     "end": "1976-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "1975-04-05T22:00:00.000Z",
     "end": "1975-09-27T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,7 +49,6 @@
     "officialSite": "http://www.tms-e.com/search/index.php?pdt_no=13",
     "begin": "1975-04-17T22:00:00.000Z",
     "end": "1975-09-26T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1975/10.json
+++ b/data/items/1975/10.json
@@ -11,37 +11,21 @@
     "officialSite": "",
     "begin": "1975-10-15T16:00:00.000Z",
     "end": "1982-06-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8TwIhu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzu2kp",
-        "begin": "2016-08-10T05:54:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-10T05:54:38.000Z"
       },
       {
         "site": "letv",
         "id": "82272",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -63,17 +47,11 @@
     "officialSite": "",
     "begin": "1975-10-05T16:00:00.000Z",
     "end": "1977-02-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1cb9",
-        "begin": "2015-10-29T08:35:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-29T08:35:22.000Z"
       },
       {
         "site": "bangumi",
@@ -93,7 +71,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/arabian_sindbad.html",
     "begin": "1975-10-01T22:30:00.000Z",
     "end": "1976-09-29T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -113,7 +90,6 @@
     "officialSite": "",
     "begin": "1975-10-05T10:00:00.000Z",
     "end": "1976-08-29T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -122,12 +98,7 @@
       {
         "site": "bilibili",
         "id": "2475",
-        "begin": "1975-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1975-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -143,7 +114,6 @@
     "officialSite": "",
     "begin": "1975-10-06T23:00:00.000Z",
     "end": "1977-09-26T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -152,12 +122,7 @@
       {
         "site": "nicovideo",
         "id": "ganso-bakabon",
-        "begin": "2011-09-22T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-22T12:00:00.000Z"
       }
     ]
   },
@@ -173,7 +138,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/archive/timebokan.html",
     "begin": "1975-10-04T23:00:00.000Z",
     "end": "1976-12-25T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1976/01.json
+++ b/data/items/1976/01.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1976-01-02T16:00:00.000Z",
     "end": "1976-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "8/8szu83s4qj0z4o0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/hahawotazunete_sanzenri.html",
     "begin": "1976-01-04T03:30:00.000Z",
     "end": "1976-12-26T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "5948",
-        "begin": "1976-01-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1976-01-03T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1976/04.json
+++ b/data/items/1976/04.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1976-04-01T16:00:00.000Z",
     "end": "1977-01-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1eit",
-        "begin": "2015-08-14T17:06:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:06:44.000Z"
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "http://www.eiken-anime.jp/works/ufod/",
     "begin": "1976-04-06T12:30:00.000Z",
     "end": "1976-09-28T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/hayabusa/",
     "begin": "1976-04-02T07:30:00.000Z",
     "end": "1976-09-17T08:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,7 +73,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works_animation/archive/gordam.html",
     "begin": "1976-04-04T12:00:00.000Z",
     "end": "1976-12-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -101,21 +92,10 @@
     "officialSite": "",
     "begin": "1976-04-17T23:00:00.000Z",
     "end": "1977-05-28T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "37177"
-      },
-      {
-        "site": "bilibili",
-        "id": "2474",
-        "begin": "1976-04-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/1976/07.json
+++ b/data/items/1976/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://machine-blaster.com/",
     "begin": "1976-07-05T14:30:00.000Z",
     "end": "1977-03-28T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "machine-blaster",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1976/10.json
+++ b/data/items/1976/10.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1976-10-07T21:30:00.000Z",
     "end": "1979-03-28T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "1976-10-01T16:00:00.000Z",
     "end": "1979-02-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibDMNiaicNZyQdq6FA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1977/01.json
+++ b/data/items/1977/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://araiguma-rascal.com/",
     "begin": "1977-01-02T22:00:00.000Z",
     "end": "1978-12-25T22:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,7 +33,6 @@
     "officialSite": "http://yatterman.jp/",
     "begin": "1977-01-01T17:50:00.000Z",
     "end": "1979-01-27T06:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1977/02.json
+++ b/data/items/1977/02.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1977-02-03T09:00:00.000Z",
     "end": "1977-09-15T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1977/03.json
+++ b/data/items/1977/03.json
@@ -11,27 +11,11 @@
     "officialSite": "",
     "begin": "1977-03-06T09:00:00.000Z",
     "end": "1978-03-26T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1enp",
-        "begin": "2015-11-09T09:22:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464504",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-09T09:22:58.000Z"
       },
       {
         "site": "bangumi",
@@ -51,7 +35,6 @@
     "officialSite": "",
     "begin": "1977-03-03T13:30:00.000Z",
     "end": "1977-12-29T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "2468",
-        "begin": "1977-03-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1977-03-02T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1977/04.json
+++ b/data/items/1977/04.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1977-04-09T16:00:00.000Z",
     "end": "1977-10-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "ginguizer",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1977/06.json
+++ b/data/items/1977/06.json
@@ -11,21 +11,10 @@
     "officialSite": "",
     "begin": "1977-06-04T10:00:00.000Z",
     "end": "1978-03-25T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "213785"
-      },
-      {
-        "site": "bilibili",
-        "id": "2467",
-        "begin": "1977-06-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/1977/09.json
+++ b/data/items/1977/09.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1977-09-22T10:00:00.000Z",
     "end": "1978-08-31T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1977/10.json
+++ b/data/items/1977/10.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.sunrise-anime.jp/sunrise-inc/works/detail.php?cid=18",
     "begin": "1977-10-08T16:00:00.000Z",
     "end": "1978-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QpZy8FiaibLmzPTbU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "3082",
-        "begin": "1977-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1977-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "1977-10-01T22:30:00.000Z",
     "end": "1978-09-30T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,7 +59,6 @@
     "officialSite": "http://www.tms-e.co.jp/search/introduction.php?pdt_no=53",
     "begin": "1977-10-03T22:30:00.000Z",
     "end": "1980-10-06T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,22 +67,12 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-2nd",
-        "begin": "2011-10-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-26T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2470",
-        "begin": "1977-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1977-10-02T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1978/01.json
+++ b/data/items/1978/01.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1978-01-01T16:00:00.000Z",
     "end": "1978-12-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MiaYSkPhezgxv7VU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1978/03.json
+++ b/data/items/1978/03.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.toei-anim.co.jp/herlock/outline.html",
     "begin": "1978-03-14T10:00:00.000Z",
     "end": "1979-02-13T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1bz9",
-        "begin": "2015-11-04T03:33:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-04T03:33:45.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1978/04.json
+++ b/data/items/1978/04.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1978-04-02T16:00:00.000Z",
     "end": "1979-08-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,21 +30,10 @@
     "officialSite": "",
     "begin": "1978-04-01T10:00:00.000Z",
     "end": "1979-01-27T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "37180"
-      },
-      {
-        "site": "bilibili",
-        "id": "2463",
-        "begin": "1978-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -61,7 +49,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/ikkyu_san.html",
     "begin": "1978-04-10T22:30:00.000Z",
     "end": "1978-10-23T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,7 +68,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/na/conan/",
     "begin": "1978-04-04T10:25:00.000Z",
     "end": "1978-10-31T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -90,22 +76,12 @@
       {
         "site": "nicovideo",
         "id": "conan",
-        "begin": "2015-11-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-20T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2464",
-        "begin": "1978-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1978-04-04T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1978/06.json
+++ b/data/items/1978/06.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1978-06-03T16:00:00.000Z",
     "end": "1979-03-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1978/07.json
+++ b/data/items/1978/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.toei-anim.co.jp/herlock/outline.html",
     "begin": "1978-07-22T16:00:00.000Z",
     "end": "1978-07-22T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1978/09.json
+++ b/data/items/1978/09.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/999/",
     "begin": "1978-09-14T18:30:00.000Z",
     "end": "1981-04-09T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1c4t",
-        "begin": "2015-10-29T08:36:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-29T08:36:10.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1978/10.json
+++ b/data/items/1978/10.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1978-10-14T16:00:00.000Z",
     "end": "1979-04-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,7 +33,6 @@
     "officialSite": "http://www.moviesquare.jp/channel/catalog?c=takra",
     "begin": "1978-10-08T22:30:00.000Z",
     "end": "1979-04-01T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1978/11.json
+++ b/data/items/1978/11.json
@@ -14,7 +14,6 @@
     "officialSite": "",
     "begin": "1978-11-07T10:00:00.000Z",
     "end": "1979-12-18T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1978/12.json
+++ b/data/items/1978/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1978-12-16T16:00:00.000Z",
     "end": "1978-12-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1979/01.json
+++ b/data/items/1979/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/anne/",
     "begin": "1979-01-07T22:30:00.000Z",
     "end": "1979-12-30T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2460",
-        "begin": "1979-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1979-01-07T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1979/02.json
+++ b/data/items/1979/02.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1979-02-09T16:00:00.000Z",
     "end": "1980-02-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb139l",
-        "begin": "2015-08-14T17:08:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:08:28.000Z"
       },
       {
         "site": "bangumi",
@@ -44,7 +38,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/zendaman/zendaman.html",
     "begin": "1979-02-03T22:30:00.000Z",
     "end": "1980-01-26T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1979/03.json
+++ b/data/items/1979/03.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1979-03-06T12:30:00.000Z",
     "end": "1980-03-25T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "5108",
-        "begin": "2001-10-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-13T16:00:01.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "1979-03-21T10:00:00.000Z",
     "end": "1980-03-05T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1979/04.json
+++ b/data/items/1979/04.json
@@ -13,57 +13,31 @@
     "officialSite": "http://www.tv-asahi.co.jp/doraemon/",
     "begin": "1979-04-02T10:00:00.000Z",
     "end": "2005-03-25T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qicXPTbUbia8ksqhI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb2ai5",
-        "begin": "2015-06-30T07:36:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-30T07:36:59.000Z"
       },
       {
         "site": "qq",
         "id": "j/jxj5pth9h3a71sg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "78930",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2011/dhpjqm",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -72,12 +46,7 @@
       {
         "site": "bilibili",
         "id": "6009",
-        "begin": "1979-04-01T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1979-04-01T16:00:01.000Z"
       }
     ]
   },
@@ -94,17 +63,11 @@
     "officialSite": "http://www.gundam.jp/",
     "begin": "1979-04-07T12:00:00.000Z",
     "end": "1980-01-26T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "r/rxg1rnfy9m736q3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -124,7 +87,6 @@
     "officialSite": "",
     "begin": "1979-04-14T22:30:00.000Z",
     "end": "1979-09-29T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -144,7 +106,6 @@
     "officialSite": "",
     "begin": "1979-04-04T11:00:00.000Z",
     "end": "1980-03-26T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1979/07.json
+++ b/data/items/1979/07.json
@@ -7,7 +7,6 @@
     "officialSite": "http://tansar5.net/",
     "begin": "1979-07-27T13:30:00.000Z",
     "end": "1980-03-28T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1979/08.json
+++ b/data/items/1979/08.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1979-08-04T16:00:00.000Z",
     "end": "1979-08-04T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1979/10.json
+++ b/data/items/1979/10.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.mxtv.co.jp/berubara/",
     "begin": "1979-10-10T12:00:00.000Z",
     "end": "1980-09-03T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "frGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2458",
-        "begin": "1979-10-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1979-10-09T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1979/12.json
+++ b/data/items/1979/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1979-12-15T16:00:00.000Z",
     "end": "1979-12-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "cagliostro",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1980/01.json
+++ b/data/items/1980/01.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1980-01-06T16:00:00.000Z",
     "end": "1980-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk0lwe9",
-        "begin": "2012-04-05T02:25:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-05T02:25:39.000Z"
       },
       {
         "site": "bangumi",
@@ -38,7 +32,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/archive/littlebit.html",
     "begin": "1980-01-07T23:00:00.000Z",
     "end": "1980-06-30T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/nils/",
     "begin": "1980-01-08T12:00:00.000Z",
     "end": "1981-03-17T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +62,7 @@
       {
         "site": "bilibili",
         "id": "2447",
-        "begin": "1980-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1980-01-07T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1980/02.json
+++ b/data/items/1980/02.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1980-02-02T13:30:00.000Z",
     "end": "1981-01-24T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1980/03.json
+++ b/data/items/1980/03.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1980-03-15T16:00:00.000Z",
     "end": "1980-03-15T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -32,27 +31,16 @@
     "officialSite": "",
     "begin": "1980-03-15T16:00:00.000Z",
     "end": "1980-03-15T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi66al",
-        "begin": "2014-03-03T02:28:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-03T02:28:35.000Z"
       },
       {
         "site": "letv",
         "id": "80772",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -61,12 +49,7 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -82,7 +65,6 @@
     "officialSite": "",
     "begin": "1980-03-19T10:00:00.000Z",
     "end": "1981-02-25T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -102,7 +84,6 @@
     "officialSite": "",
     "begin": "1980-03-08T16:00:00.000Z",
     "end": "1980-03-08T18:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1980/04.json
+++ b/data/items/1980/04.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1980-04-07T16:00:00.000Z",
     "end": "1982-06-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "e7ibKCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1980/05.json
+++ b/data/items/1980/05.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.ideon.jp/",
     "begin": "1980-05-08T09:30:00.000Z",
     "end": "1981-01-30T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2448",
-        "begin": "1980-05-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1980-05-08T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1980/07.json
+++ b/data/items/1980/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1980-07-12T16:00:00.000Z",
     "end": "1980-07-12T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1980/09.json
+++ b/data/items/1980/09.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1980-09-02T22:30:00.000Z",
     "end": "1982-09-28T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1980/10.json
+++ b/data/items/1980/10.json
@@ -11,67 +11,31 @@
     "officialSite": "http://www.mxtv.co.jp/atom/",
     "begin": "1980-10-01T22:00:00.000Z",
     "end": "1981-12-23T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1byYFn7kVJL1c9s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjabctp",
-        "begin": "2011-01-24T01:12:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-24T01:12:47.000Z"
       },
       {
         "site": "qq",
         "id": "z/zgi40gqg05wouh9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/tbatm",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464318",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "103250",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,12 +44,7 @@
       {
         "site": "bilibili",
         "id": "2449",
-        "begin": "1980-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1980-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -101,7 +60,6 @@
     "officialSite": "http://www.mxtv.co.jp/tetsujin28/",
     "begin": "1980-10-03T22:30:00.000Z",
     "end": "1981-09-25T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,12 +68,7 @@
       {
         "site": "bilibili",
         "id": "1951",
-        "begin": "1980-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1980-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -131,7 +84,6 @@
     "officialSite": "",
     "begin": "1980-10-13T12:00:00.000Z",
     "end": "1981-08-31T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,12 +92,7 @@
       {
         "site": "nicovideo",
         "id": "ashitano-joe",
-        "begin": "2012-02-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-02-15T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/1981/01.json
+++ b/data/items/1981/01.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/fushiginashimano_flone.html",
     "begin": "1981-01-04T22:30:00.000Z",
     "end": "1981-12-27T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjzgszx",
-        "begin": "2012-10-16T10:38:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-16T10:38:34.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1981/03.json
+++ b/data/items/1981/03.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1981-03-14T16:00:00.000Z",
     "end": "1981-03-14T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "y/y6cv70z00o6a8m2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -44,17 +38,11 @@
     "officialSite": "",
     "begin": "1981-03-06T16:00:00.000Z",
     "end": "1982-02-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb14sd",
-        "begin": "2015-11-04T07:40:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-04T07:40:09.000Z"
       },
       {
         "site": "bangumi",
@@ -74,17 +62,11 @@
     "officialSite": "",
     "begin": "1981-03-16T16:00:00.000Z",
     "end": "1981-03-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80790",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -93,22 +75,12 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2550",
-        "begin": "1981-03-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1981-03-13T16:00:00.000Z"
       }
     ]
   },
@@ -124,7 +96,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works_animation/archive/goldlightan.html",
     "begin": "1981-03-01T14:00:00.000Z",
     "end": "1982-02-18T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,7 +111,6 @@
     "officialSite": "http://www.tms-e.com/library/old/tv/data/t_spank.html",
     "begin": "1981-03-07T22:30:00.000Z",
     "end": "1982-03-29T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1981/04.json
+++ b/data/items/1981/04.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/arale/",
     "begin": "1981-04-08T16:00:00.000Z",
     "end": "1986-02-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1ced",
-        "begin": "2015-10-16T09:03:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-16T09:03:38.000Z"
       },
       {
         "site": "bangumi",
@@ -43,7 +37,6 @@
     "officialSite": "http://www3.nhk.or.jp/anime/archives/joly_index.html",
     "begin": "1981-04-07T22:30:00.000Z",
     "end": "1982-06-26T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -52,12 +45,7 @@
       {
         "site": "bilibili",
         "id": "3226",
-        "begin": "2009-12-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-12-31T16:00:01.000Z"
       }
     ]
   },
@@ -73,7 +61,6 @@
     "officialSite": "",
     "begin": "1981-04-16T10:00:00.000Z",
     "end": "1982-03-25T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1981/07.json
+++ b/data/items/1981/07.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1981-07-11T16:00:00.000Z",
     "end": "1981-07-11T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "l/lk34bbjniysk41a",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "1981-07-18T16:00:00.000Z",
     "end": "1981-07-18T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "1981-07-04T16:00:00.000Z",
     "end": "1981-07-04T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,7 +78,6 @@
     "officialSite": "",
     "begin": "1981-07-03T16:00:00.000Z",
     "end": "1981-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1981/08.json
+++ b/data/items/1981/08.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1981-08-01T16:00:00.000Z",
     "end": "1981-08-01T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1981/10.json
+++ b/data/items/1981/10.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.kids-station.com/campaign/urusei/",
     "begin": "1981-10-14T14:30:00.000Z",
     "end": "1986-03-19T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "m7SPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha1of1",
-        "begin": "2016-12-02T08:24:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-02T08:24:10.000Z"
       },
       {
         "site": "bangumi",
@@ -51,17 +40,11 @@
     "officialSite": "http://cnt.kingrecords.co.jp/godmars/",
     "begin": "1981-10-02T10:00:00.000Z",
     "end": "1982-12-24T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Yq2XFX3jU5H0cto",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "2444",
-        "begin": "1981-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1981-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -87,7 +65,6 @@
     "officialSite": "http://www.at-x.com/program/detail/1475",
     "begin": "1981-10-08T13:00:00.000Z",
     "end": "1983-10-06T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -107,7 +84,6 @@
     "officialSite": "http://s.mxtv.jp/anime/braiger/",
     "begin": "1981-10-06T11:00:00.000Z",
     "end": "1982-06-25T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -123,7 +99,6 @@
     "officialSite": "",
     "begin": "1981-10-03T06:30:00.000Z",
     "end": "1983-03-25T07:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -143,7 +118,6 @@
     "officialSite": "",
     "begin": "1981-10-23T16:00:00.000Z",
     "end": "1983-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -152,12 +126,7 @@
       {
         "site": "bilibili",
         "id": "2439",
-        "begin": "1981-10-22T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1981-10-22T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1982/02.json
+++ b/data/items/1982/02.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works_animation/archive/ippatsuman.html",
     "begin": "1982-02-13T21:00:00.000Z",
     "end": "1983-03-26T21:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,17 +33,11 @@
     "officialSite": "",
     "begin": "1982-02-06T14:30:00.000Z",
     "end": "1983-01-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "abGLCXHXR4XoZs4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1982/03.json
+++ b/data/items/1982/03.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1982-03-13T16:00:00.000Z",
     "end": "1982-03-13T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "f/fgvzo9c628mdd15",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,17 +35,11 @@
     "officialSite": "",
     "begin": "1982-03-13T16:00:00.000Z",
     "end": "1982-03-13T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80810",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,22 +48,12 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2551",
-        "begin": "1982-03-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1982-03-12T16:00:00.000Z"
       }
     ]
   },
@@ -92,7 +70,6 @@
     "officialSite": "http://www.minkymomo.jp/",
     "begin": "1982-03-18T10:00:00.000Z",
     "end": "1983-05-26T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1982/04.json
+++ b/data/items/1982/04.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1982-04-24T16:00:00.000Z",
     "end": "1982-04-24T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1982/07.json
+++ b/data/items/1982/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1982-07-10T16:00:00.000Z",
     "end": "1982-07-10T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://s.mxtv.jp/anime/baxinger/",
     "begin": "1982-07-06T09:30:00.000Z",
     "end": "1983-03-29T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "2441",
-        "begin": "1982-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1982-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "1982-07-28T16:00:00.000Z",
     "end": "1982-07-28T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,7 +78,6 @@
     "officialSite": "",
     "begin": "1982-07-03T16:00:00.000Z",
     "end": "1982-07-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,12 +86,7 @@
       {
         "site": "nicovideo",
         "id": "cobra-adventure",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1982/10.json
+++ b/data/items/1982/10.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1982-10-07T14:00:00.000Z",
     "end": "1983-05-19T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "X5Bs6lK4KGbJR68",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,7 @@
       {
         "site": "nicovideo",
         "id": "cobra",
-        "begin": "2011-09-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3049",
-        "begin": "1982-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-20T06:00:00.000Z"
       }
     ]
   },
@@ -61,7 +40,6 @@
     "officialSite": "",
     "begin": "1982-10-13T13:00:00.000Z",
     "end": "1983-03-30T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,17 +59,11 @@
     "officialSite": "http://www.macross.co.jp/",
     "begin": "1982-10-03T10:30:00.000Z",
     "end": "1983-06-26T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VJdx71e9LWvOTLQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,12 +72,7 @@
       {
         "site": "bilibili",
         "id": "1187",
-        "begin": "1982-10-03T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1982-10-03T10:30:00.000Z"
       }
     ]
   },
@@ -127,7 +94,6 @@
     "officialSite": "http://www.animax.co.jp/program/NN10000104",
     "begin": "1982-10-07T11:30:00.000Z",
     "end": "1983-09-22T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -136,12 +102,7 @@
       {
         "site": "bilibili",
         "id": "2442",
-        "begin": "1982-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1982-10-06T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1983/01.json
+++ b/data/items/1983/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://s.mxtv.jp/urashiman/",
     "begin": "1983-01-09T10:00:00.000Z",
     "end": "1983-12-24T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -27,7 +26,6 @@
     "officialSite": "http://www.chibaakio.jp/",
     "begin": "1983-01-10T22:30:00.000Z",
     "end": "1983-07-04T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1983/02.json
+++ b/data/items/1983/02.json
@@ -17,17 +17,11 @@
     "officialSite": "",
     "begin": "1983-02-13T16:00:00.000Z",
     "end": "1983-02-13T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha1k6d",
-        "begin": "2016-11-28T09:39:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-28T09:39:42.000Z"
       },
       {
         "site": "bangumi",
@@ -47,7 +41,6 @@
     "officialSite": "http://www.dunbine.net/",
     "begin": "1983-02-05T14:30:00.000Z",
     "end": "1983-01-21T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -56,12 +49,7 @@
       {
         "site": "bilibili",
         "id": "2433",
-        "begin": "1983-02-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1983-02-04T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1983/03.json
+++ b/data/items/1983/03.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1983-03-13T16:00:00.000Z",
     "end": "1983-03-13T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "",
     "begin": "1983-03-12T16:00:00.000Z",
     "end": "1983-03-12T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80813",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,22 +48,12 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2552",
-        "begin": "1983-03-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1983-03-11T16:00:00.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "",
     "begin": "1983-03-30T10:00:00.000Z",
     "end": "1984-02-08T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1983/04.json
+++ b/data/items/1983/04.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.votoms.net/",
     "begin": "1983-04-01T16:00:00.000Z",
     "end": "1984-03-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "v496ibGDGNnTXVb0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "4/4q1eibx0we47yhk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2436",
-        "begin": "1983-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1983-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "",
     "begin": "1983-04-04T16:00:00.000Z",
     "end": "1985-07-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhayfzx",
-        "begin": "2015-04-22T07:00:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-22T07:00:06.000Z"
       },
       {
         "site": "bangumi",
@@ -91,7 +69,6 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1980/tv_005.html",
     "begin": "1983-04-04T22:58:00.000Z",
     "end": "1984-03-09T23:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1983/07.json
+++ b/data/items/1983/07.json
@@ -12,17 +12,11 @@
     "officialSite": "http://pierrot.jp/title/magicgirl/",
     "begin": "1983-07-01T09:00:00.000Z",
     "end": "1984-06-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "h/h6r8lxcw2ho24z8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -31,42 +25,22 @@
       {
         "site": "nicovideo",
         "id": "creamy-mami",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2018/dhpmfxts",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyoz11",
-        "begin": "2018-04-01T01:00:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-01T01:00:25.000Z"
       },
       {
         "site": "bilibili",
         "id": "5600",
-        "begin": "1983-06-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1983-06-30T16:00:01.000Z"
       }
     ]
   },
@@ -82,7 +56,6 @@
     "officialSite": "",
     "begin": "1983-07-09T16:00:00.000Z",
     "end": "1983-07-09T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -102,7 +75,6 @@
     "officialSite": "http://www.tms-e.com/bb_mobile/cats_eye/",
     "begin": "1983-07-11T14:00:00.000Z",
     "end": "1985-07-08T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -111,22 +83,12 @@
       {
         "site": "nicovideo",
         "id": "catseye",
-        "begin": "2011-11-02T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-02T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2876",
-        "begin": "1983-07-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1983-07-10T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1983/10.json
+++ b/data/items/1983/10.json
@@ -14,7 +14,6 @@
     "officialSite": "http://sun-tv.co.jp/anime_list/mospeada",
     "begin": "1983-10-02T08:00:00.000Z",
     "end": "1984-03-25T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,12 +22,7 @@
       {
         "site": "bilibili",
         "id": "2432",
-        "begin": "1983-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1983-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -40,7 +34,6 @@
     "officialSite": "",
     "begin": "1983-10-10T22:30:00.000Z",
     "end": "1983-12-22T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,7 +53,6 @@
     "officialSite": "http://www.vifam.net/",
     "begin": "1983-10-21T15:30:00.000Z",
     "end": "1984-09-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,17 +72,11 @@
     "officialSite": "",
     "begin": "1983-10-13T16:00:00.000Z",
     "end": "1986-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "o5Vw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -99,12 +85,7 @@
       {
         "site": "bilibili",
         "id": "2137",
-        "begin": "1983-10-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1983-10-12T16:00:00.000Z"
       }
     ]
   },
@@ -120,17 +101,11 @@
     "officialSite": "",
     "begin": "1983-10-20T16:00:00.000Z",
     "end": "1984-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8z8KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1984/02.json
+++ b/data/items/1984/02.json
@@ -14,17 +14,11 @@
     "officialSite": "",
     "begin": "1984-02-11T16:00:00.000Z",
     "end": "1984-02-11T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha1k6d",
-        "begin": "2016-11-28T09:39:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-28T09:39:42.000Z"
       },
       {
         "site": "bangumi",
@@ -44,7 +38,6 @@
     "officialSite": "",
     "begin": "1984-02-03T09:30:00.000Z",
     "end": "1984-06-29T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -67,7 +60,6 @@
     "officialSite": "http://www.sunrise-anime.jp/sunrise-inc/works/detail.php?cid=83",
     "begin": "1984-02-04T00:00:00.000Z",
     "end": "1985-02-23T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -76,12 +68,7 @@
       {
         "site": "bilibili",
         "id": "2443",
-        "begin": "1984-02-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1984-02-03T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1984/03.json
+++ b/data/items/1984/03.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1984-03-17T16:00:00.000Z",
     "end": "1984-03-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80815",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,32 +24,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3867",
-        "begin": "1984-03-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1984-03-16T16:00:01.000Z"
       }
     ]
   },
@@ -71,7 +50,6 @@
     "officialSite": "",
     "begin": "1984-03-03T22:30:00.000Z",
     "end": "1985-12-25T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,12 +58,7 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-3rd",
-        "begin": "2011-11-30T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-30T06:00:00.000Z"
       }
     ]
   },
@@ -101,7 +74,6 @@
     "officialSite": "",
     "begin": "1984-03-11T16:00:00.000Z",
     "end": "1984-03-11T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,12 +82,7 @@
       {
         "site": "pptv",
         "id": "DwzoZs40pOJFwys",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1984/04.json
+++ b/data/items/1984/04.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.giant-gorg.net/",
     "begin": "1984-04-05T00:30:00.000Z",
     "end": "1984-09-27T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "1984-04-15T16:00:00.000Z",
     "end": "1984-09-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AC0Ylv5k1BJ181s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "2429",
-        "begin": "1984-04-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1984-04-14T16:00:00.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "1984-04-15T16:00:00.000Z",
     "end": "1984-09-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,12 +67,7 @@
       {
         "site": "nicovideo",
         "id": "God-Mazinger",
-        "begin": "2011-11-09T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-09T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/1984/10.json
+++ b/data/items/1984/10.json
@@ -11,31 +11,15 @@
     "officialSite": "http://www.hokuto-no-ken.jp/",
     "begin": "1984-10-04T10:30:00.000Z",
     "end": "1987-03-05T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "52940",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "8386"
-      },
-      {
-        "site": "bilibili",
-        "id": "1224",
-        "begin": "1984-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -51,7 +35,6 @@
     "officialSite": "http://www.giant-gorg.net/",
     "begin": "1984-10-06T16:00:00.000Z",
     "end": "1985-04-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -74,17 +57,11 @@
     "officialSite": "http://www.galient.net/",
     "begin": "1984-10-05T00:30:00.000Z",
     "end": "1985-03-29T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3hPta9M5qedKyDA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -93,12 +70,7 @@
       {
         "site": "bilibili",
         "id": "2431",
-        "begin": "1984-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1984-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -110,7 +82,6 @@
     "officialSite": "http://www.nasinc.co.jp/jp/index.php?action=USER.WORKS.DETAIL&master_id=3",
     "begin": "1984-10-06T22:15:00.000Z",
     "end": "1985-09-27T22:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1984/11.json
+++ b/data/items/1984/11.json
@@ -14,17 +14,11 @@
     "officialSite": "",
     "begin": "1984-11-06T07:00:00.000Z",
     "end": "1985-05-20T07:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OnVPzTWbC0msKpI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,12 +27,7 @@
       {
         "site": "nicovideo",
         "id": "holmes",
-        "begin": "2011-09-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-20T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/1984/12.json
+++ b/data/items/1984/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1984-12-22T16:00:00.000Z",
     "end": "1984-12-22T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   }

--- a/data/items/1985/01.json
+++ b/data/items/1985/01.json
@@ -14,17 +14,11 @@
     "officialSite": "",
     "begin": "1985-01-26T16:00:00.000Z",
     "end": "1985-01-26T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha1k6d",
-        "begin": "2016-11-28T09:39:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-28T09:39:42.000Z"
       },
       {
         "site": "bangumi",
@@ -48,17 +42,11 @@
     "officialSite": "",
     "begin": "1985-01-06T16:00:00.000Z",
     "end": "1985-12-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk6gdad",
-        "begin": "2012-10-18T00:52:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-18T00:52:22.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1985/02.json
+++ b/data/items/1985/02.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1985-02-05T16:00:00.000Z",
     "end": "1986-06-15T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,7 @@
       {
         "site": "pptv",
         "id": "edSvLZX7a6kMiavI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1914",
-        "begin": "2004-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1985/03.json
+++ b/data/items/1985/03.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.kbs-kyoto.co.jp/tv/anime/touch/",
     "begin": "1985-03-24T22:30:00.000Z",
     "end": "1987-03-22T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "m/m2oobmidz797a2w",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "letv",
         "id": "29887",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -51,27 +40,16 @@
     "officialSite": "http://www.z-gundam.net/",
     "begin": "1985-03-02T15:30:00.000Z",
     "end": "1986-02-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dMK9O6MJebcamAA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/7z6r2ttxucgry3j",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -91,17 +69,11 @@
     "officialSite": "",
     "begin": "1985-03-16T16:00:00.000Z",
     "end": "1985-03-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80862",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,32 +82,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2553",
-        "begin": "1985-03-15T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1985-03-15T16:00:00.000Z"
       }
     ]
   },
@@ -151,17 +108,11 @@
     "officialSite": "",
     "begin": "1985-03-09T16:00:00.000Z",
     "end": "1985-03-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JBznZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -181,7 +132,6 @@
     "begin": "1985-03-04T00:00:00.000Z",
     "end": "1985-06-28T00:00:00.000Z",
     "officialSite": "http://www.robotech.com/",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -190,12 +140,7 @@
       {
         "site": "netflix",
         "id": "70205018",
-        "begin": "2016-10-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/1985/04.json
+++ b/data/items/1985/04.json
@@ -11,31 +11,15 @@
     "officialSite": "",
     "begin": "1985-04-05T10:00:00.000Z",
     "end": "1985-12-27T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "bLSQDnbcTIrta9M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "20831"
-      },
-      {
-        "site": "bilibili",
-        "id": "2424",
-        "begin": "1985-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -52,7 +36,6 @@
     "officialSite": "",
     "begin": "1985-04-02T22:30:00.000Z",
     "end": "1986-02-04T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -72,7 +55,6 @@
     "officialSite": "",
     "begin": "1985-04-27T16:00:00.000Z",
     "end": "1985-04-27T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1985/07.json
+++ b/data/items/1985/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1985-07-13T16:00:00.000Z",
     "end": "1985-07-13T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   },
@@ -48,7 +42,6 @@
     "officialSite": "http://www.sunrise-inc.co.jp/dirtypair/",
     "begin": "1985-07-15T13:30:00.000Z",
     "end": "1985-12-26T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -57,12 +50,7 @@
       {
         "site": "bilibili",
         "id": "2423",
-        "begin": "1985-07-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1985-07-15T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1985/08.json
+++ b/data/items/1985/08.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1985-08-21T16:00:00.000Z",
     "end": "1985-08-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1985/09.json
+++ b/data/items/1985/09.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1985-09-24T16:00:00.000Z",
     "end": "1991-06-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha1o2d",
-        "begin": "2016-11-28T06:11:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-28T06:11:18.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1985/10.json
+++ b/data/items/1985/10.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www9.nhk.or.jp/anime/gakkatsu/",
     "begin": "1985-10-06T09:30:00.000Z",
     "end": "1986-07-13T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZtqlI4vxYZ8CgOg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "e/eruda43t4yvxxx5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2422",
-        "begin": "1985-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1985-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -62,17 +46,11 @@
     "officialSite": "",
     "begin": "1985-10-12T16:00:00.000Z",
     "end": "1988-02-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12ht",
-        "begin": "2015-10-29T08:33:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-29T08:33:50.000Z"
       },
       {
         "site": "bangumi",
@@ -92,7 +70,6 @@
     "officialSite": "",
     "begin": "1985-10-03T14:00:00.000Z",
     "end": "1986-06-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -101,22 +78,12 @@
       {
         "site": "pptv",
         "id": "Q4x49l7ENHLVU7s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2421",
-        "begin": "1985-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1985-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -132,7 +99,6 @@
     "officialSite": "http://www2u.biglobe.ne.jp/~comefx99/kimengumi.htm",
     "begin": "1985-10-20T05:00:00.000Z",
     "end": "1987-10-03T05:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1985/12.json
+++ b/data/items/1985/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1985-12-12T16:00:00.000Z",
     "end": "1985-12-12T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4kld",
-        "begin": "2015-08-11T08:03:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-11T08:03:32.000Z"
       }
     ]
   }

--- a/data/items/1986/01.json
+++ b/data/items/1986/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/1486/",
     "begin": "1986-01-05T16:00:00.000Z",
     "end": "1986-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/1495/",
     "begin": "1986-01-10T15:00:00.000Z",
     "end": "1987-10-03T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1986/02.json
+++ b/data/items/1986/02.json
@@ -14,17 +14,11 @@
     "officialSite": "",
     "begin": "1986-02-22T16:00:00.000Z",
     "end": "1986-02-22T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha1k6d",
-        "begin": "2016-11-28T09:39:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-28T09:39:42.000Z"
       },
       {
         "site": "bangumi",
@@ -48,17 +42,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/dragon/",
     "begin": "1986-02-26T16:00:00.000Z",
     "end": "1989-04-19T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1b0h",
-        "begin": "2015-12-02T01:25:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-02T01:25:31.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1986/03.json
+++ b/data/items/1986/03.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.gundam-zz.net/",
     "begin": "1986-03-01T15:30:00.000Z",
     "end": "1987-01-31T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sX9KyDCWBkSnJY0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "3/345d7yjkinr4vl8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "1986-03-15T16:00:00.000Z",
     "end": "1986-03-15T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4kld",
-        "begin": "2015-08-11T08:03:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-11T08:03:32.000Z"
       }
     ]
   },
@@ -81,17 +64,11 @@
     "officialSite": "",
     "begin": "1986-03-15T16:00:00.000Z",
     "end": "1986-03-15T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80863",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,32 +77,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2554",
-        "begin": "1986-03-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1986-03-14T16:00:00.000Z"
       }
     ]
   },
@@ -141,31 +103,15 @@
     "officialSite": "http://www.mxtv.co.jp/maison/",
     "begin": "1986-03-26T12:00:00.000Z",
     "end": "1988-03-02T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "n9CsKpL4aKYJhib8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2921"
-      },
-      {
-        "site": "bilibili",
-        "id": "3245",
-        "begin": "1986-03-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/1986/04.json
+++ b/data/items/1986/04.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1986-04-21T16:00:00.000Z",
     "end": "1986-04-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cqaiaIIjuXpzicfeU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1986/05.json
+++ b/data/items/1986/05.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1986-05-30T16:00:00.000Z",
     "end": "1986-05-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JBznZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1986/06.json
+++ b/data/items/1986/06.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1986-06-21T16:00:00.000Z",
     "end": "1986-06-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "ch61031",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1986/07.json
+++ b/data/items/1986/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1986-07-12T16:00:00.000Z",
     "end": "1986-07-12T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4kld",
-        "begin": "2015-08-11T08:03:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-11T08:03:32.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "1986-07-20T16:00:00.000Z",
     "end": "1986-07-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,22 +43,12 @@
       {
         "site": "letv",
         "id": "36845",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5569",
-        "begin": "1985-12-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1985-12-31T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1986/08.json
+++ b/data/items/1986/08.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1986-08-02T16:00:00.000Z",
     "end": "1986-08-02T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "1986-08-21T14:00:00.000Z",
     "end": "1986-10-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "4036",
-        "begin": "1986-08-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1986-08-20T16:00:01.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "1986-08-02T16:00:00.000Z",
     "end": "1986-08-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1986/10.json
+++ b/data/items/1986/10.json
@@ -13,27 +13,16 @@
     "officialSite": "http://www9.nhk.or.jp/anime/archives/oz_index.html",
     "begin": "1986-10-06T16:00:00.000Z",
     "end": "1987-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "F1cxrxd97SuODHQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/894j2j6zagv8ey4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -42,12 +31,7 @@
       {
         "site": "letv",
         "id": "7558",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -63,17 +47,11 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/seiya/",
     "begin": "1986-10-11T16:00:00.000Z",
     "end": "1989-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1c1d",
-        "begin": "2015-08-14T17:03:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:03:15.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1986/12.json
+++ b/data/items/1986/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1986-12-20T16:00:00.000Z",
     "end": "1986-12-20T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4kld",
-        "begin": "2015-08-11T08:03:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-11T08:03:32.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "1986-12-20T16:00:00.000Z",
     "end": "1986-12-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,22 +43,12 @@
       {
         "site": "nicovideo",
         "id": "DB_shenron",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   }

--- a/data/items/1987/01.json
+++ b/data/items/1987/01.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1987-01-11T16:00:00.000Z",
     "end": "1987-12-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjzgyvx",
-        "begin": "2012-10-16T10:31:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-16T10:31:21.000Z"
       },
       {
         "site": "bangumi",
@@ -31,12 +25,7 @@
       {
         "site": "bilibili",
         "id": "5411",
-        "begin": "1981-04-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1981-04-06T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1987/02.json
+++ b/data/items/1987/02.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.dragonar.net/index.html",
     "begin": "1987-02-07T16:00:00.000Z",
     "end": "1988-01-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "B0kzsRlic7y2QDnY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2414",
-        "begin": "1987-02-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1987-02-06T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1987/03.json
+++ b/data/items/1987/03.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1987-03-14T16:00:00.000Z",
     "end": "1987-03-14T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80864",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,32 +24,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2555",
-        "begin": "1987-03-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1987-03-13T16:00:00.000Z"
       }
     ]
   },
@@ -71,17 +50,11 @@
     "officialSite": "",
     "begin": "1987-03-29T16:00:00.000Z",
     "end": "1988-03-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "n9GrKZH3Z6UIhu4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1987/04.json
+++ b/data/items/1987/04.json
@@ -14,47 +14,21 @@
     "officialSite": "http://www.cityhunter-dvd.com/",
     "begin": "1987-04-06T18:35:00.000Z",
     "end": "1988-03-28T19:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fauVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk7f6i9",
-        "begin": "2012-08-24T05:26:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "49601",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-24T05:26:39.000Z"
       },
       {
         "site": "sohu",
         "id": "s2012/cslr",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -74,27 +48,16 @@
     "officialSite": "http://www.dvd-orangeroad.com/",
     "begin": "1987-04-06T12:00:00.000Z",
     "end": "1988-03-07T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jsC8OqIIeLYZlic8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "r/rr57uvmizpiqd67",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -103,12 +66,7 @@
       {
         "site": "bilibili",
         "id": "2418",
-        "begin": "1987-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1987-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -124,7 +82,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/archive/zillion.html",
     "begin": "1987-04-12T12:00:00.000Z",
     "end": "1987-12-13T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -144,17 +101,11 @@
     "officialSite": "",
     "begin": "1987-04-07T16:00:00.000Z",
     "end": "1989-10-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kIdx71e9LWvOTLQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -163,12 +114,7 @@
       {
         "site": "bilibili",
         "id": "2412",
-        "begin": "1987-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1987-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -184,17 +130,11 @@
     "officialSite": "",
     "begin": "1987-04-15T16:00:00.000Z",
     "end": "1987-04-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cqaiaIIjuXpzicfeU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1987/05.json
+++ b/data/items/1987/05.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1987-05-17T16:00:00.000Z",
     "end": "1987-05-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "ch61032",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1987/07.json
+++ b/data/items/1987/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1987-07-18T16:00:00.000Z",
     "end": "1987-07-18T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "nicovideo",
         "id": "DB_majinjyou",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "1987-07-18T16:00:00.000Z",
     "end": "1987-07-18T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,22 +48,12 @@
       {
         "site": "nicovideo",
         "id": "saint_seiya",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4um9",
-        "begin": "2016-02-16T07:22:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-16T07:22:34.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "",
     "begin": "1987-07-03T16:00:00.000Z",
     "end": "1988-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "qq",
         "id": "p/pre4y0gnrshqogq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -121,7 +93,6 @@
     "officialSite": "http://animejapan.cplaza.ne.jp/b-ch/otomo_sp/rb_carnival_ova/index.html",
     "begin": "1987-07-21T16:00:00.000Z",
     "end": "1987-07-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,12 +101,7 @@
       {
         "site": "letv",
         "id": "10002045",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1987/10.json
+++ b/data/items/1987/10.json
@@ -12,47 +12,26 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/1528/",
     "begin": "1987-10-21T22:30:00.000Z",
     "end": "1988-03-30T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OywIhu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk35gjh",
-        "begin": "2015-01-09T07:11:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T07:11:23.000Z"
       },
       {
         "site": "letv",
         "id": "78829",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "56113",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -61,12 +40,7 @@
       {
         "site": "bilibili",
         "id": "2981",
-        "begin": "1987-10-20T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1987-10-20T16:00:00.000Z"
       }
     ]
   },
@@ -86,17 +60,11 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/ladylady/",
     "begin": "1987-10-21T16:00:00.000Z",
     "end": "1988-03-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb14dl",
-        "begin": "2015-11-05T09:28:20.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-05T09:28:20.000Z"
       },
       {
         "site": "bangumi",
@@ -116,17 +84,11 @@
     "officialSite": "",
     "begin": "1987-10-09T16:00:00.000Z",
     "end": "1989-02-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk36i75",
-        "begin": "2015-09-29T05:45:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-29T05:45:01.000Z"
       },
       {
         "site": "bangumi",
@@ -146,7 +108,6 @@
     "officialSite": "",
     "begin": "1987-10-13T10:00:00.000Z",
     "end": "1988-03-22T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -166,7 +127,6 @@
     "officialSite": "http://www.sunrise-anime.jp/sunrise-inc/works/detail.php?cid=141",
     "begin": "1987-10-08T11:30:00.000Z",
     "end": "1989-09-28T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -175,12 +135,7 @@
       {
         "site": "bilibili",
         "id": "2410",
-        "begin": "1987-10-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1987-10-08T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1987/12.json
+++ b/data/items/1987/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1987-12-18T16:00:00.000Z",
     "end": "1987-12-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3927",
-        "begin": "1987-12-17T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1987-12-17T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1988/01.json
+++ b/data/items/1988/01.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1988-01-10T16:00:00.000Z",
     "end": "1988-12-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk06tkd",
-        "begin": "2012-10-16T10:33:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-16T10:33:23.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1988/02.json
+++ b/data/items/1988/02.json
@@ -14,17 +14,11 @@
     "officialSite": "",
     "begin": "1988-02-06T16:00:00.000Z",
     "end": "1988-02-06T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha1k6d",
-        "begin": "2016-11-28T09:39:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-28T09:39:42.000Z"
       },
       {
         "site": "bangumi",
@@ -44,17 +38,11 @@
     "officialSite": "",
     "begin": "1988-02-08T16:00:00.000Z",
     "end": "1988-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12ht",
-        "begin": "2015-10-29T08:33:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-29T08:33:50.000Z"
       },
       {
         "site": "bangumi",
@@ -74,7 +62,6 @@
     "officialSite": "",
     "begin": "1988-02-25T13:30:00.000Z",
     "end": "1988-11-14T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -94,7 +81,6 @@
     "officialSite": "http://www.mxtv.co.jp/maison/",
     "begin": "1988-02-06T16:00:00.000Z",
     "end": "1988-02-06T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -103,12 +89,7 @@
       {
         "site": "bilibili",
         "id": "2506",
-        "begin": "1988-02-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-02-05T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1988/03.json
+++ b/data/items/1988/03.json
@@ -11,27 +11,16 @@
     "officialSite": "http://pierrot.jp/title/onisan/",
     "begin": "1988-03-14T16:00:00.000Z",
     "end": "1988-09-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9GpGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "m/m1w0lxz5okp36s4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2401",
-        "begin": "1988-03-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-03-13T16:00:00.000Z"
       }
     ]
   },
@@ -61,27 +45,16 @@
     "officialSite": "http://www.gundam-cca.net/index.html",
     "begin": "1988-03-12T16:00:00.000Z",
     "end": "1988-03-12T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Im1X1T2jE1G0Mpo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/80yxlsuq5pxurlq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,7 +74,6 @@
     "officialSite": "",
     "begin": "1988-03-12T16:00:00.000Z",
     "end": "1988-03-12T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,22 +82,12 @@
       {
         "site": "nicovideo",
         "id": "saint_seiya",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4um9",
-        "begin": "2016-02-16T07:22:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-16T07:22:34.000Z"
       }
     ]
   },
@@ -141,17 +103,11 @@
     "officialSite": "http://www.mxtv.co.jp/kiteretsu/",
     "begin": "1988-03-27T08:15:00.000Z",
     "end": "1996-06-09T08:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk38wb1",
-        "begin": "2014-09-16T01:37:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-16T01:37:28.000Z"
       },
       {
         "site": "bangumi",
@@ -160,12 +116,7 @@
       {
         "site": "mgtv",
         "id": "56434",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -181,17 +132,11 @@
     "officialSite": "",
     "begin": "1988-03-12T16:00:00.000Z",
     "end": "1988-03-12T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80865",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -200,32 +145,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2556",
-        "begin": "1988-03-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-03-11T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1988/04.json
+++ b/data/items/1988/04.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.sunrise-inc.co.jp/works/list/detail.php?cid=147",
     "begin": "1988-04-30T16:00:00.000Z",
     "end": "1989-03-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jKOeHITqWpj7eeE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/7z297b6f8oz934b",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,32 +29,17 @@
       {
         "site": "letv",
         "id": "29360",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgih7m9",
-        "begin": "2017-11-06T03:00:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-06T03:00:08.000Z"
       },
       {
         "site": "bilibili",
         "id": "2398",
-        "begin": "1988-04-29T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-04-29T16:00:00.000Z"
       }
     ]
   },
@@ -81,27 +55,16 @@
     "officialSite": "",
     "begin": "1988-04-25T16:00:00.000Z",
     "end": "1989-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Qo139V3DM3HUUro",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "q/qw6b1fadm18jpmr",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,12 +73,7 @@
       {
         "site": "bilibili",
         "id": "4013",
-        "begin": "1988-04-24T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-04-24T16:00:01.000Z"
       }
     ]
   },
@@ -131,17 +89,11 @@
     "officialSite": "",
     "begin": "1988-04-16T16:00:00.000Z",
     "end": "1989-06-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "bangumi",
@@ -161,17 +113,11 @@
     "officialSite": "http://www.vap.co.jp/borgman/",
     "begin": "1988-04-13T12:00:00.000Z",
     "end": "1988-12-21T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ygQAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -191,7 +137,6 @@
     "officialSite": "http://www.mashin-eiyuuden-wataru.net/wataru1/",
     "begin": "1988-04-15T03:30:00.000Z",
     "end": "1989-03-31T04:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -200,22 +145,12 @@
       {
         "site": "qq",
         "id": "y/yx7fu4yp9d0c445",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyan2d",
-        "begin": "2018-05-08T10:28:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-08T10:28:04.000Z"
       }
     ]
   },
@@ -234,17 +169,11 @@
     "officialSite": "",
     "begin": "1988-04-15T16:00:00.000Z",
     "end": "1989-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5lArqRF35yWIBm4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -253,12 +182,7 @@
       {
         "site": "bilibili",
         "id": "2391",
-        "begin": "1988-12-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-12-31T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1988/05.json
+++ b/data/items/1988/05.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/hellolady/",
     "begin": "1988-05-12T16:00:00.000Z",
     "end": "1989-01-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb277h",
-        "begin": "2015-11-05T09:15:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-05T09:15:16.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1988/06.json
+++ b/data/items/1988/06.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1988-06-21T16:00:00.000Z",
     "end": "1988-06-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "1988-06-21T16:00:00.000Z",
     "end": "1988-06-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,12 +38,7 @@
       {
         "site": "nicovideo",
         "id": "ch61033",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1988/07.json
+++ b/data/items/1988/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1988-07-09T16:00:00.000Z",
     "end": "1988-07-09T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "nicovideo",
         "id": "DB_makafusigi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "1988-07-23T16:00:00.000Z",
     "end": "1988-07-23T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,22 +48,12 @@
       {
         "site": "nicovideo",
         "id": "saint_seiya",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4um9",
-        "begin": "2016-02-16T07:22:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-16T07:22:34.000Z"
       }
     ]
   },
@@ -91,17 +69,11 @@
     "officialSite": "http://www.pro-reed.com/works/tv_series/w016.html",
     "begin": "1988-07-02T10:00:00.000Z",
     "end": "1988-12-24T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EV0npQ1z4yGEAmo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,12 +82,7 @@
       {
         "site": "bilibili",
         "id": "2400",
-        "begin": "1988-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -131,7 +98,6 @@
     "officialSite": "",
     "begin": "1988-07-21T16:00:00.000Z",
     "end": "1989-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,12 +106,7 @@
       {
         "site": "pptv",
         "id": "4086uCCG9jSXFX0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -161,7 +122,6 @@
     "officialSite": "",
     "begin": "1988-07-16T16:00:00.000Z",
     "end": "1988-07-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,22 +130,12 @@
       {
         "site": "letv",
         "id": "10002031",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5489",
-        "begin": "1988-07-15T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-07-15T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1988/10.json
+++ b/data/items/1988/10.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.dvd-orangeroad.com/",
     "begin": "1988-10-08T16:00:00.000Z",
     "end": "1988-10-08T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "y/yndxod8yrn2yp4m",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2505",
-        "begin": "1988-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -51,37 +40,21 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/1550/",
     "begin": "1988-10-02T22:30:00.000Z",
     "end": "1989-03-26T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk35gjh",
-        "begin": "2015-01-09T07:11:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T07:11:23.000Z"
       },
       {
         "site": "letv",
         "id": "78829",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "56113",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,7 +74,6 @@
     "officialSite": "",
     "begin": "1988-10-17T16:00:00.000Z",
     "end": "1992-03-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -121,31 +93,15 @@
     "officialSite": "http://www.gainax.co.jp/anime/top/index.html",
     "begin": "1988-10-07T16:00:00.000Z",
     "end": "1989-07-07T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RYeBic2fNPXveXMQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "769"
-      },
-      {
-        "site": "bilibili",
-        "id": "2663",
-        "begin": "1988-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/1988/11.json
+++ b/data/items/1988/11.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.anime-int.com/works/zeorymar/",
     "begin": "1988-11-26T16:00:00.000Z",
     "end": "1990-02-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZqmTEXnfT43wbtY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "i/i6ztb86ztc26ri7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "5204",
-        "begin": "1988-11-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1988-11-25T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1989/01.json
+++ b/data/items/1989/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/1558/",
     "begin": "1989-01-15T16:00:00.000Z",
     "end": "1989-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "5496",
-        "begin": "1989-01-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1989-01-14T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1989/02.json
+++ b/data/items/1989/02.json
@@ -11,27 +11,16 @@
     "officialSite": "",
     "begin": "1989-02-15T16:00:00.000Z",
     "end": "1991-01-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pujUUrogkM4xrxc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "n/n0h73rggh1m2tsk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2504",
-        "begin": "1989-02-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1989-02-14T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1989/03.json
+++ b/data/items/1989/03.json
@@ -11,27 +11,16 @@
     "officialSite": "",
     "begin": "1989-03-25T16:00:00.000Z",
     "end": "1989-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cq2XFX3jU5H0cto",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hyeg0kuopccwl8b",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "1989-03-18T16:00:00.000Z",
     "end": "1989-03-18T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,22 +48,12 @@
       {
         "site": "nicovideo",
         "id": "saint_seiya",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4um9",
-        "begin": "2016-02-16T07:22:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-16T07:22:34.000Z"
       }
     ]
   },
@@ -91,17 +69,11 @@
     "officialSite": "",
     "begin": "1989-03-11T16:00:00.000Z",
     "end": "1989-03-11T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "79694",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,32 +82,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2557",
-        "begin": "1989-03-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1989-03-10T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1989/04.json
+++ b/data/items/1989/04.json
@@ -11,27 +11,16 @@
     "officialSite": "",
     "begin": "1989-04-06T16:00:00.000Z",
     "end": "1990-01-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jp5p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/dufyuei43211elz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2392",
-        "begin": "1989-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1989-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -61,37 +45,21 @@
     "officialSite": "http://www.kids-station.com/tv/g/g2/",
     "begin": "1989-04-15T03:30:00.000Z",
     "end": "1989-09-16T04:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8kMibvCSKibjiabGYE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha0521",
-        "begin": "2016-11-07T03:01:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-07T03:01:42.000Z"
       },
       {
         "site": "qq",
         "id": "h/h5vvjdp8h9fmexn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -114,17 +82,11 @@
     "officialSite": "http://www.mxtv.co.jp/dragonz/",
     "begin": "1989-04-26T16:00:00.000Z",
     "end": "1996-01-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1a9l",
-        "begin": "2015-12-02T02:03:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-02T02:03:01.000Z"
       },
       {
         "site": "bangumi",
@@ -147,7 +109,6 @@
     "officialSite": "",
     "begin": "1989-04-15T11:00:00.000Z",
     "end": "1990-03-24T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -167,7 +128,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1989-04-01T16:00:00.000Z",
     "end": "1989-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -176,12 +136,7 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -201,17 +156,11 @@
     "officialSite": "",
     "begin": "1989-04-07T16:00:00.000Z",
     "end": "1990-03-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mPjEQqoQgL4hnwc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -220,12 +169,7 @@
       {
         "site": "bilibili",
         "id": "2397",
-        "begin": "1989-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1989-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -241,17 +185,11 @@
     "officialSite": "",
     "begin": "1989-04-07T16:00:00.000Z",
     "end": "1990-03-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vfTQTrYcjMotqxM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1989/06.json
+++ b/data/items/1989/06.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1989-06-17T16:00:00.000Z",
     "end": "1989-06-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "p/piqxaj51j697rkt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "letv",
         "id": "10004313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "",
     "begin": "1989-06-01T16:00:00.000Z",
     "end": "1989-12-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "k/kh2z3ryu1llzs9w",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1989/07.json
+++ b/data/items/1989/07.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1989-07-21T16:00:00.000Z",
     "end": "1990-08-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrha4tbh",
-        "begin": "2016-12-06T01:58:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-06T01:58:55.000Z"
       },
       {
         "site": "bangumi",
@@ -42,17 +36,11 @@
     "officialSite": "",
     "begin": "1989-07-15T16:00:00.000Z",
     "end": "1989-07-15T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       },
       {
         "site": "bangumi",
@@ -61,12 +49,7 @@
       {
         "site": "nicovideo",
         "id": "DBZ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -82,17 +65,11 @@
     "officialSite": "",
     "begin": "1989-07-29T16:00:00.000Z",
     "end": "1989-07-29T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "bangumi",
@@ -112,17 +89,11 @@
     "officialSite": "",
     "begin": "1989-07-01T16:00:00.000Z",
     "end": "1989-08-02T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9WtFwyuRATibiaIIg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -142,7 +113,6 @@
     "officialSite": "",
     "begin": "1989-07-15T16:00:00.000Z",
     "end": "1989-07-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -151,22 +121,12 @@
       {
         "site": "nicovideo",
         "id": "PATLABOR_01",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4016",
-        "begin": "1989-07-14T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1989-07-14T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1989/08.json
+++ b/data/items/1989/08.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1989-08-05T16:00:00.000Z",
     "end": "1989-09-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "pptv",
         "id": "XerVU7shkc8ysBg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4000",
-        "begin": "1989-08-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1989-08-04T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1989/09.json
+++ b/data/items/1989/09.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1989-09-28T16:00:00.000Z",
     "end": "1989-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JBznZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "1989-09-25T16:00:00.000Z",
     "end": "1990-12-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "nicovideo",
         "id": "midoriyama",
-        "begin": "2016-08-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-01T06:00:00.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "1989-09-01T16:00:00.000Z",
     "end": "1994-05-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,22 +67,12 @@
       {
         "site": "nicovideo",
         "id": "angel-cop",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2059",
-        "begin": "2002-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-10-07T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1989/10.json
+++ b/data/items/1989/10.json
@@ -11,37 +11,21 @@
     "officialSite": "",
     "begin": "1989-10-12T16:00:00.000Z",
     "end": "1990-10-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WeHcWsIomNY5tx8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/uxqnq5iqr3do76d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "78858",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -61,27 +45,16 @@
     "officialSite": "",
     "begin": "1989-10-20T16:00:00.000Z",
     "end": "1992-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "80I9uyOJibTeaGIA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/d6nxz5npppuo1yt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,7 +74,6 @@
     "officialSite": "http://www.vap.co.jp/yawara/",
     "begin": "1989-10-15T22:30:00.000Z",
     "end": "1992-09-20T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -121,21 +93,10 @@
     "officialSite": "",
     "begin": "1989-10-03T13:00:00.000Z",
     "end": "1990-03-27T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "18850"
-      },
-      {
-        "site": "bilibili",
-        "id": "2394",
-        "begin": "1989-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -154,7 +115,6 @@
     "officialSite": "",
     "begin": "1989-10-11T23:30:00.000Z",
     "end": "1990-09-26T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -163,22 +123,12 @@
       {
         "site": "nicovideo",
         "id": "PATLABOR_ON_TELEVISION",
-        "begin": "2016-10-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-14T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2327",
-        "begin": "1989-10-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1989-10-10T16:00:00.000Z"
       }
     ]
   },
@@ -194,7 +144,6 @@
     "officialSite": "",
     "begin": "1989-10-18T16:00:00.000Z",
     "end": "1990-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -214,7 +163,6 @@
     "officialSite": "",
     "begin": "1989-10-10T16:00:00.000Z",
     "end": "1992-09-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -223,12 +171,7 @@
       {
         "site": "nicovideo",
         "id": "warau",
-        "begin": "2017-03-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-15T06:00:00.000Z"
       }
     ]
   },
@@ -244,7 +187,6 @@
     "officialSite": "",
     "begin": "1989-10-07T16:00:00.000Z",
     "end": "1989-10-07T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -253,12 +195,7 @@
       {
         "site": "nicovideo",
         "id": "ch61049",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1989/11.json
+++ b/data/items/1989/11.json
@@ -12,17 +12,11 @@
     "officialSite": "",
     "begin": "1989-11-21T16:00:00.000Z",
     "end": "1991-09-05T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MXpGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1989/12.json
+++ b/data/items/1989/12.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1989-12-16T16:00:00.000Z",
     "end": "1990-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cKiaUEnrgUI7xb9c",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1990/01.json
+++ b/data/items/1990/01.json
@@ -12,37 +12,21 @@
     "officialSite": "",
     "begin": "1990-01-04T16:00:00.000Z",
     "end": "1991-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TH5KyDCWBkSnJY0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk0gz0d",
-        "begin": "2012-03-21T06:49:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-21T06:49:26.000Z"
       },
       {
         "site": "qq",
         "id": "g/gu60xakyjp8dtgk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,12 +35,7 @@
       {
         "site": "bilibili",
         "id": "5397",
-        "begin": "1990-01-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1990-01-03T16:00:01.000Z"
       }
     ]
   },
@@ -73,37 +52,21 @@
     "officialSite": "",
     "begin": "1990-01-07T16:00:00.000Z",
     "end": "1992-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gqaSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk1980p",
-        "begin": "2014-04-09T23:53:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:53:55.000Z"
       },
       {
         "site": "letv",
         "id": "81066",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -123,7 +86,6 @@
     "officialSite": "",
     "begin": "1990-01-06T16:00:00.000Z",
     "end": "1990-12-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -132,12 +94,7 @@
       {
         "site": "nicovideo",
         "id": "heiseitensai-bakabon",
-        "begin": "2018-07-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-03T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/1990/02.json
+++ b/data/items/1990/02.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.yusha.net/exkizer/",
     "begin": "1990-02-03T16:00:00.000Z",
     "end": "1991-01-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1990/03.json
+++ b/data/items/1990/03.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.mashin-eiyuuden-wataru.net/wataru2/",
     "begin": "1990-03-09T16:00:00.000Z",
     "end": "1991-03-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XOvWVLwiaktAzsRk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "qq",
         "id": "3/30ixdve8pnydu50",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyamz9",
-        "begin": "2018-05-16T08:31:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-16T08:31:01.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "",
     "begin": "1990-03-10T16:00:00.000Z",
     "end": "1990-03-10T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,22 +53,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_konoyodeitiban",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -101,17 +74,11 @@
     "officialSite": "",
     "begin": "1990-03-10T16:00:00.000Z",
     "end": "1990-03-10T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80869",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -120,22 +87,12 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2558",
-        "begin": "1990-03-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1990-03-09T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1990/04.json
+++ b/data/items/1990/04.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1990-04-06T16:00:00.000Z",
     "end": "1990-12-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ic0s2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "http://www.koredeiinoda.net/manga/ataro_anime.html",
     "begin": "1990-04-21T16:00:00.000Z",
     "end": "1990-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://www.mxtv.co.jp/moomin/",
     "begin": "1990-04-12T16:00:00.000Z",
     "end": "1991-10-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +62,7 @@
       {
         "site": "letv",
         "id": "10005863",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -94,17 +81,11 @@
     "officialSite": "http://www.nhk.or.jp/anime/nadia/",
     "begin": "1990-04-13T16:00:00.000Z",
     "end": "1991-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NXdRzzedDUuuLJQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -113,12 +94,7 @@
       {
         "site": "bilibili",
         "id": "2358",
-        "begin": "1990-04-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1990-04-12T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1990/06.json
+++ b/data/items/1990/06.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1990-06-30T16:00:00.000Z",
     "end": "1991-11-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,42 +19,22 @@
       {
         "site": "pptv",
         "id": "Vphk4kqwIF7BP6c",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "Record_of_Lodoss_War",
-        "begin": "2018-04-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-01T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "162",
-        "begin": "1990-06-29T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1990-06-29T16:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "a/a37vwo4h7x6fq4t",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1990/07.json
+++ b/data/items/1990/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1990-07-20T16:00:00.000Z",
     "end": "1990-07-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3930",
-        "begin": "1990-07-19T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1990-07-19T16:00:01.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "",
     "begin": "1990-07-07T16:00:00.000Z",
     "end": "1990-07-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,22 +53,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_tikyumarugoto",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -101,17 +74,11 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/archive/robinhood.html",
     "begin": "1990-07-29T16:00:00.000Z",
     "end": "1992-10-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sf3HRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1990/08.json
+++ b/data/items/1990/08.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1990-08-25T16:00:00.000Z",
     "end": "1990-08-25T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "7/7sn4yjfuz730dt6",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "letv",
         "id": "10004313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "",
     "begin": "1990-08-25T16:00:00.000Z",
     "end": "1990-08-25T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "s/s4zusns75ylge5a",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "letv",
         "id": "10004313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1990/09.json
+++ b/data/items/1990/09.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1990-09-14T16:00:00.000Z",
     "end": "1991-03-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XY56ibGDGNnTXVb0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1990/10.json
+++ b/data/items/1990/10.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1990-10-07T16:00:00.000Z",
     "end": "1990-10-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -32,41 +31,20 @@
     "officialSite": "http://tezukaosamu.net/jp/anime/48.html",
     "begin": "1990-10-18T16:00:00.000Z",
     "end": "1991-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uvLOTLQaiasgrqRE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk020x5",
-        "begin": "2012-05-31T05:57:51.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-05-31T05:57:51.000Z"
       },
       {
         "site": "bangumi",
         "id": "6605"
-      },
-      {
-        "site": "bilibili",
-        "id": "2360",
-        "begin": "1990-10-17T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -82,17 +60,11 @@
     "officialSite": "",
     "begin": "1990-10-06T16:00:00.000Z",
     "end": "1991-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LF8ppw915SOGBGw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,12 +73,7 @@
       {
         "site": "bilibili",
         "id": "5453",
-        "begin": "1990-10-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1990-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -122,7 +89,6 @@
     "officialSite": "",
     "begin": "1990-10-25T16:00:00.000Z",
     "end": "1991-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -131,12 +97,7 @@
       {
         "site": "pptv",
         "id": "Rolz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1991/01.json
+++ b/data/items/1991/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/kingyo/",
     "begin": "1991-01-12T16:00:00.000Z",
     "end": "1992-02-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,7 +33,6 @@
     "officialSite": "http://www.tms-e.com/search/index.php?pdt_no=318",
     "begin": "1991-01-05T16:00:00.000Z",
     "end": "1991-11-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1991/02.json
+++ b/data/items/1991/02.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.yusha.net/fighbird/",
     "begin": "1991-02-02T16:00:00.000Z",
     "end": "1992-02-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Y62XFX3jU5H0cto",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -44,7 +38,6 @@
     "officialSite": "",
     "begin": "1991-02-19T16:00:00.000Z",
     "end": "1992-02-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -53,12 +46,7 @@
       {
         "site": "nicovideo",
         "id": "saverkids",
-        "begin": "2011-11-09T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-09T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/1991/03.json
+++ b/data/items/1991/03.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.vap.co.jp/cyber/",
     "begin": "1991-03-15T16:00:00.000Z",
     "end": "1991-11-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NgD7eeFHticVY1j4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,22 +27,12 @@
       {
         "site": "letv",
         "id": "21118",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2350",
-        "begin": "1991-03-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1991-03-14T16:00:00.000Z"
       }
     ]
   },
@@ -64,17 +48,11 @@
     "officialSite": "",
     "begin": "1991-03-16T16:00:00.000Z",
     "end": "1991-03-16T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "k/kd7sd8mpyq2j2nn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -94,7 +72,6 @@
     "officialSite": "",
     "begin": "1991-03-09T16:00:00.000Z",
     "end": "1991-03-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -103,22 +80,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_supersaiyajin",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -134,17 +101,11 @@
     "officialSite": "",
     "begin": "1991-03-09T16:00:00.000Z",
     "end": "1991-03-09T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80870",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -153,22 +114,12 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2559",
-        "begin": "1991-03-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1991-03-08T16:00:00.000Z"
       }
     ]
   },
@@ -184,7 +135,6 @@
     "officialSite": "",
     "begin": "1991-03-09T16:00:00.000Z",
     "end": "1991-03-09T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -193,12 +143,7 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1991/04.json
+++ b/data/items/1991/04.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.eldran.net/raijin-oh/index.html",
     "begin": "1991-04-03T16:00:00.000Z",
     "end": "1992-03-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "3304",
-        "begin": "1991-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1991-04-02T16:00:01.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "1991-04-12T16:00:00.000Z",
     "end": "1992-03-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "nicovideo",
         "id": "hsm-nanafushigi",
-        "begin": "2017-07-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/1991/05.json
+++ b/data/items/1991/05.json
@@ -11,27 +11,16 @@
     "officialSite": "",
     "begin": "1991-05-22T16:00:00.000Z",
     "end": "1992-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zRnjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/l8yeq8hadkbh258",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,7 +40,6 @@
     "officialSite": "http://www.mxtv.co.jp/maison/",
     "begin": "1991-05-21T16:00:00.000Z",
     "end": "1991-05-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "bilibili",
         "id": "3963",
-        "begin": "1991-05-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1991-05-20T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1991/07.json
+++ b/data/items/1991/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1991-07-14T16:00:00.000Z",
     "end": "1992-05-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2346",
-        "begin": "1991-07-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1991-07-13T16:00:00.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "1991-07-20T16:00:00.000Z",
     "end": "1991-07-20T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,22 +43,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_tobikkiri",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -81,17 +64,11 @@
     "officialSite": "",
     "begin": "1991-07-25T16:00:00.000Z",
     "end": "1992-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ej0Ihu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1991/08.json
+++ b/data/items/1991/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1991-08-09T16:00:00.000Z",
     "end": "1991-08-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3931",
-        "begin": "1991-08-08T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1991-08-08T16:00:01.000Z"
       }
     ]
   },
@@ -61,27 +45,16 @@
     "officialSite": "",
     "begin": "1991-08-16T16:00:00.000Z",
     "end": "1991-08-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "K2Vf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "i/izzhgoy2bctltv6",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -90,12 +63,7 @@
       {
         "site": "bilibili",
         "id": "1965",
-        "begin": "2003-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -111,17 +79,11 @@
     "officialSite": "",
     "begin": "1991-08-25T16:00:00.000Z",
     "end": "1992-04-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Pw34dt5EtPJV0zs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -141,17 +103,11 @@
     "officialSite": "",
     "begin": "1991-08-17T16:00:00.000Z",
     "end": "1991-08-17T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7kUvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1991/10.json
+++ b/data/items/1991/10.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1991-10-04T16:00:00.000Z",
     "end": "1992-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "1991-10-18T16:00:00.000Z",
     "end": "1992-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OXJOzDSaCkiarKZE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "2347",
-        "begin": "1991-10-17T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1991-10-17T16:00:00.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "http://www.pro-reed.com/works/tv_series/w023.html",
     "begin": "1991-10-02T16:00:00.000Z",
     "end": "1992-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,7 +78,6 @@
     "officialSite": "http://www.mxtv.co.jp/moomin_boken/",
     "begin": "1991-10-10T16:00:00.000Z",
     "end": "1992-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -107,7 +93,6 @@
     "officialSite": "http://www.tms-e.com/online/lineup/chie2/index.html",
     "begin": "1991-10-19T16:00:00.000Z",
     "end": "1992-09-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -127,7 +112,6 @@
     "officialSite": "http://www.mxtv.co.jp/dodge/",
     "begin": "1991-10-14T16:00:00.000Z",
     "end": "1992-09-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1991/11.json
+++ b/data/items/1991/11.json
@@ -14,7 +14,6 @@
     "officialSite": "",
     "begin": "1991-11-02T16:00:00.000Z",
     "end": "1991-11-02T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,7 +33,6 @@
     "officialSite": "",
     "begin": "1991-11-22T16:00:00.000Z",
     "end": "1993-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -43,22 +41,12 @@
       {
         "site": "pptv",
         "id": "Y9GsKpL4aKYJhib8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3152",
-        "begin": "1993-04-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-04-10T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1991/12.json
+++ b/data/items/1991/12.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1991-12-21T16:00:00.000Z",
     "end": "1993-04-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UJtl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "3328",
-        "begin": "1991-12-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1991-12-20T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1992/01.json
+++ b/data/items/1992/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.sunrise-anime.jp/sunrise-inc/works/detail.php?cid=140",
     "begin": "1992-01-10T08:00:00.000Z",
     "end": "1992-12-25T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wW9a2ECmFlS3NZ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1992/02.json
+++ b/data/items/1992/02.json
@@ -11,17 +11,11 @@
     "officialSite": "http://king-cr.jp/special/tekkaman/",
     "begin": "1992-02-18T16:00:00.000Z",
     "end": "1993-01-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MRvmZMwyouBDwSk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "letv",
         "id": "29255",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -51,27 +40,16 @@
     "officialSite": "",
     "begin": "1992-02-08T16:00:00.000Z",
     "end": "1993-01-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "svfRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "x/xfbopppqn90fq4l",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,12 +58,7 @@
       {
         "site": "bilibili",
         "id": "2340",
-        "begin": "1992-02-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1992-02-08T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1992/03.json
+++ b/data/items/1992/03.json
@@ -14,17 +14,11 @@
     "officialSite": "http://sailormoon.channel.or.jp/",
     "begin": "1992-03-07T16:00:00.000Z",
     "end": "1993-02-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1359",
-        "begin": "2015-08-14T17:05:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:05:28.000Z"
       },
       {
         "site": "bangumi",
@@ -33,12 +27,7 @@
       {
         "site": "nicovideo",
         "id": "sailormoon",
-        "begin": "2014-07-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T15:00:00.000Z"
       }
     ]
   },
@@ -54,7 +43,6 @@
     "officialSite": "",
     "begin": "1992-03-07T16:00:00.000Z",
     "end": "1992-03-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -63,22 +51,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_gekitotsu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -94,17 +72,11 @@
     "officialSite": "",
     "begin": "1992-03-07T16:00:00.000Z",
     "end": "1992-03-07T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80878",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -113,32 +85,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2560",
-        "begin": "1992-03-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1992-03-06T16:00:00.000Z"
       }
     ]
   },
@@ -154,17 +111,11 @@
     "officialSite": "",
     "begin": "1992-03-27T16:00:00.000Z",
     "end": "1992-08-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8zYSkPhezgxv7VU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -172,13 +123,8 @@
       },
       {
         "site": "bilibili",
-        "id": "6533",
-        "begin": "1992-03-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "7932",
+        "begin": "1992-03-26T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1992/04.json
+++ b/data/items/1992/04.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.eldran.net/gambaruger/",
     "begin": "1992-04-01T16:00:00.000Z",
     "end": "1993-02-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WpVv7VW7K2nMSrI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2341",
-        "begin": "1992-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1992-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -51,57 +40,31 @@
     "officialSite": "http://www.tv-asahi.co.jp/shinchan/",
     "begin": "1992-04-13T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RNibqKJD2ZqQHhe0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk1kp41",
-        "begin": "2014-08-12T12:43:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-12T12:43:05.000Z"
       },
       {
         "site": "qq",
         "id": "i/ipm2meuu857sw3e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "91890",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/dhplbxxqj",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1992/07.json
+++ b/data/items/1992/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1992-07-24T16:00:00.000Z",
     "end": "1992-07-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3934",
-        "begin": "1992-07-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1992-07-23T16:00:01.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "",
     "begin": "1992-07-11T16:00:00.000Z",
     "end": "1992-07-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,22 +53,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_kyokugen",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -101,17 +74,11 @@
     "officialSite": "",
     "begin": "1992-07-18T16:00:00.000Z",
     "end": "1992-07-18T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "bangumi",
@@ -131,17 +98,11 @@
     "officialSite": "",
     "begin": "1992-07-18T16:00:00.000Z",
     "end": "1992-07-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7kUvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -161,7 +122,6 @@
     "officialSite": "",
     "begin": "1992-07-29T16:00:00.000Z",
     "end": "1992-07-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,12 +130,7 @@
       {
         "site": "pptv",
         "id": "u4B7ibWHHN3XYVr4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1992/08.json
+++ b/data/items/1992/08.json
@@ -14,7 +14,6 @@
     "officialSite": "http://cgi2.nhk.or.jp/etv50/request/detail/index.cgi?program_id=94",
     "begin": "1992-08-24T16:00:00.000Z",
     "end": "1995-11-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -37,17 +36,11 @@
     "officialSite": "",
     "begin": "1992-08-01T16:00:00.000Z",
     "end": "1994-05-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "9/90m19poyuet6mjj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -67,17 +60,11 @@
     "officialSite": "",
     "begin": "1992-08-29T16:00:00.000Z",
     "end": "1992-08-29T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "w/wbi4lp0sl11pt7a",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1992/10.json
+++ b/data/items/1992/10.json
@@ -11,7 +11,6 @@
     "officialSite": "http://s.mxtv.jp/mikan_enikki/",
     "begin": "1992-10-16T16:00:00.000Z",
     "end": "1993-06-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -27,7 +26,6 @@
     "officialSite": "http://s.mxtv.jp/kobochan/",
     "begin": "1992-10-19T16:00:00.000Z",
     "end": "1994-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -47,17 +45,11 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1990/tv_027.html",
     "begin": "1992-10-10T16:00:00.000Z",
     "end": "1995-01-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LAjzcdkicrib1QzjY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -66,22 +58,12 @@
       {
         "site": "nicovideo",
         "id": "YuYuHakusho",
-        "begin": "2016-11-11T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2338",
-        "begin": "1992-10-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1992-10-09T16:00:00.000Z"
       }
     ]
   },
@@ -97,7 +79,6 @@
     "officialSite": "",
     "begin": "1992-10-02T16:00:00.000Z",
     "end": "1993-12-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -117,27 +98,16 @@
     "officialSite": "",
     "begin": "1992-10-21T16:00:00.000Z",
     "end": "1994-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "5/5n2lnpamfl14923",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "NBfycNgibruxPzTU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -157,27 +127,16 @@
     "officialSite": "",
     "begin": "1992-10-21T16:00:00.000Z",
     "end": "1994-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "H1AsqhJ46CaJB28",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bv4ksstk6j91sbj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1992/11.json
+++ b/data/items/1992/11.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1992-11-01T16:00:00.000Z",
     "end": "1993-06-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HU46uCCG9jSXFX0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "3808",
-        "begin": "1992-10-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1992-10-31T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1993/01.json
+++ b/data/items/1993/01.json
@@ -14,7 +14,6 @@
     "officialSite": "",
     "begin": "1993-01-08T16:00:00.000Z",
     "end": "1993-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,7 +33,6 @@
     "officialSite": "http://www.at-x.com/program/detail/4461",
     "begin": "1993-01-25T16:00:00.000Z",
     "end": "1993-07-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -43,12 +41,7 @@
       {
         "site": "bilibili",
         "id": "2332",
-        "begin": "1993-01-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-01-24T16:00:00.000Z"
       }
     ]
   },
@@ -65,17 +58,11 @@
     "officialSite": "",
     "begin": "1993-01-17T16:00:00.000Z",
     "end": "1993-12-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjzg2cp",
-        "begin": "2012-10-16T10:34:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-16T10:34:58.000Z"
       },
       {
         "site": "bangumi",
@@ -95,17 +82,11 @@
     "officialSite": "",
     "begin": "1993-01-30T16:00:00.000Z",
     "end": "1994-01-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lNayMJjibbqwPjfU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -114,12 +95,7 @@
       {
         "site": "bilibili",
         "id": "2331",
-        "begin": "1993-01-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-01-30T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1993/02.json
+++ b/data/items/1993/02.json
@@ -11,27 +11,16 @@
     "officialSite": "",
     "begin": "1993-02-21T16:00:00.000Z",
     "end": "1994-05-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "60w3tR2D8zGUEno",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hr9p94mq747w5g9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "1451",
-        "begin": "1993-02-20T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-02-20T16:00:00.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "",
     "begin": "1993-02-24T16:00:00.000Z",
     "end": "1993-02-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1993/03.json
+++ b/data/items/1993/03.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.sunrise-inc.co.jp/works/list/detail.php?cid=122",
     "begin": "1993-03-03T16:00:00.000Z",
     "end": "1994-02-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "as65N58FdbMWlPw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2330",
-        "begin": "1993-03-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-03-02T16:00:00.000Z"
       }
     ]
   },
@@ -54,17 +43,11 @@
     "officialSite": "http://sailormoon.channel.or.jp/",
     "begin": "1993-03-06T16:00:00.000Z",
     "end": "1994-03-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12zp",
-        "begin": "2015-08-14T17:08:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:08:28.000Z"
       },
       {
         "site": "bangumi",
@@ -73,12 +56,7 @@
       {
         "site": "nicovideo",
         "id": "sailor_moon_r",
-        "begin": "2015-07-18T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-18T10:00:00.000Z"
       }
     ]
   },
@@ -94,7 +72,6 @@
     "officialSite": "",
     "begin": "1993-03-06T16:00:00.000Z",
     "end": "1993-03-06T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -103,12 +80,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   },
@@ -124,7 +96,6 @@
     "officialSite": "",
     "begin": "1993-03-06T16:00:00.000Z",
     "end": "1993-03-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -133,22 +104,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_moetsukiro",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -164,17 +125,11 @@
     "officialSite": "",
     "begin": "1993-03-06T16:00:00.000Z",
     "end": "1993-03-06T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80947",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -183,32 +138,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2561",
-        "begin": "1993-03-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-03-05T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1993/04.json
+++ b/data/items/1993/04.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.gundam.channel.or.jp/program/_vg_tv.shtml",
     "begin": "1993-04-02T16:00:00.000Z",
     "end": "1994-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CDcSkPhezgxv7VU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jo3cpdky93amp9u",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,17 +40,11 @@
     "officialSite": "http://www.mxtv.co.jp/gs_mikami/",
     "begin": "1993-04-11T16:00:00.000Z",
     "end": "1994-03-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1b8t",
-        "begin": "2015-08-14T16:07:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T16:07:25.000Z"
       },
       {
         "site": "bangumi",
@@ -81,7 +64,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "1993-04-10T16:00:00.000Z",
     "end": "1994-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -90,12 +72,7 @@
       {
         "site": "bilibili",
         "id": "3620",
-        "begin": "2008-03-30T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-03-30T16:00:01.000Z"
       }
     ]
   },
@@ -111,17 +88,11 @@
     "officialSite": "",
     "begin": "1993-04-06T16:00:00.000Z",
     "end": "1994-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cibHLSbEXh8Uopg4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -130,12 +101,7 @@
       {
         "site": "bilibili",
         "id": "2329",
-        "begin": "1993-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -151,17 +117,11 @@
     "officialSite": "",
     "begin": "1993-04-09T16:00:00.000Z",
     "end": "1994-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "faibZF3iclVZP2dNw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -181,17 +141,11 @@
     "officialSite": "",
     "begin": "1993-04-05T16:00:00.000Z",
     "end": "1996-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9F0opg505CKFA2s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -200,12 +154,7 @@
       {
         "site": "bilibili",
         "id": "2334",
-        "begin": "1993-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-04-05T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1993/05.json
+++ b/data/items/1993/05.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1993-05-05T16:00:00.000Z",
     "end": "1993-05-05T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1993/06.json
+++ b/data/items/1993/06.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1993-06-21T16:00:00.000Z",
     "end": "1993-08-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "pptv",
         "id": "hMbCQKgOfrwfnQU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15247",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1993/07.json
+++ b/data/items/1993/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1993-07-23T16:00:00.000Z",
     "end": "1993-07-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3935",
-        "begin": "1993-07-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-07-22T16:00:01.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "",
     "begin": "1993-07-10T16:00:00.000Z",
     "end": "1993-07-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "",
     "begin": "1993-07-10T16:00:00.000Z",
     "end": "1993-07-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,22 +77,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_gingagirigiri",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -131,26 +98,15 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "1993-07-24T16:00:00.000Z",
     "end": "1993-07-24T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": "",
         "url": "http://www.iqiyi.com/dongman/20130715/839f4bf2c2cbe419.html"
       },
       {
@@ -160,22 +116,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3868",
-        "begin": "1993-07-23T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "18452",
+        "begin": "1993-07-23T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1993/08.json
+++ b/data/items/1993/08.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1993-08-07T16:00:00.000Z",
     "end": "1993-08-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "m/mmgowdl01xcnz23",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "PATLABOR_02",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4015",
-        "begin": "1993-08-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-08-06T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1993/09.json
+++ b/data/items/1993/09.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1993-09-24T16:00:00.000Z",
     "end": "1993-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "9/9n6g3bdgru8g17v",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1993/10.json
+++ b/data/items/1993/10.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.toei-video.co.jp/BD/slamdunk.html",
     "begin": "1993-10-16T16:00:00.000Z",
     "end": "1996-03-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb244t",
-        "begin": "2015-11-28T11:19:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-28T11:19:28.000Z"
       },
       {
         "site": "bangumi",
@@ -33,12 +27,7 @@
       {
         "site": "nicovideo",
         "id": "SLAM_DUNK",
-        "begin": "2017-11-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-06T03:00:00.000Z"
       }
     ]
   },
@@ -54,17 +43,11 @@
     "officialSite": "",
     "begin": "1993-10-21T16:00:00.000Z",
     "end": "1993-10-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7kUvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -84,7 +67,6 @@
     "officialSite": "",
     "begin": "1993-10-01T16:00:00.000Z",
     "end": "1994-02-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -93,22 +75,12 @@
       {
         "site": "pptv",
         "id": "Xu3YVr4klNI1sxs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4001",
-        "begin": "1992-12-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1992-12-31T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1993/11.json
+++ b/data/items/1993/11.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/shoot/",
     "begin": "1993-11-07T16:00:00.000Z",
     "end": "1994-12-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9T8KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/fqy4dpm1wlnc478",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,22 +29,12 @@
       {
         "site": "letv",
         "id": "34386",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2328",
-        "begin": "1993-11-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1993-11-06T16:00:00.000Z"
       }
     ]
   },
@@ -71,17 +50,11 @@
     "officialSite": "",
     "begin": "1993-11-19T16:00:00.000Z",
     "end": "2002-10-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "u4hz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,7 +74,6 @@
     "officialSite": "",
     "begin": "1993-11-25T16:00:00.000Z",
     "end": "1995-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -121,7 +93,6 @@
     "officialSite": "",
     "begin": "1993-11-26T16:00:00.000Z",
     "end": "1994-01-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,12 +101,7 @@
       {
         "site": "pptv",
         "id": "zHxHxS2TA0GkIoo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1993/12.json
+++ b/data/items/1993/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1993-12-05T16:00:00.000Z",
     "end": "1993-12-05T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "1993-12-05T16:00:00.000Z",
     "end": "1993-12-05T16:16:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,17 +49,11 @@
     "officialSite": "",
     "begin": "1993-12-22T16:00:00.000Z",
     "end": "1993-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7kUvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1994/01.json
+++ b/data/items/1994/01.json
@@ -13,17 +13,11 @@
     "officialSite": "",
     "begin": "1994-01-16T16:00:00.000Z",
     "end": "1994-12-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk0m4ad",
-        "begin": "2012-04-05T02:23:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-05T02:23:38.000Z"
       },
       {
         "site": "bangumi",
@@ -43,17 +37,11 @@
     "officialSite": "",
     "begin": "1994-01-07T16:00:00.000Z",
     "end": "1995-06-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6yUfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -73,7 +61,6 @@
     "officialSite": "",
     "begin": "1994-01-21T16:00:00.000Z",
     "end": "1997-01-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -82,12 +69,7 @@
       {
         "site": "pptv",
         "id": "ZKaiaIIjuXpzicfeU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1994/03.json
+++ b/data/items/1994/03.json
@@ -15,17 +15,11 @@
     "officialSite": "http://sailormoon.channel.or.jp/",
     "begin": "1994-03-19T16:00:00.000Z",
     "end": "1995-02-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12s9",
-        "begin": "2015-08-14T17:09:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:09:03.000Z"
       },
       {
         "site": "bangumi",
@@ -49,17 +43,11 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/mamaboy/",
     "begin": "1994-03-13T16:00:00.000Z",
     "end": "1995-09-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5lQvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -68,22 +56,12 @@
       {
         "site": "bilibili",
         "id": "2324",
-        "begin": "1994-03-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1994-03-12T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "29242",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -99,7 +77,6 @@
     "officialSite": "",
     "begin": "1994-03-12T16:00:00.000Z",
     "end": "1994-03-12T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -108,12 +85,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   },
@@ -129,7 +101,6 @@
     "officialSite": "",
     "begin": "1994-03-12T16:00:00.000Z",
     "end": "1994-03-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -138,22 +109,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_kikennnafutari",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -169,7 +130,6 @@
     "officialSite": "",
     "begin": "1994-03-12T16:00:00.000Z",
     "end": "1994-03-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -178,12 +138,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb405h",
-        "begin": "2016-02-04T10:33:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:33:39.000Z"
       }
     ]
   },
@@ -199,17 +154,11 @@
     "officialSite": "",
     "begin": "1994-03-12T16:00:00.000Z",
     "end": "1994-03-12T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80948",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -218,12 +167,7 @@
       {
         "site": "bilibili",
         "id": "2562",
-        "begin": "1994-03-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1994-03-11T16:00:00.000Z"
       }
     ]
   },
@@ -239,7 +183,6 @@
     "officialSite": "",
     "begin": "1994-03-21T16:00:00.000Z",
     "end": "1994-12-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -248,12 +191,7 @@
       {
         "site": "pptv",
         "id": "ToF7ibWHHN3XYVr4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1994/04.json
+++ b/data/items/1994/04.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1994-04-05T16:00:00.000Z",
     "end": "1995-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "redbaron",
-        "begin": "2011-11-23T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-23T06:00:00.000Z"
       }
     ]
   },
@@ -41,27 +35,16 @@
     "officialSite": "http://www.g-gundam.net/",
     "begin": "1994-04-01T16:00:00.000Z",
     "end": "1995-03-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CzgDgelPvic1g3kY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/w0nbxlyqmc6clnc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -81,27 +64,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "1994-04-23T16:00:00.000Z",
     "end": "1994-04-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/d7a321d48f825733.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/d7a321d48f825733.html"
       },
       {
         "site": "bangumi",
@@ -110,22 +82,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3870",
-        "begin": "1994-04-22T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10472",
+        "begin": "1994-04-22T16:00:01.000Z"
       }
     ]
   },
@@ -141,17 +103,11 @@
     "officialSite": "",
     "begin": "1994-04-01T16:00:00.000Z",
     "end": "1995-02-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NHdRzzedDUuuLJQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -160,12 +116,7 @@
       {
         "site": "bilibili",
         "id": "3809",
-        "begin": "1994-03-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1994-03-31T16:00:01.000Z"
       }
     ]
   },
@@ -181,17 +132,11 @@
     "officialSite": "",
     "begin": "1994-04-06T16:00:00.000Z",
     "end": "1995-03-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LmBc2kKoGFa5N58",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -211,17 +156,11 @@
     "officialSite": "",
     "begin": "1994-04-05T16:00:00.000Z",
     "end": "1995-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dLibKCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1994/07.json
+++ b/data/items/1994/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1994-07-29T16:00:00.000Z",
     "end": "1994-07-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3937",
-        "begin": "1994-07-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1994-07-28T16:00:01.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "",
     "begin": "1994-07-09T16:00:00.000Z",
     "end": "1994-07-09T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb54vl",
-        "begin": "2015-08-04T01:02:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-04T01:02:58.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "",
     "begin": "1994-07-09T16:00:00.000Z",
     "end": "1994-07-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,22 +77,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_supersenshi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -131,17 +98,11 @@
     "officialSite": "",
     "begin": "1994-07-08T16:00:00.000Z",
     "end": "1995-02-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tINibicGTKOnjbWcE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1994/08.json
+++ b/data/items/1994/08.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1994-08-20T16:00:00.000Z",
     "end": "1994-08-20T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb405h",
-        "begin": "2016-02-04T10:33:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:33:39.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "",
     "begin": "1994-08-25T16:00:00.000Z",
     "end": "1995-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gsq2NJwCcrATkfk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1994/09.json
+++ b/data/items/1994/09.json
@@ -11,27 +11,16 @@
     "officialSite": "",
     "begin": "1994-09-24T16:00:00.000Z",
     "end": "1995-11-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JhrlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "k/k1c99o8395wcddv",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "1343",
-        "begin": "1994-09-23T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1994-09-23T16:00:00.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "",
     "begin": "1994-09-03T16:00:00.000Z",
     "end": "1995-08-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MHpGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,12 +58,7 @@
       {
         "site": "bilibili",
         "id": "5209",
-        "begin": "1994-09-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1994-09-02T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1994/10.json
+++ b/data/items/1994/10.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.madhouse.co.jp/works/1994-1993/works_tv_dna.html",
     "begin": "1994-10-07T16:00:00.000Z",
     "end": "1994-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "http://www.macross.co.jp/",
     "begin": "1994-10-16T16:00:00.000Z",
     "end": "1995-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PAv2dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://www.nasinc.co.jp/jp/index.php?action=USER.WORKS.DETAIL&master_id=13",
     "begin": "1994-10-21T16:00:00.000Z",
     "end": "1995-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +62,7 @@
       {
         "site": "nicovideo",
         "id": "captsubaj",
-        "begin": "2012-11-11T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-11T12:00:00.000Z"
       }
     ]
   },
@@ -94,27 +81,16 @@
     "officialSite": "http://www.tms-e.com/search/index.php?pdt_no=36",
     "begin": "1994-10-17T16:00:00.000Z",
     "end": "1995-11-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2XJNyzOZCUeqKJA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "292188",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -123,22 +99,12 @@
       {
         "site": "nicovideo",
         "id": "rayearth",
-        "begin": "2011-09-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-20T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2325",
-        "begin": "1994-10-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1994-10-16T16:00:00.000Z"
       }
     ]
   },
@@ -154,17 +120,11 @@
     "officialSite": "",
     "begin": "1994-10-13T16:00:00.000Z",
     "end": "1995-09-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BUdBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -173,22 +133,12 @@
       {
         "site": "nicovideo",
         "id": "guruguru-anime",
-        "begin": "2017-07-22T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-22T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2326",
-        "begin": "1994-10-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1994-10-12T16:00:00.000Z"
       }
     ]
   },
@@ -204,7 +154,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "1994-10-03T08:35:00.000Z",
     "end": "1995-03-24T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -224,7 +173,6 @@
     "officialSite": "",
     "begin": "1994-10-21T16:00:00.000Z",
     "end": "1996-08-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -233,12 +181,7 @@
       {
         "site": "pptv",
         "id": "0H1Ixia6UBEKlI4s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1994/11.json
+++ b/data/items/1994/11.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1994-11-21T16:00:00.000Z",
     "end": "1994-11-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "bPrWVLwiaktAzsRk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,17 +35,11 @@
     "officialSite": "",
     "begin": "1994-11-21T16:00:00.000Z",
     "end": "2007-10-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aMK9O6MJebcamAA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1994/12.json
+++ b/data/items/1994/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1994-12-04T16:00:00.000Z",
     "end": "1994-12-04T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "1994-12-16T16:00:00.000Z",
     "end": "1997-06-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7VItqxN56SeKCHA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1995/01.json
+++ b/data/items/1995/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://xn--zenki-n47ih90pntc329h.jp/",
     "begin": "1995-01-09T16:00:00.000Z",
     "end": "1995-12-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2319",
-        "begin": "1995-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-01-08T16:00:00.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://www3.nhk.or.jp/anime/romio/index.html",
     "begin": "1995-01-15T16:00:00.000Z",
     "end": "1995-12-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -62,37 +55,21 @@
     "officialSite": "http://chibimaru.tv/",
     "begin": "1995-01-08T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qoFr6VG3J2XIRq4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc1qsl",
-        "begin": "2014-12-30T03:44:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-30T03:44:00.000Z"
       },
       {
         "site": "letv",
         "id": "81067",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1995/03.json
+++ b/data/items/1995/03.json
@@ -15,17 +15,11 @@
     "officialSite": "http://sailormoon.channel.or.jp/",
     "begin": "1995-03-04T16:00:00.000Z",
     "end": "1996-03-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12wl",
-        "begin": "2017-11-23T09:16:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-23T09:16:58.000Z"
       },
       {
         "site": "bangumi",
@@ -45,7 +39,6 @@
     "officialSite": "",
     "begin": "1995-03-04T16:00:00.000Z",
     "end": "1995-03-04T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -54,22 +47,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_fushion",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -85,7 +68,6 @@
     "officialSite": "",
     "begin": "1995-03-04T16:00:00.000Z",
     "end": "1995-03-04T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -94,12 +76,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb405h",
-        "begin": "2016-02-04T10:33:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:33:39.000Z"
       }
     ]
   },
@@ -115,17 +92,11 @@
     "officialSite": "",
     "begin": "1995-03-04T16:00:00.000Z",
     "end": "1995-03-04T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80950",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -134,32 +105,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2563",
-        "begin": "1995-03-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-03-03T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1995/04.json
+++ b/data/items/1995/04.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1995-04-08T16:00:00.000Z",
     "end": "1996-03-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,7 +33,6 @@
     "officialSite": "http://www.geocities.jp/yazawanet/",
     "begin": "1995-04-05T16:00:00.000Z",
     "end": "1996-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -43,12 +41,7 @@
       {
         "site": "bilibili",
         "id": "2323",
-        "begin": "1995-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -64,7 +57,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/azuki/",
     "begin": "1995-04-04T16:00:00.000Z",
     "end": "1998-03-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -84,17 +76,11 @@
     "officialSite": "http://web.archive.org/web/*/slayers-tv.net/",
     "begin": "1995-04-07T16:00:00.000Z",
     "end": "1995-09-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KRrlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -114,27 +100,16 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1995/tv_030.html",
     "begin": "1995-04-06T16:00:00.000Z",
     "end": "1996-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QYt181vBMWicSULg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjpucit",
-        "begin": "2014-09-12T06:31:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:31:34.000Z"
       },
       {
         "site": "bangumi",
@@ -143,12 +118,7 @@
       {
         "site": "letv",
         "id": "14042",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -164,27 +134,16 @@
     "officialSite": "http://www.gundam-w.jp/index.html",
     "begin": "1995-04-07T16:00:00.000Z",
     "end": "1996-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NwTicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/8w1oda40j0vkiwo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -204,31 +163,15 @@
     "officialSite": "",
     "begin": "1995-04-02T16:00:00.000Z",
     "end": "1995-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icTQQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "9756"
-      },
-      {
-        "site": "bilibili",
-        "id": "1613",
-        "begin": "1995-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -244,7 +187,6 @@
     "officialSite": "",
     "begin": "1995-04-08T16:00:00.000Z",
     "end": "1995-04-08T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -264,26 +206,15 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "1995-04-15T16:00:00.000Z",
     "end": "1995-04-15T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": "",
         "url": "http://www.iqiyi.com/v_19rrifx03h.html"
       },
       {
@@ -293,22 +224,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3871",
-        "begin": "1995-04-14T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "51552",
+        "begin": "1995-04-14T16:00:01.000Z"
       }
     ]
   },
@@ -324,17 +245,11 @@
     "officialSite": "",
     "begin": "1995-04-07T16:00:00.000Z",
     "end": "1996-01-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Y6uVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -343,12 +258,7 @@
       {
         "site": "bilibili",
         "id": "2311",
-        "begin": "1995-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -364,7 +274,6 @@
     "officialSite": "",
     "begin": "1995-04-20T16:00:00.000Z",
     "end": "1996-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -373,12 +282,7 @@
       {
         "site": "nicovideo",
         "id": "bonobono",
-        "begin": "2014-07-24T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-24T06:00:00.000Z"
       }
     ]
   },
@@ -394,7 +298,6 @@
     "officialSite": "",
     "begin": "1995-04-22T16:00:00.000Z",
     "end": "1995-04-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -403,12 +306,7 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -424,7 +322,6 @@
     "officialSite": "",
     "begin": "1995-04-04T16:00:00.000Z",
     "end": "1995-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -433,12 +330,7 @@
       {
         "site": "letv",
         "id": "29648",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1995/06.json
+++ b/data/items/1995/06.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.pro-reed.com/works/tv_series/w029.html",
     "begin": "1995-06-01T16:00:00.000Z",
     "end": "1996-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IAcCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jpsxhvkup9ves18",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2316",
-        "begin": "1995-05-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-05-31T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1995/07.json
+++ b/data/items/1995/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1995-07-07T16:00:00.000Z",
     "end": "1996-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "1995-07-15T16:00:00.000Z",
     "end": "1995-07-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,22 +38,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_ryuuken",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "1995-07-15T16:00:00.000Z",
     "end": "1995-07-15T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,12 +67,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb405h",
-        "begin": "2016-02-04T10:33:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:33:39.000Z"
       }
     ]
   },
@@ -101,17 +83,11 @@
     "officialSite": "",
     "begin": "1995-07-15T16:00:00.000Z",
     "end": "1995-07-15T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "bangumi",
@@ -131,17 +107,11 @@
     "officialSite": "",
     "begin": "1995-07-25T16:00:00.000Z",
     "end": "1996-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ej0Ihu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1995/08.json
+++ b/data/items/1995/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1995-08-04T16:00:00.000Z",
     "end": "1995-08-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3939",
-        "begin": "1995-08-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-08-03T16:00:01.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "",
     "begin": "1995-08-05T16:00:00.000Z",
     "end": "1995-08-05T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "z/zjbhkhzmf5eqrie",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,22 +58,12 @@
       {
         "site": "pptv",
         "id": "RfTgXsYsnNo9uyM",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3905",
-        "begin": "1995-08-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-08-04T16:00:01.000Z"
       }
     ]
   },
@@ -111,17 +79,11 @@
     "officialSite": "",
     "begin": "1995-08-21T16:00:00.000Z",
     "end": "1995-09-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7kUvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1995/09.json
+++ b/data/items/1995/09.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.toei-anim.co.jp/lineup/tv/gokinjyo/",
     "begin": "1995-09-10T16:00:00.000Z",
     "end": "1996-09-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JAn0ctpAsO5Rzzc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,12 +27,7 @@
       {
         "site": "bilibili",
         "id": "2315",
-        "begin": "1995-09-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-09-09T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1995/10.json
+++ b/data/items/1995/10.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1995-10-12T16:00:00.000Z",
     "end": "1996-09-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ebONC3PZSYfqaNA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "letv",
         "id": "20783",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2321",
-        "begin": "1995-10-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-10-11T16:00:00.000Z"
       }
     ]
   },
@@ -62,17 +46,11 @@
     "officialSite": "http://www.eva-info.jp/",
     "begin": "1995-10-04T16:00:00.000Z",
     "end": "1996-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9uy1h",
-        "begin": "2016-10-31T16:00:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-31T16:00:33.000Z"
       },
       {
         "site": "bangumi",
@@ -81,32 +59,17 @@
       {
         "site": "nicovideo",
         "id": "eva-anime",
-        "begin": "2015-03-21T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-21T00:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "4/42ccf73x27mdank",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1635",
-        "begin": "1995-10-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -122,7 +85,6 @@
     "officialSite": "",
     "begin": "1995-10-10T16:00:00.000Z",
     "end": "1995-10-10T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -142,7 +104,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "1995-10-02T08:35:00.000Z",
     "end": "1996-03-21T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -162,17 +123,11 @@
     "officialSite": "",
     "begin": "1995-10-03T16:00:00.000Z",
     "end": "1996-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iczELiafFXxwVo5k4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -181,12 +136,7 @@
       {
         "site": "bilibili",
         "id": "2314",
-        "begin": "1995-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1995-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -202,7 +152,6 @@
     "officialSite": "http://www.anime-int.com/works/elhazard/tv/",
     "begin": "1995-10-06T16:00:00.000Z",
     "end": "1996-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1995/11.json
+++ b/data/items/1995/11.json
@@ -14,17 +14,11 @@
     "officialSite": "",
     "begin": "1995-11-18T16:00:00.000Z",
     "end": "1995-11-18T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "w/wicl987c39zqmkh",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,12 +27,7 @@
       {
         "site": "letv",
         "id": "37953",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1995/12.json
+++ b/data/items/1995/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1995-12-23T16:00:00.000Z",
     "end": "1995-12-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "1995-12-23T16:00:00.000Z",
     "end": "1995-12-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Gj0Ihu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1996/01.json
+++ b/data/items/1996/01.json
@@ -15,87 +15,36 @@
     "officialSite": "http://www.ytv.co.jp/conan/",
     "begin": "1996-01-08T10:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "85224",
-        "begin": "1996-01-13T11:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0gyd",
-        "begin": "2016-09-28T12:45:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-28T12:45:45.000Z"
       },
       {
         "site": "qq",
         "id": "5/53q0eh78q97e4d1",
-        "begin": "1996-01-13T11:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-01-13T11:30:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2012/mztkn",
-        "begin": "1996-01-13T11:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-01-13T11:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "5938",
-        "begin": "1996-01-13T11:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-01-13T11:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "ac24Np4EdLIVkics",
-        "begin": "1996-01-13T11:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "7-W5njV4CQI",
-        "begin": "1996-01-13T11:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "1996-01-13T11:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "cc003400962411de83b1",
-        "begin": "2012-05-10T10:15:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-05-10T10:15:24.000Z"
       },
       {
         "site": "bangumi",
@@ -104,12 +53,7 @@
       {
         "site": "netflix",
         "id": "80090370",
-        "begin": "2016-01-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-01T08:00:00.000Z"
       }
     ]
   },
@@ -125,47 +69,26 @@
     "officialSite": "http://cgi.shopro.co.jp/tv/let_go/",
     "begin": "1996-01-08T09:00:00.000Z",
     "end": "1997-12-22T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BlkjoQlv3x2AicmY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rriftxv1",
-        "begin": "2013-08-07T10:21:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-07T10:21:00.000Z"
       },
       {
         "site": "qq",
         "id": "y/yfn3bjrmshbtski",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "48285",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -188,27 +111,16 @@
     "officialSite": "http://www.sonymusic.co.jp/Movie/TV/Kenshin/",
     "begin": "1996-01-10T16:00:00.000Z",
     "end": "1998-09-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UfLNS7MZiaccqqBA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "k/k6d2ovf4jl79n58",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -217,32 +129,17 @@
       {
         "site": "nicovideo",
         "id": "rurouni-kenshin-tokyo",
-        "begin": "2014-09-13T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-13T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80016571",
-        "begin": "2016-01-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-01T08:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2303",
-        "begin": "1996-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -262,17 +159,11 @@
     "officialSite": "",
     "begin": "1996-01-05T16:00:00.000Z",
     "end": "1996-01-05T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "w/w44r23kw9ljdyyp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -281,12 +172,7 @@
       {
         "site": "letv",
         "id": "10004313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -302,27 +188,16 @@
     "officialSite": "",
     "begin": "1996-01-25T16:00:00.000Z",
     "end": "1999-07-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fdSvLZX7a6kMiavI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/87lrosxr1yta375",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -343,17 +218,11 @@
     "officialSite": "",
     "begin": "1996-01-07T16:00:00.000Z",
     "end": "1998-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12ad",
-        "begin": "2015-10-29T09:09:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-29T09:09:06.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1996/02.json
+++ b/data/items/1996/02.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/dragongt/",
     "begin": "1996-02-07T16:00:00.000Z",
     "end": "1997-11-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1d0l",
-        "begin": "2015-12-30T08:59:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-30T08:59:15.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1996/03.json
+++ b/data/items/1996/03.json
@@ -15,17 +15,11 @@
     "officialSite": "http://sailormoon.channel.or.jp/",
     "begin": "1996-03-09T16:00:00.000Z",
     "end": "1997-02-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12j1",
-        "begin": "2015-08-14T17:08:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:08:42.000Z"
       },
       {
         "site": "bangumi",
@@ -45,7 +39,6 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1995/tv_031.html",
     "begin": "1996-03-02T16:00:00.000Z",
     "end": "1997-07-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -54,12 +47,7 @@
       {
         "site": "nicovideo",
         "id": "makibao-anime",
-        "begin": "2017-03-10T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-10T09:00:00.000Z"
       }
     ]
   },
@@ -75,7 +63,6 @@
     "officialSite": "",
     "begin": "1996-03-02T16:00:00.000Z",
     "end": "1996-03-02T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -84,22 +71,12 @@
       {
         "site": "nicovideo",
         "id": "DBZ_saikyou",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4015",
-        "begin": "2016-02-04T10:34:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T10:34:13.000Z"
       }
     ]
   },
@@ -115,17 +92,11 @@
     "officialSite": "",
     "begin": "1996-03-02T16:00:00.000Z",
     "end": "1996-03-02T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80951",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -134,22 +105,12 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2564",
-        "begin": "1996-03-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-03-01T16:00:00.000Z"
       }
     ]
   },
@@ -165,31 +126,15 @@
     "officialSite": "",
     "begin": "1996-03-06T16:00:00.000Z",
     "end": "1996-08-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "bdumJIzyYqADgek",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "80698"
-      },
-      {
-        "site": "bilibili",
-        "id": "5634",
-        "begin": "1996-03-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/1996/04.json
+++ b/data/items/1996/04.json
@@ -11,17 +11,11 @@
     "officialSite": "http://web.archive.org/web/*/slayers-tv.net/",
     "begin": "1996-04-05T16:00:00.000Z",
     "end": "1996-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QfLNS7MZiaccqqBA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,17 +35,11 @@
     "officialSite": "http://www.super-vision.co.jp/dvd/omocha/",
     "begin": "1996-04-05T16:00:00.000Z",
     "end": "1998-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AzQPjfVbywls6lI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,22 +48,12 @@
       {
         "site": "letv",
         "id": "20949",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2306",
-        "begin": "1996-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "http://www.escaflowne.jp/",
     "begin": "1996-04-02T16:00:00.000Z",
     "end": "1996-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "2300",
-        "begin": "1996-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -121,17 +93,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/nube/",
     "begin": "1996-04-13T16:00:00.000Z",
     "end": "1997-08-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1b39",
-        "begin": "2015-08-14T16:07:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T16:07:37.000Z"
       },
       {
         "site": "bangumi",
@@ -140,12 +106,7 @@
       {
         "site": "nicovideo",
         "id": "nube",
-        "begin": "2015-01-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-14T15:00:00.000Z"
       }
     ]
   },
@@ -161,27 +122,16 @@
     "officialSite": "http://www.gundam-x.net/",
     "begin": "1996-04-05T16:00:00.000Z",
     "end": "1996-12-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NQL9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/uiu4a0bfw9gkkpb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -201,7 +151,6 @@
     "officialSite": "",
     "begin": "1996-04-03T16:00:00.000Z",
     "end": "1996-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -210,12 +159,7 @@
       {
         "site": "bilibili",
         "id": "2298",
-        "begin": "1996-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -231,27 +175,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "1996-04-13T16:00:00.000Z",
     "end": "1996-04-13T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/v_19rrifx03f.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/v_19rrifx03f.html"
       },
       {
         "site": "bangumi",
@@ -260,12 +193,7 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -281,7 +209,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "1996-04-01T08:35:00.000Z",
     "end": "1996-09-13T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -301,17 +228,11 @@
     "officialSite": "",
     "begin": "1996-04-06T16:00:00.000Z",
     "end": "1996-09-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7EMtqxN56SeKCHA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -320,22 +241,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh8fzwl",
-        "begin": "2017-06-14T16:00:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T16:00:16.000Z"
       },
       {
         "site": "bilibili",
         "id": "2297",
-        "begin": "1996-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -351,17 +262,11 @@
     "officialSite": "http://www.pro-reed.com/works/tv_series/w031.html",
     "begin": "1996-04-05T16:00:00.000Z",
     "end": "1997-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gMy4Np4EdLIVkics",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -370,12 +275,7 @@
       {
         "site": "bilibili",
         "id": "2296",
-        "begin": "1996-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -391,7 +291,6 @@
     "officialSite": "",
     "begin": "1996-04-20T16:00:00.000Z",
     "end": "1996-04-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -400,22 +299,12 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3932",
-        "begin": "1996-04-19T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-04-19T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1996/06.json
+++ b/data/items/1996/06.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/kotikame/index.html",
     "begin": "1996-06-16T16:00:00.000Z",
     "end": "2004-12-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BjEMiavJYyAZp508",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2299",
-        "begin": "1996-06-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-06-16T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1996/07.json
+++ b/data/items/1996/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1995/tv_033.html",
     "begin": "1996-07-11T16:00:00.000Z",
     "end": "1997-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "1996-07-19T16:00:00.000Z",
     "end": "1996-07-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,7 +49,6 @@
     "officialSite": "",
     "begin": "1996-07-06T16:00:00.000Z",
     "end": "1996-07-06T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +57,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4kld",
-        "begin": "2015-08-11T08:03:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-11T08:03:32.000Z"
       }
     ]
   },
@@ -82,7 +74,6 @@
     "officialSite": "",
     "begin": "1996-07-06T16:00:00.000Z",
     "end": "1996-07-06T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1996/08.json
+++ b/data/items/1996/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1996-08-02T16:00:00.000Z",
     "end": "1996-08-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3941",
-        "begin": "1996-08-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-08-01T16:00:01.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "",
     "begin": "1996-08-03T16:00:00.000Z",
     "end": "1996-08-03T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "v/vipzjddgmxp2e25",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,22 +58,12 @@
       {
         "site": "pptv",
         "id": "RfTgXsYsnNo9uyM",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3906",
-        "begin": "1996-08-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-08-02T16:00:01.000Z"
       }
     ]
   },
@@ -111,17 +79,11 @@
     "officialSite": "",
     "begin": "1996-08-01T16:00:00.000Z",
     "end": "1997-07-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NnlDwSmPicz2gHoY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -130,12 +92,7 @@
       {
         "site": "bilibili",
         "id": "3810",
-        "begin": "1996-07-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-07-31T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1996/09.json
+++ b/data/items/1996/09.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/metals/",
     "begin": "1996-09-16T09:30:00.000Z",
     "end": "1999-03-07T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhaajfd",
-        "begin": "2016-01-04T09:27:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-04T09:27:18.000Z"
       },
       {
         "site": "bangumi",
@@ -42,7 +36,6 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/ienakiko_remi.html",
     "begin": "1996-09-01T16:00:00.000Z",
     "end": "1997-03-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,12 +44,7 @@
       {
         "site": "bilibili",
         "id": "2785",
-        "begin": "1996-08-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-08-31T16:00:00.000Z"
       }
     ]
   },
@@ -73,17 +61,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/hanadan/",
     "begin": "1996-09-08T16:00:00.000Z",
     "end": "1997-08-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1ct5",
-        "begin": "2015-11-02T05:25:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-02T05:25:25.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1996/10.json
+++ b/data/items/1996/10.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.mashroom.com/comic/yat/",
     "begin": "1996-10-05T16:00:00.000Z",
     "end": "1997-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,12 +22,7 @@
       {
         "site": "bilibili",
         "id": "2304",
-        "begin": "1996-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -44,17 +38,11 @@
     "officialSite": "",
     "begin": "1996-10-04T16:00:00.000Z",
     "end": "1997-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1RzoZs40pOJFwys",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -63,12 +51,7 @@
       {
         "site": "bilibili",
         "id": "1615",
-        "begin": "1996-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -84,7 +67,6 @@
     "officialSite": "",
     "begin": "1996-10-02T16:00:00.000Z",
     "end": "1997-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -104,17 +86,11 @@
     "officialSite": "http://www.starchild.co.jp/special/nadeshiko/",
     "begin": "1996-10-01T16:00:00.000Z",
     "end": "1997-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "naibaGIDmVpT3dd0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -123,12 +99,7 @@
       {
         "site": "nicovideo",
         "id": "nadeshiko",
-        "begin": "2013-12-27T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-27T03:00:00.000Z"
       }
     ]
   },
@@ -144,27 +115,16 @@
     "officialSite": "",
     "begin": "1996-10-05T16:00:00.000Z",
     "end": "1997-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HSUgngZs3Bp9ib2M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "p/pamxefuoyoxrqus",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -185,27 +145,16 @@
     "officialSite": "",
     "begin": "1996-10-25T16:00:00.000Z",
     "end": "1997-02-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nbCcGoLoWJb5d98",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjp9zvx",
-        "begin": "2013-04-18T02:18:20.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-18T02:18:20.000Z"
       },
       {
         "site": "bangumi",
@@ -225,17 +174,11 @@
     "officialSite": "",
     "begin": "1996-10-01T16:00:00.000Z",
     "end": "1997-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KGNd20OpGVe6OKA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -244,12 +187,7 @@
       {
         "site": "bilibili",
         "id": "3263",
-        "begin": "1996-09-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-09-30T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1996/11.json
+++ b/data/items/1996/11.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.vap.co.jp/orangeroad/",
     "begin": "1996-11-02T16:00:00.000Z",
     "end": "1996-11-02T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "9/9uzlr16d82f0gef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "4049",
-        "begin": "1996-11-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1996-11-01T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1996/12.json
+++ b/data/items/1996/12.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/kindaichi",
     "begin": "1996-12-14T16:00:00.000Z",
     "end": "1996-12-14T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1997/01.json
+++ b/data/items/1997/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://ch.nicovideo.jp/gogogo02",
     "begin": "1997-01-09T16:00:00.000Z",
     "end": "1997-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -32,27 +31,16 @@
     "officialSite": "",
     "begin": "1997-01-25T16:00:00.000Z",
     "end": "1997-01-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbyxml",
-        "begin": "2014-10-31T04:50:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-31T04:50:21.000Z"
       },
       {
         "site": "qq",
         "id": "i/izkiu4p8jljjjvk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -61,12 +49,7 @@
       {
         "site": "bilibili",
         "id": "6058",
-        "begin": "1997-01-24T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-01-24T16:00:01.000Z"
       }
     ]
   },
@@ -82,17 +65,11 @@
     "officialSite": "",
     "begin": "1997-01-09T16:00:00.000Z",
     "end": "1997-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibDIOjPRayghr6VE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,12 +78,7 @@
       {
         "site": "letv",
         "id": "29220",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -122,7 +94,6 @@
     "officialSite": "",
     "begin": "1997-01-06T16:00:00.000Z",
     "end": "1997-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -131,12 +102,7 @@
       {
         "site": "qq",
         "id": "w/w5vg5k5rwmlkab9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1997/02.json
+++ b/data/items/1997/02.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1997-02-01T16:00:00.000Z",
     "end": "1998-01-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "1823",
-        "begin": "1997-01-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-01-31T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1997/03.json
+++ b/data/items/1997/03.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1997-03-15T16:00:00.000Z",
     "end": "1997-03-15T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zj65",
-        "begin": "2016-10-31T16:00:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-31T16:00:43.000Z"
       },
       {
         "site": "bangumi",
@@ -29,13 +23,8 @@
       },
       {
         "site": "bilibili",
-        "id": "1637",
-        "begin": "1997-03-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10312",
+        "begin": "1997-03-14T16:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "1997-03-08T16:00:00.000Z",
     "end": "1997-03-08T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4kld",
-        "begin": "2015-08-11T08:03:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-11T08:03:32.000Z"
       }
     ]
   },
@@ -81,7 +64,6 @@
     "officialSite": "",
     "begin": "1997-03-26T16:00:00.000Z",
     "end": "1997-03-26T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -101,7 +83,6 @@
     "officialSite": "",
     "begin": "1997-03-08T16:00:00.000Z",
     "end": "1997-03-08T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -121,17 +102,11 @@
     "officialSite": "",
     "begin": "1997-03-08T16:00:00.000Z",
     "end": "1997-03-08T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80952",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,22 +115,12 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3864",
-        "begin": "1997-03-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-03-07T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1997/04.json
+++ b/data/items/1997/04.json
@@ -23,47 +23,26 @@
     "officialSite": "http://www.shopro.co.jp/tv/archive/pokemon/",
     "begin": "1997-04-01T09:30:00.000Z",
     "end": "2002-11-14T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ASUPjfVbywls6lI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifpgxp",
-        "begin": "2014-04-09T23:55:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:55:28.000Z"
       },
       {
         "site": "qq",
         "id": "t/tyeqdw6rof7t5ow",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2017/jlbkm1",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -83,31 +62,15 @@
     "officialSite": "http://www.tenchi-web.com/",
     "begin": "1997-04-01T09:00:00.000Z",
     "end": "1997-09-23T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TibDbWcEnl9U4th4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "19542"
-      },
-      {
-        "site": "bilibili",
-        "id": "1614",
-        "begin": "1997-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -123,17 +86,11 @@
     "officialSite": "http://www.starchild.co.jp/special/utena/",
     "begin": "1997-04-02T09:00:00.000Z",
     "end": "1997-12-24T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ToB8ibmLIOHbZV78",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -142,22 +99,12 @@
       {
         "site": "nicovideo",
         "id": "utena-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2277",
-        "begin": "1997-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -176,7 +123,6 @@
     "officialSite": "http://www.at-x.com/program/detail/3549",
     "begin": "1997-04-09T16:00:00.000Z",
     "end": "1999-05-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -196,17 +142,11 @@
     "officialSite": "http://web.archive.org/web/*/slayers-tv.net/",
     "begin": "1997-04-04T16:00:00.000Z",
     "end": "1997-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QicTPTbUbia8ksqhI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -226,7 +166,6 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1995/tv_034.html",
     "begin": "1997-04-03T16:00:00.000Z",
     "end": "1997-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -247,27 +186,16 @@
     "officialSite": "",
     "begin": "1997-04-27T16:00:00.000Z",
     "end": "1998-09-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk0tzb1",
-        "begin": "2014-04-09T23:58:56.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:58:56.000Z"
       },
       {
         "site": "letv",
         "id": "46119",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -276,12 +204,7 @@
       {
         "site": "qq",
         "id": "7/7jzjwwtpqo2hilu",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -297,17 +220,11 @@
     "officialSite": "",
     "begin": "1997-04-25T16:00:00.000Z",
     "end": "1997-04-25T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "m/mvc7etmp0qsi89x",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -316,12 +233,7 @@
       {
         "site": "letv",
         "id": "10004313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -337,17 +249,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/kindaichi/",
     "begin": "1997-04-07T16:00:00.000Z",
     "end": "2000-09-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1avt",
-        "begin": "2015-08-14T16:12:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T16:12:33.000Z"
       },
       {
         "site": "bangumi",
@@ -367,27 +273,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "1997-04-19T16:00:00.000Z",
     "end": "1997-04-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/75c20dc1fe211093.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/75c20dc1fe211093.html"
       },
       {
         "site": "bangumi",
@@ -396,22 +291,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3874",
-        "begin": "1997-04-18T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "11652",
+        "begin": "1997-04-18T16:00:01.000Z"
       }
     ]
   },
@@ -427,17 +312,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "1997-04-19T16:00:00.000Z",
     "end": "1997-04-19T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -446,22 +325,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -477,17 +346,11 @@
     "officialSite": "",
     "begin": "1997-04-02T16:00:00.000Z",
     "end": "1997-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JmlT0TmfD02wLpY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -507,17 +370,11 @@
     "officialSite": "",
     "begin": "1997-04-02T16:00:00.000Z",
     "end": "2000-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3WpV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -526,12 +383,7 @@
       {
         "site": "bilibili",
         "id": "2031",
-        "begin": "1997-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-04-01T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1997/05.json
+++ b/data/items/1997/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1995/tv_035.html",
     "begin": "1997-05-03T16:00:00.000Z",
     "end": "1997-10-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GlUvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2281",
-        "begin": "1997-05-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-05-02T16:00:00.000Z"
       }
     ]
   },
@@ -51,27 +40,16 @@
     "officialSite": "",
     "begin": "1997-05-25T16:00:00.000Z",
     "end": "1998-10-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nbCcGoLoWJb5d98",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjpa0lt",
-        "begin": "2013-04-18T02:16:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-18T02:16:00.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1997/07.json
+++ b/data/items/1997/07.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1997-07-19T16:00:00.000Z",
     "end": "1997-07-19T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zj65",
-        "begin": "2016-10-31T16:00:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-31T16:00:43.000Z"
       },
       {
         "site": "bangumi",
@@ -29,13 +23,8 @@
       },
       {
         "site": "bilibili",
-        "id": "1630",
-        "begin": "1997-07-18T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10272",
+        "begin": "1997-07-18T16:00:01.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "1997-07-12T16:00:00.000Z",
     "end": "1997-07-12T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4kld",
-        "begin": "2015-08-11T08:03:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-11T08:03:32.000Z"
       }
     ]
   },
@@ -81,7 +64,6 @@
     "officialSite": "",
     "begin": "1997-07-12T16:00:00.000Z",
     "end": "1997-07-12T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -101,17 +83,11 @@
     "officialSite": "",
     "begin": "1997-07-12T16:00:00.000Z",
     "end": "1997-07-12T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "bangumi",
@@ -131,17 +107,11 @@
     "officialSite": "",
     "begin": "1997-07-19T16:00:00.000Z",
     "end": "1998-07-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HE46uCCG9jSXFX0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,12 +120,7 @@
       {
         "site": "bilibili",
         "id": "2283",
-        "begin": "1997-07-18T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-07-18T16:00:00.000Z"
       }
     ]
   },
@@ -171,7 +136,6 @@
     "officialSite": "",
     "begin": "1997-07-25T16:00:00.000Z",
     "end": "1997-12-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -180,22 +144,12 @@
       {
         "site": "pptv",
         "id": "2nVQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3806",
-        "begin": "1997-07-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-07-24T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1997/08.json
+++ b/data/items/1997/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1997-08-01T16:00:00.000Z",
     "end": "1997-08-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3943",
-        "begin": "1997-07-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-07-31T16:00:01.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "",
     "begin": "1997-08-02T16:00:00.000Z",
     "end": "1997-08-02T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/oduylf96schr6ce",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,22 +58,12 @@
       {
         "site": "pptv",
         "id": "RfTgXsYsnNo9uyM",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3907",
-        "begin": "1997-08-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-08-01T16:00:01.000Z"
       }
     ]
   },
@@ -111,17 +79,11 @@
     "officialSite": "",
     "begin": "1997-08-21T16:00:00.000Z",
     "end": "1998-01-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gsy4Np4EdLIVkics",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -130,22 +92,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh8fz5p",
-        "begin": "2017-06-14T16:00:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T16:00:12.000Z"
       },
       {
         "site": "bilibili",
         "id": "3861",
-        "begin": "1997-08-20T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-08-20T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1997/09.json
+++ b/data/items/1997/09.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/crayon/",
     "begin": "1997-09-07T16:00:00.000Z",
     "end": "1999-01-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "1997-09-30T09:00:00.000Z",
     "end": "1998-03-24T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1997/10.json
+++ b/data/items/1997/10.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.mashin-eiyuuden-wataru.net/chowataru/",
     "begin": "1997-10-02T16:00:00.000Z",
     "end": "1998-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lJp29FzCMnDTUbk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "qq",
         "id": "o/on6zl3l9vg0qyyq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyamst",
-        "begin": "2018-05-16T09:42:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-16T09:42:21.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "http://www.vap.co.jp/berserk/tv.html",
     "begin": "1997-10-07T16:00:00.000Z",
     "end": "1998-03-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "k7uGBGzSQoDjYck",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,12 +58,7 @@
       {
         "site": "nicovideo",
         "id": "kenpudenki-berserk-anime",
-        "begin": "2016-07-27T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-27T06:00:00.000Z"
       }
     ]
   },
@@ -101,17 +74,11 @@
     "officialSite": "http://www.anime-int.com/works/daiundoukai/tv/index.html",
     "begin": "1997-10-03T16:00:00.000Z",
     "end": "1998-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5kk0shqA8C6RD3c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -120,12 +87,7 @@
       {
         "site": "bilibili",
         "id": "2285",
-        "begin": "1997-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -141,7 +103,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "1997-10-06T08:35:00.000Z",
     "end": "1998-02-25T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -161,17 +122,11 @@
     "officialSite": "",
     "begin": "1997-10-02T16:00:00.000Z",
     "end": "1997-12-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "P3BMyjKYCEapJ48",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -180,12 +135,7 @@
       {
         "site": "bilibili",
         "id": "5444",
-        "begin": "1997-10-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-10-01T16:00:01.000Z"
       }
     ]
   },
@@ -201,17 +151,11 @@
     "officialSite": "",
     "begin": "1997-10-06T16:00:00.000Z",
     "end": "1998-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vY149l7ENHLVU7s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -220,12 +164,7 @@
       {
         "site": "nicovideo",
         "id": "vampire-miyu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1997/11.json
+++ b/data/items/1997/11.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1997-11-26T16:00:00.000Z",
     "end": "1999-09-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1cip",
-        "begin": "2015-11-10T07:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-10T07:05:00.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/1997/12.json
+++ b/data/items/1997/12.json
@@ -11,21 +11,10 @@
     "officialSite": "http://www.anime-int.com/works/burn-up/scramble/",
     "begin": "1997-12-12T16:00:00.000Z",
     "end": "1998-07-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "36810"
-      },
-      {
-        "site": "bilibili",
-        "id": "4028",
-        "begin": "1997-12-11T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -41,17 +30,11 @@
     "officialSite": "http://www.macross.co.jp/",
     "begin": "1997-12-18T16:00:00.000Z",
     "end": "1998-07-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "j/j9j0tgpss02qg39",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,27 +54,16 @@
     "officialSite": "http://www.macross.co.jp/",
     "begin": "1997-12-20T16:00:00.000Z",
     "end": "1997-12-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zmRf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "6/6dypzbjwcdovtjd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -111,7 +83,6 @@
     "officialSite": "",
     "begin": "1997-12-18T16:00:00.000Z",
     "end": "1998-07-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -120,22 +91,12 @@
       {
         "site": "pptv",
         "id": "zgP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2291",
-        "begin": "1997-12-17T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1997-12-17T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1998/01.json
+++ b/data/items/1998/01.json
@@ -14,41 +14,20 @@
     "officialSite": "http://www.pro-reed.com/works/tv_series/w032.html",
     "begin": "1998-01-07T09:00:00.000Z",
     "end": "1998-03-25T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "H1AsqhJ46CaJB28",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/udqfni7dwdkdt70",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "49886"
-      },
-      {
-        "site": "bilibili",
-        "id": "2265",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
       }
     ]
   },
@@ -64,7 +43,6 @@
     "officialSite": "http://cgi.shopro.co.jp/tv/let_go/",
     "begin": "1998-01-05T09:00:00.000Z",
     "end": "1998-12-21T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -73,22 +51,7 @@
       {
         "site": "qq",
         "id": "f/fcirunt4i2j1kuz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4035",
-        "begin": "1998-01-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -104,7 +67,6 @@
     "officialSite": "http://www.sunrise-inc.co.jp/seihou/",
     "begin": "1998-01-08T16:00:00.000Z",
     "end": "1998-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -113,12 +75,7 @@
       {
         "site": "bilibili",
         "id": "2267",
-        "begin": "1998-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -134,17 +91,11 @@
     "officialSite": "",
     "begin": "1998-01-07T16:00:00.000Z",
     "end": "1998-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KhvmZMwyouBDwSk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1998/02.json
+++ b/data/items/1998/02.json
@@ -16,17 +16,11 @@
     "officialSite": "",
     "begin": "1998-02-28T16:00:00.000Z",
     "end": "1998-02-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "18638",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1998/03.json
+++ b/data/items/1998/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.vifam.net/",
     "begin": "1998-03-21T16:00:00.000Z",
     "end": "1998-10-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "1998-03-07T16:00:00.000Z",
     "end": "1998-03-07T18:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zj65",
-        "begin": "2016-10-31T16:00:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-31T16:00:43.000Z"
       },
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "",
     "begin": "1998-03-07T16:00:00.000Z",
     "end": "1998-03-07T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,17 +73,11 @@
     "officialSite": "",
     "begin": "1998-03-07T16:00:00.000Z",
     "end": "1998-03-07T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80953",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,22 +86,12 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1998/04.json
+++ b/data/items/1998/04.json
@@ -12,17 +12,11 @@
     "officialSite": "http://ch.nicovideo.jp/bw2",
     "begin": "1998-04-01T09:30:00.000Z",
     "end": "1999-01-27T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhajmkd",
-        "begin": "2016-04-11T04:56:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-11T04:56:31.000Z"
       },
       {
         "site": "bangumi",
@@ -31,12 +25,7 @@
       {
         "site": "letv",
         "id": "10020849",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -52,17 +41,11 @@
     "officialSite": "",
     "begin": "1998-04-01T09:00:00.000Z",
     "end": "1998-09-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0RjkYsowoN5Bvyc",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,32 +54,17 @@
       {
         "site": "nicovideo",
         "id": "Record_of_Lodoss_War2",
-        "begin": "2018-04-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-01T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "163",
-        "begin": "1998-03-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-03-31T16:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "4/4iskjyeeqsnp96t",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -115,7 +83,6 @@
     "officialSite": "http://www.mashroom.com/comic/yat/",
     "begin": "1998-04-11T16:00:00.000Z",
     "end": "1998-10-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -135,7 +102,6 @@
     "officialSite": "",
     "begin": "1998-04-05T16:00:00.000Z",
     "end": "1999-02-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -158,27 +124,16 @@
     "officialSite": "",
     "begin": "1998-04-19T16:00:00.000Z",
     "end": "1998-12-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "u5Nu7FS6KmjLSbE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "e/e57sd2czup3fw7v",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -198,7 +153,6 @@
     "officialSite": "http://www.b-ch.com/cgi-bin/contents/ttl/det.cgi?ttl_c=396",
     "begin": "1998-04-01T16:00:00.000Z",
     "end": "1998-09-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -218,7 +172,6 @@
     "officialSite": "http://www.nifty.com/animefan/fanclb/pri9/",
     "begin": "1998-04-08T16:00:00.000Z",
     "end": "1998-10-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -227,12 +180,7 @@
       {
         "site": "bilibili",
         "id": "2252",
-        "begin": "1998-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -248,17 +196,11 @@
     "officialSite": "",
     "begin": "1998-04-02T16:00:00.000Z",
     "end": "1998-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "j7uGBGzSQoDjYck",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -267,12 +209,7 @@
       {
         "site": "bilibili",
         "id": "2258",
-        "begin": "1998-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -289,57 +226,31 @@
     "officialSite": "http://www.nhk-character.com/chara/sakura/index.html",
     "begin": "1998-04-07T16:00:00.000Z",
     "end": "2000-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gqqVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjbqod",
-        "begin": "2014-04-09T23:30:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:30:55.000Z"
       },
       {
         "site": "letv",
         "id": "37973",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/mksny",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "102776",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -348,22 +259,12 @@
       {
         "site": "qq",
         "id": "w/wplx79f0v0dlop3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3756",
-        "begin": "1998-04-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-06T16:00:01.000Z"
       }
     ]
   },
@@ -379,17 +280,11 @@
     "officialSite": "http://animejapan.cplaza.ne.jp/b-ch/brain_tva/brain_tva.html",
     "begin": "1998-04-08T16:00:00.000Z",
     "end": "1998-11-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Igv2dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -410,17 +305,11 @@
     "officialSite": "http://www.starchild.co.jp/special/lostunivers/",
     "begin": "1998-04-03T16:00:00.000Z",
     "end": "1998-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icEdCwCiaOicjyfHYU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -429,12 +318,7 @@
       {
         "site": "bilibili",
         "id": "2254",
-        "begin": "1998-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -450,7 +334,6 @@
     "officialSite": "",
     "begin": "1998-04-06T16:00:00.000Z",
     "end": "1999-01-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -474,17 +357,11 @@
     "officialSite": "http://pierrot.jp/title/magicgirl/",
     "begin": "1998-04-05T16:00:00.000Z",
     "end": "1998-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "r8mzMZnicb60QjvY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -493,12 +370,7 @@
       {
         "site": "bilibili",
         "id": "2260",
-        "begin": "1998-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -514,27 +386,16 @@
     "officialSite": "",
     "begin": "1998-04-06T16:00:00.000Z",
     "end": "1999-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FCwXlf1j0xF08lo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bporoyheauyi2pk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -543,12 +404,7 @@
       {
         "site": "bilibili",
         "id": "1450",
-        "begin": "1998-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -564,7 +420,6 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1995/tv_039.html",
     "begin": "1998-04-06T16:00:00.000Z",
     "end": "1998-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -573,12 +428,7 @@
       {
         "site": "bilibili",
         "id": "2253",
-        "begin": "1998-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -594,7 +444,6 @@
     "officialSite": "",
     "begin": "1998-04-06T16:00:00.000Z",
     "end": "1998-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -614,7 +463,6 @@
     "officialSite": "http://www.fujitv.co.jp/dt8/index2.html",
     "begin": "1998-04-18T16:00:00.000Z",
     "end": "1998-11-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -634,27 +482,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "1998-04-18T16:00:00.000Z",
     "end": "1998-04-18T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/5b125eb281c3ee4e.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/5b125eb281c3ee4e.html"
       },
       {
         "site": "bangumi",
@@ -663,12 +500,7 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -684,17 +516,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "1998-04-18T16:00:00.000Z",
     "end": "1998-04-18T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -703,22 +529,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -734,7 +550,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "1998-04-06T08:35:00.000Z",
     "end": "1998-06-26T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -754,17 +569,11 @@
     "officialSite": "",
     "begin": "1998-04-04T16:00:00.000Z",
     "end": "1998-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yBfxb9c9retOzDQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -784,17 +593,11 @@
     "officialSite": "http://www.marine-e.co.jp/Gluhen/index.htm",
     "begin": "1998-04-08T16:00:00.000Z",
     "end": "1998-09-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oevVU7shkc8ysBg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -814,17 +617,11 @@
     "officialSite": "",
     "begin": "1998-04-08T16:00:00.000Z",
     "end": "1998-07-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XOTfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -833,12 +630,7 @@
       {
         "site": "bilibili",
         "id": "2257",
-        "begin": "1998-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -854,17 +646,11 @@
     "officialSite": "",
     "begin": "1998-04-06T16:00:00.000Z",
     "end": "1998-06-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "71gjoQlv3x2AicmY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -873,12 +659,7 @@
       {
         "site": "bilibili",
         "id": "5270",
-        "begin": "1998-04-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-05T16:00:01.000Z"
       }
     ]
   },
@@ -894,7 +675,6 @@
     "officialSite": "",
     "begin": "1998-04-21T16:00:00.000Z",
     "end": "1998-12-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -903,22 +683,12 @@
       {
         "site": "pptv",
         "id": "Y9eyMJjibbqwPjfU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3989",
-        "begin": "1998-04-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-04-20T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1998/06.json
+++ b/data/items/1998/06.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "1998-06-18T17:10:00.000Z",
     "end": "1998-06-18T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -27,7 +26,6 @@
     "officialSite": "",
     "begin": "1998-06-18T16:00:00.000Z",
     "end": "1998-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -36,12 +34,7 @@
       {
         "site": "nicovideo",
         "id": "supermilk-chan",
-        "begin": "2011-06-17T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-06-17T12:00:00.000Z"
       }
     ]
   }

--- a/data/items/1998/07.json
+++ b/data/items/1998/07.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/lain/",
     "begin": "1998-07-06T16:00:00.000Z",
     "end": "1998-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LV8ppw915SOGBGw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2251",
-        "begin": "1998-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1998-07-24T16:00:00.000Z",
     "end": "1998-07-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,32 +48,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3945",
-        "begin": "1998-07-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-07-23T16:00:01.000Z"
       }
     ]
   },
@@ -101,37 +74,21 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "1998-07-18T16:00:00.000Z",
     "end": "1998-07-18T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "34954",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,22 +97,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5758",
-        "begin": "1998-07-17T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-07-17T16:00:01.000Z"
       }
     ]
   },
@@ -171,17 +118,11 @@
     "officialSite": "",
     "begin": "1998-07-02T16:00:00.000Z",
     "end": "1998-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ruDcWsIomNY5tx8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -190,12 +131,7 @@
       {
         "site": "bilibili",
         "id": "2250",
-        "begin": "1998-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-07-01T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1998/08.json
+++ b/data/items/1998/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.momose-net.com/",
     "begin": "1998-08-25T16:00:00.000Z",
     "end": "1998-10-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "1998-08-01T16:00:00.000Z",
     "end": "1998-08-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "i/iatciy3zx6euxfz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,22 +43,12 @@
       {
         "site": "pptv",
         "id": "RfTgXsYsnNo9uyM",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3908",
-        "begin": "1998-07-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-07-31T16:00:01.000Z"
       }
     ]
   },
@@ -81,17 +64,11 @@
     "officialSite": "",
     "begin": "1998-08-01T16:00:00.000Z",
     "end": "1998-08-01T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "p/pqd8onvspoiw24u",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -111,17 +88,11 @@
     "officialSite": "",
     "begin": "1998-08-01T16:00:00.000Z",
     "end": "1998-08-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "i/izkiu4p8jljjjvk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -141,31 +112,15 @@
     "officialSite": "",
     "begin": "1998-08-25T16:00:00.000Z",
     "end": "1999-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ou3XVb0jk9E0sho",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "23213"
-      },
-      {
-        "site": "bilibili",
-        "id": "2353",
-        "begin": "1998-08-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -181,7 +136,6 @@
     "officialSite": "http://www.b-ch.com/cgi-bin/contents/ttl/det.cgi?ttl_c=444",
     "begin": "1998-08-08T16:00:00.000Z",
     "end": "1998-08-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -190,12 +144,7 @@
       {
         "site": "pptv",
         "id": "yX1X1T2jE1G0Mpo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1998/09.json
+++ b/data/items/1998/09.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1998-09-23T16:00:00.000Z",
     "end": "1998-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "c/cxfzlchx74egw5y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1998/10.json
+++ b/data/items/1998/10.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1998-10-04T16:00:00.000Z",
     "end": "1999-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nbSPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "http://ch.nicovideo.jp/devilman-lady",
     "begin": "1998-10-10T16:00:00.000Z",
     "end": "1999-04-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "nicovideo",
         "id": "devilman-lady",
-        "begin": "2011-11-23T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-23T06:00:00.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "1998-10-05T16:00:00.000Z",
     "end": "1999-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,17 +78,11 @@
     "officialSite": "http://www.production-ig.co.jp/xebec/sakuhin/joki/",
     "begin": "1998-10-07T09:00:00.000Z",
     "end": "1999-03-31T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9jgEgupQwP5h30c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,12 +91,7 @@
       {
         "site": "bilibili",
         "id": "2243",
-        "begin": "1998-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -131,17 +107,11 @@
     "officialSite": "http://www.sunrise-inc.co.jp/datacard/card0164.htm",
     "begin": "1998-10-04T00:30:00.000Z",
     "end": "1999-03-28T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GFMtqxN56SeKCHA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,12 +120,7 @@
       {
         "site": "bilibili",
         "id": "2247",
-        "begin": "1998-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -173,18 +138,7 @@
     "officialSite": "http://www.sunrise-anime.jp/sunrise-inc/works/detail.php?cid=41",
     "begin": "1998-10-23T09:00:00.000Z",
     "end": "1999-04-23T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "2261",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "253"
@@ -192,12 +146,7 @@
       {
         "site": "letv",
         "id": "46349",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -216,17 +165,11 @@
     "officialSite": "http://www.at-x.com/program/detail/985",
     "begin": "1998-10-07T16:00:00.000Z",
     "end": "1998-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "W9ibqKJD2ZqQHhe0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -235,12 +178,7 @@
       {
         "site": "bilibili",
         "id": "5415",
-        "begin": "1998-10-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-10-06T16:00:01.000Z"
       }
     ]
   },
@@ -256,7 +194,6 @@
     "officialSite": "",
     "begin": "1998-10-05T16:00:00.000Z",
     "end": "1998-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -276,17 +213,11 @@
     "officialSite": "http://www.vap.co.jp/keaton/index.html",
     "begin": "1998-10-05T16:00:00.000Z",
     "end": "1999-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "P1slowtx4RibCAGg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -295,12 +226,7 @@
       {
         "site": "bilibili",
         "id": "2249",
-        "begin": "1998-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -318,27 +244,16 @@
     "officialSite": "http://www.gainax.co.jp/anime/karekano/",
     "begin": "1998-10-02T16:00:00.000Z",
     "end": "1999-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "t5pl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3275",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -358,17 +273,11 @@
     "officialSite": "",
     "begin": "1998-10-03T16:00:00.000Z",
     "end": "1999-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dbaSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -377,12 +286,7 @@
       {
         "site": "bilibili",
         "id": "2268",
-        "begin": "1998-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -398,17 +302,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/getten/index2.html",
     "begin": "1998-10-17T16:00:00.000Z",
     "end": "1999-04-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HE85txibF9TOWFHw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -417,12 +315,7 @@
       {
         "site": "bilibili",
         "id": "2244",
-        "begin": "1998-10-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-10-16T16:00:00.000Z"
       }
     ]
   },
@@ -439,17 +332,11 @@
     "officialSite": "",
     "begin": "1998-10-25T16:00:00.000Z",
     "end": "2000-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrginde9",
-        "begin": "2014-07-23T05:05:41.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-23T05:05:41.000Z"
       },
       {
         "site": "bangumi",
@@ -458,12 +345,7 @@
       {
         "site": "bilibili",
         "id": "3274",
-        "begin": "1998-10-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-10-24T16:00:01.000Z"
       }
     ]
   },
@@ -479,17 +361,11 @@
     "officialSite": "",
     "begin": "1998-10-06T16:00:00.000Z",
     "end": "1999-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibzUPjfVbywls6lI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -498,12 +374,7 @@
       {
         "site": "bilibili",
         "id": "3264",
-        "begin": "1998-10-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-10-05T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1998/11.json
+++ b/data/items/1998/11.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1998-11-06T16:00:00.000Z",
     "end": "1999-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "1998-11-30T16:00:00.000Z",
     "end": "1998-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YtaxL5f9basOjPQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "2241",
-        "begin": "1998-11-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-11-29T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1998/12.json
+++ b/data/items/1998/12.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1998-12-11T16:00:00.000Z",
     "end": "1998-12-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "6/6eavchny0o21tia",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,17 +35,11 @@
     "officialSite": "",
     "begin": "1998-12-21T16:00:00.000Z",
     "end": "2000-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NXZS0DiaeDkyvLZU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,22 +48,12 @@
       {
         "site": "letv",
         "id": "39831",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3811",
-        "begin": "1998-12-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1998-12-20T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/1999/01.json
+++ b/data/items/1999/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1995/tv_042.html",
     "begin": "1999-01-04T09:00:00.000Z",
     "end": "1999-12-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2222",
-        "begin": "1999-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-01-03T16:00:00.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "http://www.sunrise-inc.co.jp/seikai/",
     "begin": "1999-01-12T04:30:00.000Z",
     "end": "1999-03-27T05:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6x7qaNA2puRHxS0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,27 +59,16 @@
     "officialSite": "",
     "begin": "1999-01-06T16:00:00.000Z",
     "end": "1999-03-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xQz4dt5EtPJV0zs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/7e385twecsrp5d3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "2223",
-        "begin": "1999-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-01-05T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1999/02.json
+++ b/data/items/1999/02.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.nagoyatv.com/anime-history/data/data25/data25.html",
     "begin": "1999-02-06T22:00:00.000Z",
     "end": "2000-01-29T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2221",
-        "begin": "1999-02-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-02-06T16:00:00.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/doremi/index.html",
     "begin": "1999-02-06T23:30:00.000Z",
     "end": "2000-01-30T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1djl",
-        "begin": "2015-08-14T17:06:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:06:04.000Z"
       },
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "nicovideo",
         "id": "doremi",
-        "begin": "2016-06-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-15T06:00:00.000Z"
       }
     ]
   },
@@ -81,7 +64,6 @@
     "officialSite": "",
     "begin": "1999-02-05T12:00:00.000Z",
     "end": "1999-06-25T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -90,12 +72,7 @@
       {
         "site": "bilibili",
         "id": "5478",
-        "begin": "1999-02-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-02-04T16:00:01.000Z"
       }
     ]
   },
@@ -111,7 +88,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/beastwars/",
     "begin": "1999-02-03T09:30:00.000Z",
     "end": "1999-09-29T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -131,27 +107,16 @@
     "officialSite": "http://www.kenshin-tv.com/",
     "begin": "1999-02-20T16:00:00.000Z",
     "end": "1999-09-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UvXQTrYcjMotqxM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "c/cz3xrrh4apzn2o1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -160,12 +125,7 @@
       {
         "site": "nicovideo",
         "id": "rurouni-kenshin-tuioku",
-        "begin": "2014-09-13T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-13T06:00:00.000Z"
       }
     ]
   },
@@ -181,17 +141,11 @@
     "officialSite": "",
     "begin": "1999-02-13T16:00:00.000Z",
     "end": "2000-01-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TYB8ibmLIOHbZV78",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -200,22 +154,7 @@
       {
         "site": "letv",
         "id": "19710",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2236",
-        "begin": "1999-02-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1999/03.json
+++ b/data/items/1999/03.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/dejimon/",
     "begin": "1999-03-07T10:00:00.000Z",
     "end": "2000-03-26T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1dmp",
-        "begin": "2016-05-06T02:36:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-05-06T02:36:47.000Z"
       },
       {
         "site": "bangumi",
@@ -31,12 +25,7 @@
       {
         "site": "nicovideo",
         "id": "digimon-adventure",
-        "begin": "2015-05-04T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-04T08:00:00.000Z"
       }
     ]
   },
@@ -52,17 +41,11 @@
     "officialSite": "",
     "begin": "1999-03-06T16:00:00.000Z",
     "end": "1999-03-06T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80954",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,32 +54,17 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mvtl",
-        "begin": "2018-05-31T16:13:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:13:18.000Z"
       },
       {
         "site": "bilibili",
         "id": "3903",
-        "begin": "1999-03-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-03-05T16:00:01.000Z"
       }
     ]
   },
@@ -112,51 +80,25 @@
     "officialSite": "",
     "begin": "1999-03-01T16:00:00.000Z",
     "end": "1999-03-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oo149l7ENHLVU7s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "p/pkazflvu90q9dsq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10002683",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1953"
-      },
-      {
-        "site": "bilibili",
-        "id": "2194",
-        "begin": "1999-02-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -172,7 +114,6 @@
     "officialSite": "",
     "begin": "1999-03-06T16:00:00.000Z",
     "end": "1999-03-06T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -192,7 +133,6 @@
     "officialSite": "",
     "begin": "1999-03-29T16:00:00.000Z",
     "end": "1999-04-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -201,12 +141,7 @@
       {
         "site": "pptv",
         "id": "JxvmZMwyouBDwSk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -222,7 +157,6 @@
     "officialSite": "",
     "begin": "1999-03-06T16:00:00.000Z",
     "end": "1999-03-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -231,12 +165,7 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -252,7 +181,6 @@
     "officialSite": "",
     "begin": "1999-03-06T16:00:00.000Z",
     "end": "1999-03-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -261,12 +189,7 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/1999/04.json
+++ b/data/items/1999/04.json
@@ -12,27 +12,16 @@
     "officialSite": "http://www.turn-a-gundam.net/",
     "begin": "1999-04-09T07:55:00.000Z",
     "end": "2000-04-14T08:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SvnEQqoQgL4hnwc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "q/q22xttucp95iwpb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -52,7 +41,6 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_1995/tv_044.html",
     "begin": "1999-04-07T09:00:00.000Z",
     "end": "1999-09-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -72,17 +60,11 @@
     "officialSite": "http://www.kids-station.com/program/detail/150542.html",
     "begin": "1999-04-05T15:30:00.000Z",
     "end": "1999-06-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HiasWlPxia0hBz8Vk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -91,12 +73,7 @@
       {
         "site": "bilibili",
         "id": "1946",
-        "begin": "1999-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -112,27 +89,16 @@
     "officialSite": "http://www.sunrise-inc.co.jp/seihou/",
     "begin": "1999-04-07T01:00:00.000Z",
     "end": "1999-06-30T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icE86uCCG9jSXFX0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5mjbhi1kqh1ytk1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -152,7 +118,6 @@
     "officialSite": "",
     "begin": "1999-04-04T23:00:00.000Z",
     "end": "1999-09-26T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -161,12 +126,7 @@
       {
         "site": "bilibili",
         "id": "2225",
-        "begin": "1999-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -182,27 +142,16 @@
     "officialSite": "http://aquaplus.jp/th/th_anime.html",
     "begin": "1999-04-01T23:00:00.000Z",
     "end": "1999-06-24T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VOzXVb0jk9E0sho",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "g/gjdk4z87xsfrkar",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -211,12 +160,7 @@
       {
         "site": "letv",
         "id": "80638",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -232,17 +176,11 @@
     "officialSite": "http://web.archive.org/web/20071011202701/www.anime-int.com/works/dual/tv/",
     "begin": "1999-04-08T15:00:00.000Z",
     "end": "1999-07-01T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "U5xo5k60JGLFQ6s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -251,12 +189,7 @@
       {
         "site": "bilibili",
         "id": "2217",
-        "begin": "1999-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -272,21 +205,10 @@
     "officialSite": "http://www.at-x.com/program_detail/index.html/2355/",
     "begin": "1999-04-20T01:00:00.000Z",
     "end": "2000-03-25T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "45329"
-      },
-      {
-        "site": "bilibili",
-        "id": "2215",
-        "begin": "1999-04-19T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -302,7 +224,6 @@
     "officialSite": "http://www3.nhk.or.jp/anime/yui/index.html",
     "begin": "1999-04-09T22:40:00.000Z",
     "end": "1999-10-01T23:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -322,17 +243,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/gokudo/index.html",
     "begin": "1999-04-02T22:15:00.000Z",
     "end": "1999-09-24T22:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "A0w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -341,12 +256,7 @@
       {
         "site": "bilibili",
         "id": "5502",
-        "begin": "1999-04-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-04-01T16:00:01.000Z"
       }
     ]
   },
@@ -358,7 +268,6 @@
     "officialSite": "http://www.ponycanyon.co.jp/pc-moe/d4princess/index.html",
     "begin": "1999-04-06T16:00:00.000Z",
     "end": "1999-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -378,27 +287,16 @@
     "officialSite": "",
     "begin": "1999-04-23T16:00:00.000Z",
     "end": "1999-04-23T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "f/feuy7gwbvk0a5p1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "49139",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -407,12 +305,7 @@
       {
         "site": "letv",
         "id": "10004313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -428,7 +321,6 @@
     "officialSite": "",
     "begin": "1999-04-06T16:00:00.000Z",
     "end": "1999-04-06T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -437,12 +329,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tgp",
-        "begin": "2015-08-06T12:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-06T12:03:19.000Z"
       }
     ]
   },
@@ -458,26 +345,15 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "1999-04-17T16:00:00.000Z",
     "end": "1999-04-17T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": "",
         "url": "http://www.iqiyi.com/dongman/20130715/923b3cfbf8291077.html"
       },
       {
@@ -487,12 +363,7 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -508,17 +379,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "1999-04-17T16:00:00.000Z",
     "end": "1999-04-17T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -527,22 +392,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -558,7 +413,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "1999-04-05T08:35:00.000Z",
     "end": "1999-07-30T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -578,17 +432,11 @@
     "officialSite": "",
     "begin": "1999-04-01T16:00:00.000Z",
     "end": "1999-10-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wW1Y1j6kFFK1M5s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -597,12 +445,7 @@
       {
         "site": "bilibili",
         "id": "2216",
-        "begin": "1999-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-03-31T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1999/05.json
+++ b/data/items/1999/05.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1999-05-03T16:00:00.000Z",
     "end": "1999-10-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "J2hU0jqgEE6xL5c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1999/06.json
+++ b/data/items/1999/06.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.mxtv.co.jp/gto/",
     "begin": "1999-06-30T16:00:00.000Z",
     "end": "2000-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xQYCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjvfqop",
-        "begin": "2013-05-10T04:10:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-05-10T04:10:16.000Z"
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2238",
-        "begin": "1999-06-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-06-29T16:00:00.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "",
     "begin": "1999-06-25T16:00:00.000Z",
     "end": "1999-09-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nZaCAGjOPnzfXcU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1999/07.json
+++ b/data/items/1999/07.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1999-07-02T09:00:00.000Z",
     "end": "2000-06-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "anime-medarot",
-        "begin": "2019-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-07-01T15:00:00.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/kacho-ohji/home.html",
     "begin": "1999-07-08T23:00:00.000Z",
     "end": "2000-10-07T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7yIenARq2hh7ibWE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,7 +59,6 @@
     "officialSite": "http://animejapan.cplaza.ne.jp/b-ch/mahotai/index.html",
     "begin": "1999-07-07T00:30:00.000Z",
     "end": "1999-10-06T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,7 +78,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "1999-07-30T16:30:00.000Z",
     "end": "1999-07-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,32 +86,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3947",
-        "begin": "1999-07-29T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-07-29T16:00:01.000Z"
       }
     ]
   },
@@ -141,37 +112,21 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "1999-07-17T16:00:00.000Z",
     "end": "1999-07-17T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "71806",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -180,22 +135,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5757",
-        "begin": "1999-07-16T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-07-16T16:00:01.000Z"
       }
     ]
   },
@@ -211,17 +156,11 @@
     "officialSite": "",
     "begin": "1999-07-03T16:00:00.000Z",
     "end": "1999-12-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/opv3q70xfz08gnd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -230,12 +169,7 @@
       {
         "site": "bilibili",
         "id": "2210",
-        "begin": "1999-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-07-02T16:00:00.000Z"
       }
     ]
   },
@@ -253,7 +187,6 @@
     "officialSite": "",
     "begin": "1999-07-27T16:00:00.000Z",
     "end": "1999-07-27T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -273,17 +206,11 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "1999-07-17T17:10:00.000Z",
     "end": "1999-07-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -304,17 +231,11 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/nanako/",
     "begin": "1999-07-05T16:00:00.000Z",
     "end": "2000-03-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SvzHRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1999/08.json
+++ b/data/items/1999/08.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "1999-08-21T16:00:00.000Z",
     "end": "1999-08-21T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "31390",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,32 +24,17 @@
       {
         "site": "mgtv",
         "id": "322699",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "a/a7i7zzprly7pmmj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhg0s71",
-        "begin": "2018-03-19T15:08:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-19T15:08:14.000Z"
       }
     ]
   },
@@ -71,7 +50,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/kin-m2/",
     "begin": "1999-08-21T16:00:00.000Z",
     "end": "1999-08-21T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/1999/09.json
+++ b/data/items/1999/09.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/program/zoids/1st/index.html",
     "begin": "1999-09-04T16:00:00.000Z",
     "end": "2000-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,12 +22,7 @@
       {
         "site": "nicovideo",
         "id": "zoids",
-        "begin": "2013-01-11T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-11T13:30:00.000Z"
       }
     ]
   },
@@ -44,17 +38,11 @@
     "officialSite": "",
     "begin": "1999-09-18T16:00:00.000Z",
     "end": "2000-11-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6j4Jhib9VxQNm5Ew",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/1999/10.json
+++ b/data/items/1999/10.json
@@ -15,45 +15,20 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/onep/",
     "begin": "1999-10-20T01:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2013/onepiece/",
-        "begin": "1999-10-24T01:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-24T01:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb3xvl",
-        "begin": "2017-07-26T08:17:56.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "海贼王",
-        "begin": "1999-10-24T01:30:00.000Z",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2017-07-26T08:17:56.000Z"
       },
       {
         "site": "bangumi",
         "id": "975"
-      },
-      {
-        "site": "saraba1st",
-        "id": "98922"
       }
     ]
   },
@@ -70,27 +45,16 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/hunter_hunter.html",
     "begin": "1999-10-16T16:00:00.000Z",
     "end": "2001-03-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WIlz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "52528",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -99,22 +63,12 @@
       {
         "site": "nicovideo",
         "id": "hunterhunter",
-        "begin": "2014-06-05T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-06-05T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "877",
-        "begin": "1999-10-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-15T16:00:00.000Z"
       }
     ]
   },
@@ -130,7 +84,6 @@
     "officialSite": "http://www.sunrise-inc.co.jp/ryvius/",
     "begin": "1999-10-06T09:00:00.000Z",
     "end": "2000-03-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -139,12 +92,7 @@
       {
         "site": "bilibili",
         "id": "2208",
-        "begin": "1999-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -163,17 +111,11 @@
     "officialSite": "http://kc.kodansha.co.jp/content/top.php/02888/1000000111",
     "begin": "1999-10-15T15:00:00.000Z",
     "end": "2000-01-21T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hKuWFHziaUpDzcdk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -182,12 +124,7 @@
       {
         "site": "bilibili",
         "id": "208",
-        "begin": "1999-10-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-14T16:00:00.000Z"
       }
     ]
   },
@@ -203,17 +140,11 @@
     "officialSite": "http://www.the-big-o.net/",
     "begin": "1999-10-13T14:00:00.000Z",
     "end": "2000-01-19T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OAjzcdkicrib1QzjY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -222,12 +153,7 @@
       {
         "site": "bilibili",
         "id": "2224",
-        "begin": "1999-10-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-12T16:00:00.000Z"
       }
     ]
   },
@@ -243,7 +169,6 @@
     "officialSite": "http://home-aki.cool.ne.jp/anime-list/kurochan.htm",
     "begin": "1999-10-02T21:30:00.000Z",
     "end": "2000-12-30T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -252,12 +177,7 @@
       {
         "site": "bilibili",
         "id": "2204",
-        "begin": "1999-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -273,7 +193,6 @@
     "officialSite": "http://www.at-x.com/program/detail/1432",
     "begin": "1999-10-05T22:00:00.000Z",
     "end": "2000-04-04T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -282,12 +201,7 @@
       {
         "site": "bilibili",
         "id": "2135",
-        "begin": "1999-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -303,7 +217,6 @@
     "officialSite": "http://www.anime-int.com/works/now/tv/",
     "begin": "1999-10-14T08:30:00.000Z",
     "end": "2000-01-20T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -312,12 +225,7 @@
       {
         "site": "bilibili",
         "id": "2206",
-        "begin": "1999-10-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-13T16:00:00.000Z"
       }
     ]
   },
@@ -333,27 +241,16 @@
     "officialSite": "http://www.anime-int.com/works/bluegender/tv/",
     "begin": "1999-10-07T16:00:00.000Z",
     "end": "2000-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lNiakIorwYJ4Bfibc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "y/yvxrfuhvj72dhe7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -362,12 +259,7 @@
       {
         "site": "bilibili",
         "id": "2202",
-        "begin": "1999-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -383,7 +275,6 @@
     "officialSite": "http://www.ponycanyon.co.jp/pc-moe/risky/index.html",
     "begin": "1999-10-15T16:00:00.000Z",
     "end": "2000-04-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -403,17 +294,11 @@
     "officialSite": "",
     "begin": "1999-10-02T16:00:00.000Z",
     "end": "2000-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eLONC3PZSYfqaNA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -422,12 +307,7 @@
       {
         "site": "bilibili",
         "id": "2269",
-        "begin": "1999-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -443,17 +323,11 @@
     "officialSite": "",
     "begin": "1999-10-08T16:00:00.000Z",
     "end": "2000-03-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UeHcWsIomNY5tx8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -462,12 +336,7 @@
       {
         "site": "bilibili",
         "id": "2199",
-        "begin": "1999-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -483,31 +352,15 @@
     "officialSite": "",
     "begin": "1999-10-07T16:00:00.000Z",
     "end": "2000-03-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DhicqaNA2puRHxS0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "10422"
-      },
-      {
-        "site": "bilibili",
-        "id": "2205",
-        "begin": "1999-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -519,7 +372,6 @@
     "officialSite": "",
     "begin": "1999-10-19T16:00:00.000Z",
     "end": "2000-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -528,12 +380,7 @@
       {
         "site": "nicovideo",
         "id": "rerere-tensaibakabon",
-        "begin": "2018-07-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-06T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/1999/11.json
+++ b/data/items/1999/11.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.broccoli.co.jp/dejiko/",
     "begin": "1999-11-29T16:00:00.000Z",
     "end": "1999-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "2085",
-        "begin": "1999-11-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-11-30T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/1999/12.json
+++ b/data/items/1999/12.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "1999-12-18T16:00:00.000Z",
     "end": "2000-12-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "pptv",
         "id": "zwLibfORKuvhb2UE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3404",
-        "begin": "1999-12-17T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1999-12-17T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2000/01.json
+++ b/data/items/2000/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.supermilk-chan.com/",
     "begin": "2000-01-27T16:00:00.000Z",
     "end": "2000-04-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "oh-supermilk-chan",
-        "begin": "2011-06-17T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-06-17T12:00:00.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://www.b-ch.com/cgi-bin/contents/ttl/det.cgi?ttl_c=416",
     "begin": "2000-01-26T16:00:00.000Z",
     "end": "2000-04-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "2151",
-        "begin": "2000-01-25T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-01-25T16:00:00.000Z"
       }
     ]
   },
@@ -71,17 +59,11 @@
     "officialSite": "",
     "begin": "2000-01-10T16:00:00.000Z",
     "end": "2000-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "m/m0gjz15r0yh4530",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -90,12 +72,7 @@
       {
         "site": "bilibili",
         "id": "2167",
-        "begin": "2000-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -111,17 +88,11 @@
     "officialSite": "",
     "begin": "2000-01-05T16:00:00.000Z",
     "end": "2000-03-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BCkUkvpg0A5x71c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -130,22 +101,12 @@
       {
         "site": "bilibili",
         "id": "2150",
-        "begin": "2000-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-01-04T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "boogiepop-phantom",
-        "begin": "2018-09-21T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-09-21T09:00:00.000Z"
       }
     ]
   }

--- a/data/items/2000/02.json
+++ b/data/items/2000/02.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.nagoyatv.com/anime-history/data/data26/data26.html",
     "begin": "2000-02-05T22:00:00.000Z",
     "end": "2001-09-30T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -32,17 +31,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/doremi_s/index.html",
     "begin": "2000-02-05T23:30:00.000Z",
     "end": "2001-01-28T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1dd5",
-        "begin": "2015-08-14T17:06:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:06:02.000Z"
       },
       {
         "site": "bangumi",
@@ -62,27 +55,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/mashura/",
     "begin": "2000-02-05T16:00:00.000Z",
     "end": "2000-09-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1drx",
-        "begin": "2015-08-14T17:07:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464502",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:07:34.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/2000/03.json
+++ b/data/items/2000/03.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "2000-03-04T16:00:00.000Z",
     "end": "2000-03-04T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "2000-03-04T16:00:00.000Z",
     "end": "2000-03-04T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,12 +38,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tgp",
-        "begin": "2015-08-06T12:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-06T12:03:19.000Z"
       }
     ]
   },
@@ -61,17 +54,11 @@
     "officialSite": "",
     "begin": "2000-03-11T16:00:00.000Z",
     "end": "2000-03-11T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80955",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,22 +67,12 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2566",
-        "begin": "2000-03-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-03-10T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2000/04.json
+++ b/data/items/2000/04.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/Works/03/3_3.html#4",
     "begin": "2000-04-05T09:00:00.000Z",
     "end": "2000-09-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,27 +33,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yugioh2000/",
     "begin": "2000-04-18T10:28:00.000Z",
     "end": "2004-09-29T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3nBLyTGXB0WoJo4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "46857",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -63,42 +51,22 @@
       {
         "site": "nicovideo",
         "id": "yugioh2000",
-        "begin": "2014-08-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-20T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70177034",
-        "begin": "2017-02-08T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-08T08:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7h4st",
-        "begin": "2018-08-09T16:00:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-09T16:00:14.000Z"
       },
       {
         "site": "bilibili",
         "id": "3054",
-        "begin": "2000-04-17T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-04-17T16:00:00.000Z"
       }
     ]
   },
@@ -114,17 +82,11 @@
     "officialSite": "http://www.sakura-taisen.com/",
     "begin": "2000-04-08T09:00:00.000Z",
     "end": "2000-09-23T15:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icUMibvCSKibjiabGYE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -145,17 +107,11 @@
     "officialSite": "",
     "begin": "2000-04-03T14:30:00.000Z",
     "end": "2000-09-18T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "l9mjIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -175,7 +131,6 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/boys/noplugin.html",
     "begin": "2000-04-11T15:30:00.000Z",
     "end": "2000-07-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -195,17 +150,11 @@
     "officialSite": "http://www.sunrise-inc.co.jp/seikai/",
     "begin": "2000-04-14T04:30:00.000Z",
     "end": "2000-07-14T05:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6hicpZ881peNGxCw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -225,7 +174,6 @@
     "officialSite": "http://www.sunrise-inc.co.jp/seikai/",
     "begin": "2000-04-07T04:30:00.000Z",
     "end": "2000-04-07T05:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -245,7 +193,6 @@
     "officialSite": "http://www3.nhk.or.jp/anime/daa/",
     "begin": "2000-04-04T20:00:00.000Z",
     "end": "2001-09-25T20:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -254,12 +201,7 @@
       {
         "site": "bilibili",
         "id": "5407",
-        "begin": "2000-04-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-04-03T16:00:01.000Z"
       }
     ]
   },
@@ -275,7 +217,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/lovehina/",
     "begin": "2000-04-19T00:00:00.000Z",
     "end": "2001-04-02T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -295,17 +236,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/niea/",
     "begin": "2000-04-26T02:00:00.000Z",
     "end": "2000-07-19T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IRnkYsowoN5Bvyc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -314,12 +249,7 @@
       {
         "site": "bilibili",
         "id": "2153",
-        "begin": "2000-04-25T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-04-25T16:00:00.000Z"
       }
     ]
   },
@@ -338,7 +268,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/carobot/",
     "begin": "2000-04-05T09:30:00.000Z",
     "end": "2000-12-27T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -358,17 +287,11 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_2000/tv_051.html",
     "begin": "2000-04-20T16:00:00.000Z",
     "end": "2000-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qYJ9ib2PJOXfaWMA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -377,12 +300,7 @@
       {
         "site": "bilibili",
         "id": "2152",
-        "begin": "2000-04-19T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-04-19T16:00:00.000Z"
       }
     ]
   },
@@ -399,17 +317,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/digimon02/",
     "begin": "2000-04-02T16:00:00.000Z",
     "end": "2001-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1dp5",
-        "begin": "2015-08-14T17:06:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:06:52.000Z"
       },
       {
         "site": "bangumi",
@@ -418,12 +330,7 @@
       {
         "site": "nicovideo",
         "id": "digimon-adventure02",
-        "begin": "2015-09-16T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-16T06:00:00.000Z"
       }
     ]
   },
@@ -439,27 +346,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2000-04-22T16:00:00.000Z",
     "end": "2000-04-22T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/v_19rrifx03a.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/v_19rrifx03a.html"
       },
       {
         "site": "bangumi",
@@ -468,22 +364,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3879",
-        "begin": "2000-04-21T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10492",
+        "begin": "2000-04-21T16:00:01.000Z"
       }
     ]
   },
@@ -499,17 +385,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2000-04-22T16:00:00.000Z",
     "end": "2000-04-22T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -518,22 +398,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -549,7 +419,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2000-04-03T08:35:00.000Z",
     "end": "2000-07-24T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -570,27 +439,16 @@
     "officialSite": "http://www.gainax.co.jp/anime/flcl",
     "begin": "2000-04-26T16:00:00.000Z",
     "end": "2001-03-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TicPOTLQaiasgrqRE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2988",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -599,22 +457,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh7p811",
-        "begin": "2017-11-30T10:13:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-30T10:13:44.000Z"
       },
       {
         "site": "nicovideo",
         "id": "flcl-anime",
-        "begin": "2018-07-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-11T15:00:00.000Z"
       }
     ]
   },
@@ -630,17 +478,11 @@
     "officialSite": "",
     "begin": "2000-04-04T16:00:00.000Z",
     "end": "2001-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mbSPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -649,32 +491,17 @@
       {
         "site": "nicovideo",
         "id": "saiyuki",
-        "begin": "2017-01-10T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2144",
-        "begin": "2000-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-04-03T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "38600",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2000/05.json
+++ b/data/items/2000/05.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "2000-05-25T16:00:00.000Z",
     "end": "2000-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "19231",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "pptv",
         "id": "hsia0MpoAcK4Rjicc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2000/06.json
+++ b/data/items/2000/06.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "2000-06-23T16:00:00.000Z",
     "end": "2001-11-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "pptv",
         "id": "ImxY1j6kFFK1M5s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2000/07.json
+++ b/data/items/2000/07.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.hamutaro.com/",
     "begin": "2000-07-07T09:30:00.000Z",
     "end": "2006-03-31T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "z/z815w0i978vt1bh",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "http://www.trans-arts.co.jp/data/works/medarot/medarot.htm",
     "begin": "2000-07-07T09:00:00.000Z",
     "end": "2001-03-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "nicovideo",
         "id": "anime-medarot2",
-        "begin": "2019-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-07-01T15:00:00.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "2000-07-21T08:30:00.000Z",
     "end": "2001-01-12T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,7 +78,6 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/hand-maid/index.htm",
     "begin": "2000-07-26T12:30:00.000Z",
     "end": "2000-09-27T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,12 +86,7 @@
       {
         "site": "bilibili",
         "id": "2142",
-        "begin": "2000-07-25T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-07-25T16:00:00.000Z"
       }
     ]
   },
@@ -121,7 +102,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2000-07-28T16:00:00.000Z",
     "end": "2000-07-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,32 +110,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3948",
-        "begin": "2000-07-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-07-27T16:00:01.000Z"
       }
     ]
   },
@@ -171,21 +136,10 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/st-dawn/",
     "begin": "2000-07-11T16:00:00.000Z",
     "end": "2000-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "65554"
-      },
-      {
-        "site": "bilibili",
-        "id": "2154",
-        "begin": "2000-07-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -201,17 +155,11 @@
     "officialSite": "",
     "begin": "2000-07-15T16:00:00.000Z",
     "end": "2000-07-15T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "71775",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -220,12 +168,7 @@
       {
         "site": "bilibili",
         "id": "3860",
-        "begin": "2000-07-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-07-14T16:00:01.000Z"
       }
     ]
   },
@@ -241,7 +184,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2000-07-28T16:00:00.000Z",
     "end": "2000-07-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -250,12 +192,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tgp",
-        "begin": "2015-08-06T12:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-06T12:03:19.000Z"
       }
     ]
   },
@@ -271,17 +208,11 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2000-07-08T16:00:00.000Z",
     "end": "2000-07-08T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -290,12 +221,7 @@
       {
         "site": "bilibili",
         "id": "5350",
-        "begin": "2000-07-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-07-07T16:00:01.000Z"
       }
     ]
   },
@@ -311,7 +237,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2000-07-08T17:10:00.000Z",
     "end": "2000-07-08T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2000/10.json
+++ b/data/items/2000/10.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.dendoh.net/index.html",
     "begin": "2000-10-04T09:00:00.000Z",
     "end": "2001-06-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wKWPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2143",
-        "begin": "2000-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://www.tms-e.com/library/on_air_back/devil/",
     "begin": "2000-10-06T22:30:00.000Z",
     "end": "2001-09-28T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "bilibili",
         "id": "2081",
-        "begin": "2000-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -81,7 +64,6 @@
     "officialSite": "http://www.telecom-anime.com/cybersix/japanese/index.html",
     "begin": "2000-10-16T16:00:00.000Z",
     "end": "2001-01-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -101,7 +83,6 @@
     "officialSite": "http://www.vap.co.jp/ippo/",
     "begin": "2000-10-03T10:30:00.000Z",
     "end": "2002-03-12T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,22 +91,12 @@
       {
         "site": "nicovideo",
         "id": "ippo_anime",
-        "begin": "2014-04-22T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-22T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "500",
-        "begin": "2000-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -144,7 +115,6 @@
     "officialSite": "http://www.gonzo.co.jp/works/0001.html",
     "begin": "2000-10-03T00:30:00.000Z",
     "end": "2000-12-26T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -153,12 +123,7 @@
       {
         "site": "bilibili",
         "id": "2161",
-        "begin": "2000-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -177,27 +142,16 @@
     "officialSite": "http://www.ytv.co.jp/inuyasha/index_set.html",
     "begin": "2000-10-16T10:30:00.000Z",
     "end": "2004-09-13T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "4/4qw8q7lcsf7yh8z",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "46169",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -206,12 +160,7 @@
       {
         "site": "netflix",
         "id": "70204995",
-        "begin": "2016-12-15T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-15T08:00:00.000Z"
       }
     ]
   },
@@ -227,41 +176,20 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/gravi/",
     "begin": "2000-10-04T08:00:00.000Z",
     "end": "2001-01-10T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "v4p181vBMWicSULg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "i/ipyt80um6hrpcpu",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2912"
-      },
-      {
-        "site": "bilibili",
-        "id": "2159",
-        "begin": "2000-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -277,21 +205,10 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/Kikaider/",
     "begin": "2000-10-16T13:30:00.000Z",
     "end": "2001-01-08T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "18457"
-      },
-      {
-        "site": "bilibili",
-        "id": "2158",
-        "begin": "2000-10-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -307,7 +224,6 @@
     "officialSite": "http://www.mediafactory.co.jp/c000051/archives/015/006/15615.html",
     "begin": "2000-10-05T10:00:00.000Z",
     "end": "2001-03-23T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -327,7 +243,6 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/kaidan/",
     "begin": "2000-10-22T08:00:00.000Z",
     "end": "2001-03-25T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -336,22 +251,12 @@
       {
         "site": "nicovideo",
         "id": "gakkou-no-kaidan",
-        "begin": "2018-07-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-06T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2171",
-        "begin": "2000-10-21T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-10-21T16:00:00.000Z"
       }
     ]
   },
@@ -367,7 +272,6 @@
     "officialSite": "http://www.bones.co.jp/works/tv01/index.html",
     "begin": "2000-10-24T11:00:00.000Z",
     "end": "2001-05-01T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -387,27 +291,16 @@
     "officialSite": "http://www.jvcmusic.co.jp/m-serve/tv/soma/index.html",
     "begin": "2000-10-05T02:00:00.000Z",
     "end": "2001-03-29T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZdKtK5P5aacKiaPA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z7tsublda0lj93i",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -416,12 +309,7 @@
       {
         "site": "bilibili",
         "id": "2168",
-        "begin": "2000-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -437,17 +325,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/tetsuya/",
     "begin": "2000-10-07T16:00:00.000Z",
     "end": "2001-03-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1e5t",
-        "begin": "2015-11-04T03:09:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-04T03:09:34.000Z"
       },
       {
         "site": "bangumi",
@@ -467,41 +349,20 @@
     "officialSite": "http://www.jcstaff.co.jp/sho-sai/ya-shokai/yami-syokai.htm",
     "begin": "2000-10-02T16:00:00.000Z",
     "end": "2000-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icEI9uyOJibTeaGIA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "21509",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2908"
-      },
-      {
-        "site": "bilibili",
-        "id": "5343",
-        "begin": "2000-10-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -517,17 +378,11 @@
     "officialSite": "",
     "begin": "2000-10-21T16:00:00.000Z",
     "end": "2000-10-21T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/oku52t51m1rgmh1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -536,12 +391,7 @@
       {
         "site": "bilibili",
         "id": "3760",
-        "begin": "2000-10-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-10-20T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2000/11.json
+++ b/data/items/2000/11.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "2000-11-18T16:00:00.000Z",
     "end": "2000-11-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "nicovideo",
         "id": "blood-vampire",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2170",
-        "begin": "2000-11-17T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2000-11-17T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2000/12.json
+++ b/data/items/2000/12.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "2000-12-21T16:00:00.000Z",
     "end": "2001-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AjgDgelPvic1g3kY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2001/01.json
+++ b/data/items/2001/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.d-rights.com/beyblade/2002/2001/",
     "begin": "2001-01-08T09:00:00.000Z",
     "end": "2001-12-24T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "22ZS0DiaeDkyvLZU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "5336",
-        "begin": "2001-01-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-01-07T16:00:01.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/program/zoids/zero/index.html",
     "begin": "2001-01-06T13:00:00.000Z",
     "end": "2001-06-30T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "letv",
         "id": "81931",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -81,17 +64,11 @@
     "officialSite": "http://www.starchild.co.jp/special/tales/",
     "begin": "2001-01-08T09:30:00.000Z",
     "end": "2001-03-26T09:56:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CTkEgupQwP5h30c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "3312",
-        "begin": "2001-01-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-01-07T16:00:01.000Z"
       }
     ]
   },
@@ -121,27 +93,16 @@
     "officialSite": "",
     "begin": "2001-01-13T16:00:00.000Z",
     "end": "2001-01-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "f9SvLZX7a6kMiavI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/uk42ddvuyqxiq9q",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,12 +111,7 @@
       {
         "site": "bilibili",
         "id": "209",
-        "begin": "2001-01-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-01-12T16:00:00.000Z"
       }
     ]
   },
@@ -172,31 +128,15 @@
     "officialSite": "http://baki.ne.jp/",
     "begin": "2001-01-08T16:00:00.000Z",
     "end": "2001-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgckd45",
-        "begin": "2013-08-06T06:37:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-06T06:37:33.000Z"
       },
       {
         "site": "bangumi",
         "id": "62893"
-      },
-      {
-        "site": "bilibili",
-        "id": "5337",
-        "begin": "2001-01-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -212,31 +152,15 @@
     "officialSite": "http://www.bandaivisual.co.jp/arjuna/",
     "begin": "2001-01-09T16:00:00.000Z",
     "end": "2001-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ia7eSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "19418"
-      },
-      {
-        "site": "bilibili",
-        "id": "2862",
-        "begin": "2001-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2001/02.json
+++ b/data/items/2001/02.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/doremi_m/",
     "begin": "2001-02-03T23:30:00.000Z",
     "end": "2002-01-27T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb13od",
-        "begin": "2015-08-14T17:07:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:07:39.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/2001/03.json
+++ b/data/items/2001/03.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/gals/",
     "begin": "2001-03-31T23:30:00.000Z",
     "end": "2002-03-31T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HlErqRF35yWIBm4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "2001-03-03T16:00:00.000Z",
     "end": "2001-03-03T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "",
     "begin": "2001-03-03T16:00:00.000Z",
     "end": "2001-03-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +62,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tgp",
-        "begin": "2015-08-06T12:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-06T12:03:19.000Z"
       }
     ]
   },
@@ -91,17 +78,11 @@
     "officialSite": "",
     "begin": "2001-03-10T16:00:00.000Z",
     "end": "2001-03-10T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80960",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,42 +91,22 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mou1",
-        "begin": "2018-05-31T16:12:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:12:58.000Z"
       },
       {
         "site": "bilibili",
         "id": "3865",
-        "begin": "2001-03-09T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-03-09T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2001/04.json
+++ b/data/items/2001/04.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.toho-a-park.com/character/comet/index.html",
     "begin": "2001-04-01T00:30:00.000Z",
     "end": "2002-01-27T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "P18ppw915SOGBGw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -31,12 +25,7 @@
       {
         "site": "bilibili",
         "id": "2821",
-        "begin": "2001-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -52,17 +41,11 @@
     "officialSite": "http://mv.avex.jp/angelic/",
     "begin": "2001-04-01T08:20:00.000Z",
     "end": "2001-09-30T08:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "23JNyzOZCUeqKJA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,22 +54,12 @@
       {
         "site": "nicovideo",
         "id": "angelic",
-        "begin": "2012-06-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-06T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2125",
-        "begin": "2001-03-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -102,7 +75,6 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-tokyo.co.jp/webdiver/",
     "begin": "2001-04-06T09:00:00.000Z",
     "end": "2002-03-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -118,7 +90,6 @@
     "officialSite": "http://www.g-tac.co.jp/batonext/batoindex.html",
     "begin": "2001-04-06T23:00:00.000Z",
     "end": "2002-03-29T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -138,17 +109,11 @@
     "officialSite": "http://www.fujitv.co.jp/jp/b_hp/digimont/",
     "begin": "2001-04-01T00:00:00.000Z",
     "end": "2002-03-31T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1df9",
-        "begin": "2015-08-20T03:32:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-20T03:32:13.000Z"
       },
       {
         "site": "bangumi",
@@ -157,12 +122,7 @@
       {
         "site": "nicovideo",
         "id": "digimon_t",
-        "begin": "2016-12-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-01T06:00:00.000Z"
       }
     ]
   },
@@ -178,21 +138,10 @@
     "officialSite": "http://www.starchild.co.jp/special/sispri/index.html",
     "begin": "2001-04-04T14:00:00.000Z",
     "end": "2001-09-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "3690"
-      },
-      {
-        "site": "bilibili",
-        "id": "2128",
-        "begin": "2001-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -208,17 +157,11 @@
     "officialSite": "http://www.aquaplus.co.jp/cp/",
     "begin": "2001-04-02T15:00:00.000Z",
     "end": "2001-06-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Zcm0MpoAcK4Rjicc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -227,12 +170,7 @@
       {
         "site": "bilibili",
         "id": "2132",
-        "begin": "2001-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -248,17 +186,11 @@
     "officialSite": "http://www.kids-station.com/minisite/tokushu/soultaker/",
     "begin": "2001-04-04T13:30:00.000Z",
     "end": "2001-07-04T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7yEbmQFn1xV49l4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -267,12 +199,7 @@
       {
         "site": "bilibili",
         "id": "5213",
-        "begin": "2001-04-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-03T16:00:01.000Z"
       }
     ]
   },
@@ -288,17 +215,11 @@
     "officialSite": "",
     "begin": "2001-04-03T06:00:00.000Z",
     "end": "2001-09-05T06:57:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "81olowtx4RibCAGg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -307,42 +228,22 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgj95ml",
-        "begin": "2013-11-13T07:24:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-11-13T07:24:05.000Z"
       },
       {
         "site": "bilibili",
         "id": "2091",
-        "begin": "2001-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-02T16:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "7/7tr0snbbxb7rmre",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "8506",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -358,31 +259,15 @@
     "officialSite": "http://www.vap.co.jp/zoe/tv/",
     "begin": "2001-04-06T13:30:00.000Z",
     "end": "2001-09-28T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CEIibvCSKibjiabGYE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "36882"
-      },
-      {
-        "site": "bilibili",
-        "id": "2107",
-        "begin": "2001-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -398,17 +283,11 @@
     "officialSite": "http://www.tms-e.com/library/on_air_back/arms/index.html",
     "begin": "2001-04-07T13:30:00.000Z",
     "end": "2002-03-30T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "a8ib6OKAGdrQXlf0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -431,17 +310,11 @@
     "officialSite": "http://www.jvcmusic.co.jp/m-serve/tv/noir/",
     "begin": "2001-04-05T07:00:00.000Z",
     "end": "2001-09-27T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "k/kqigw4r6dshzz5n",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -450,22 +323,7 @@
       {
         "site": "nicovideo",
         "id": "noir-anime",
-        "begin": "2014-01-30T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2111",
-        "begin": "2001-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-30T06:00:00.000Z"
       }
     ]
   },
@@ -481,7 +339,6 @@
     "officialSite": "http://www.geneshaft.com/",
     "begin": "2001-04-05T22:30:00.000Z",
     "end": "2001-06-24T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -490,12 +347,7 @@
       {
         "site": "bilibili",
         "id": "5320",
-        "begin": "2001-04-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-04T16:00:01.000Z"
       }
     ]
   },
@@ -511,7 +363,6 @@
     "officialSite": "http://www.at-x.com/program/detail/1911",
     "begin": "2001-04-12T14:15:00.000Z",
     "end": "2001-06-28T14:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -531,7 +382,6 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/pretear/index_set.html",
     "begin": "2001-04-04T16:00:00.000Z",
     "end": "2001-06-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -540,12 +390,7 @@
       {
         "site": "bilibili",
         "id": "2112",
-        "begin": "2001-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -561,17 +406,11 @@
     "officialSite": "http://www.madhouse.co.jp/works/2001-2000/works_tv_galaxyange.html",
     "begin": "2001-04-07T16:00:00.000Z",
     "end": "2001-09-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vvDMSrIYiaMYppw8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -580,12 +419,7 @@
       {
         "site": "bilibili",
         "id": "1942",
-        "begin": "2001-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -601,7 +435,6 @@
     "officialSite": "http://www.at-x.com/program/detail/1433",
     "begin": "2001-04-12T16:00:00.000Z",
     "end": "2001-06-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -610,12 +443,7 @@
       {
         "site": "bilibili",
         "id": "2136",
-        "begin": "2001-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -631,27 +459,16 @@
     "officialSite": "",
     "begin": "2001-04-07T16:00:00.000Z",
     "end": "2001-09-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HiaIdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/727svzatiemfj2x",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -660,12 +477,7 @@
       {
         "site": "bilibili",
         "id": "1341",
-        "begin": "2001-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -682,17 +494,11 @@
     "officialSite": "http://www.nippon-animation.co.jp/work/1486/",
     "begin": "2001-04-01T16:00:00.000Z",
     "end": "2001-04-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjz23id",
-        "begin": "2012-10-17T01:26:27.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-17T01:26:27.000Z"
       },
       {
         "site": "bangumi",
@@ -712,27 +518,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2001-04-21T16:00:00.000Z",
     "end": "2001-04-21T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/v_19rrifx027.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/v_19rrifx027.html"
       },
       {
         "site": "bangumi",
@@ -741,22 +536,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3880",
-        "begin": "2001-04-20T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "11152",
+        "begin": "2001-04-20T16:00:01.000Z"
       }
     ]
   },
@@ -772,17 +557,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2001-04-21T16:00:00.000Z",
     "end": "2001-04-21T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -791,22 +570,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -822,7 +591,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2001-04-02T08:35:00.000Z",
     "end": "2001-07-20T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -842,31 +610,15 @@
     "officialSite": "",
     "begin": "2001-04-03T16:00:00.000Z",
     "end": "2001-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oOvVU7shkc8ysBg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "8378"
-      },
-      {
-        "site": "bilibili",
-        "id": "5322",
-        "begin": "2001-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -882,31 +634,15 @@
     "officialSite": "",
     "begin": "2001-04-05T16:00:00.000Z",
     "end": "2001-07-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "c7yIBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "33064"
-      },
-      {
-        "site": "bilibili",
-        "id": "5321",
-        "begin": "2001-04-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -922,17 +658,11 @@
     "officialSite": "http://www.jcstaff.co.jp/sho-sai/ri-shokai/riui-syokai.htm",
     "begin": "2001-04-03T16:00:00.000Z",
     "end": "2001-09-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ltmjIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -941,12 +671,7 @@
       {
         "site": "bilibili",
         "id": "5323",
-        "begin": "2001-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-04-02T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2001/05.json
+++ b/data/items/2001/05.json
@@ -11,7 +11,6 @@
     "officialSite": "http://web.archive.org/web/*/www.bastoflemon.com/",
     "begin": "2001-05-03T22:30:00.000Z",
     "end": "2001-11-15T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://web.archive.org/web/*/www.tokyo.advfilms.com/anime/chance/",
     "begin": "2001-05-20T17:30:00.000Z",
     "end": "2001-08-26T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,7 +49,6 @@
     "officialSite": "http://web.archive.org/web/*/http://www.figure-17.com/",
     "begin": "2001-05-27T02:00:00.000Z",
     "end": "2001-08-19T03:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,7 +68,6 @@
     "officialSite": "http://www.muryou.gr.jp/",
     "begin": "2001-05-08T10:00:00.000Z",
     "end": "2001-10-30T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,12 +76,7 @@
       {
         "site": "nicovideo",
         "id": "muryou",
-        "begin": "2013-12-27T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-27T03:00:00.000Z"
       }
     ]
   },
@@ -102,17 +93,11 @@
     "officialSite": "http://www.gundam-evolve.net/",
     "begin": "2001-05-17T16:00:00.000Z",
     "end": "2007-01-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Fz4KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -132,7 +117,6 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/ROD/media/ovaindex.html",
     "begin": "2001-05-23T16:00:00.000Z",
     "end": "2002-02-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -141,12 +125,7 @@
       {
         "site": "pptv",
         "id": "icEs2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2001/06.json
+++ b/data/items/2001/06.json
@@ -15,17 +15,11 @@
     "officialSite": "",
     "begin": "2001-06-01T16:00:00.000Z",
     "end": "2001-06-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjz56e9",
-        "begin": "2012-10-17T01:22:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-17T01:22:28.000Z"
       },
       {
         "site": "bangumi",
@@ -45,7 +39,6 @@
     "officialSite": "",
     "begin": "2001-06-15T16:00:00.000Z",
     "end": "2002-02-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -54,22 +47,7 @@
       {
         "site": "pptv",
         "id": "AyoVkicth0Q9y8Fg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3269",
-        "begin": "2001-06-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2001/07.json
+++ b/data/items/2001/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/fruits_basket/",
     "begin": "2001-07-05T09:00:00.000Z",
     "end": "2001-12-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/shaman/",
     "begin": "2001-07-04T09:30:00.000Z",
     "end": "2002-09-25T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,12 +38,7 @@
       {
         "site": "nicovideo",
         "id": "skg",
-        "begin": "2018-11-30T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-30T06:00:00.000Z"
       }
     ]
   },
@@ -61,17 +54,11 @@
     "officialSite": "http://www.jvcmusic.co.jp/m-serve/tv/scryed/top.html",
     "begin": "2001-07-04T09:00:00.000Z",
     "end": "2001-12-26T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Cy8amABm1hR39V0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -91,31 +78,15 @@
     "officialSite": "http://www.e-tnk.net/anime/anime_taruto.html",
     "begin": "2001-07-05T09:30:00.000Z",
     "end": "2001-09-27T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xAic5d99FtfNW1Dw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "89726"
-      },
-      {
-        "site": "bilibili",
-        "id": "2103",
-        "begin": "2001-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -131,17 +102,11 @@
     "officialSite": "http://www.sunrise-inc.co.jp/seikai/",
     "begin": "2001-07-11T04:30:00.000Z",
     "end": "2001-09-12T05:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kdqmJIzyYqADgek",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,12 +115,7 @@
       {
         "site": "bilibili",
         "id": "2165",
-        "begin": "2001-07-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-07-10T16:00:00.000Z"
       }
     ]
   },
@@ -171,17 +131,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/imm-egg/index.html",
     "begin": "2001-07-03T23:30:00.000Z",
     "end": "2001-09-05T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kbuGBGzSQoDjYck",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -190,12 +144,7 @@
       {
         "site": "bilibili",
         "id": "2104",
-        "begin": "2001-07-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -211,17 +160,11 @@
     "officialSite": "",
     "begin": "2001-07-28T16:00:00.000Z",
     "end": "2001-07-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "r/r4bi7ga6fd7yovx",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -230,22 +173,12 @@
       {
         "site": "letv",
         "id": "10002014",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5297",
-        "begin": "2001-07-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-07-27T16:00:01.000Z"
       }
     ]
   },
@@ -261,7 +194,6 @@
     "officialSite": "",
     "begin": "2001-07-14T16:00:00.000Z",
     "end": "2001-07-14T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -270,12 +202,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tgp",
-        "begin": "2015-08-06T12:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-06T12:03:19.000Z"
       }
     ]
   },
@@ -292,17 +219,11 @@
     "officialSite": "http://baki.ne.jp/",
     "begin": "2001-07-24T16:00:00.000Z",
     "end": "2001-12-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgck361",
-        "begin": "2013-08-06T06:37:53.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-06T06:37:53.000Z"
       },
       {
         "site": "bangumi",
@@ -322,27 +243,16 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2001-07-07T16:00:00.000Z",
     "end": "2001-07-07T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -351,22 +261,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5756",
-        "begin": "2001-07-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-07-06T16:00:01.000Z"
       }
     ]
   },
@@ -382,17 +282,11 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2001-07-07T17:10:00.000Z",
     "end": "2001-07-07T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -412,17 +306,11 @@
     "officialSite": "",
     "begin": "2001-07-20T16:00:00.000Z",
     "end": "2001-07-20T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "bangumi",
@@ -442,41 +330,20 @@
     "officialSite": "http://www.gonzo.co.jp/works/0105.html",
     "begin": "2001-07-30T16:00:00.000Z",
     "end": "2001-10-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ick04th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "83323"
       },
       {
-        "site": "bilibili",
-        "id": "5296",
-        "begin": "2001-07-29T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "29568",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -492,7 +359,6 @@
     "officialSite": "",
     "begin": "2001-07-19T16:00:00.000Z",
     "end": "2003-05-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -501,22 +367,12 @@
       {
         "site": "pptv",
         "id": "yAP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2062",
-        "begin": "2002-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-01T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2001/08.json
+++ b/data/items/2001/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2001-08-03T16:00:00.000Z",
     "end": "2001-08-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3949",
-        "begin": "2001-08-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-08-02T16:00:01.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "http://c-you.jp/daiokishin/",
     "begin": "2001-08-18T16:00:00.000Z",
     "end": "2001-08-18T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2001/10.json
+++ b/data/items/2001/10.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.sunrise-anime.jp/sunrise-inc/works/detail.php?cid=71",
     "begin": "2001-10-06T22:00:00.000Z",
     "end": "2003-01-25T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "5380",
-        "begin": "2001-10-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-06T16:00:01.000Z"
       }
     ]
   },
@@ -41,27 +35,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cap_tsuba/main_index.html",
     "begin": "2001-10-07T08:20:00.000Z",
     "end": "2002-10-06T08:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RvHMSrIYiaMYppw8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "22279",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "2137",
-        "begin": "1983-10-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "1983-10-12T16:00:00.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/hikaru/",
     "begin": "2001-10-10T10:27:00.000Z",
     "end": "2003-03-26T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "nicovideo",
         "id": "hikaru",
-        "begin": "2012-12-14T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-14T06:00:00.000Z"
       }
     ]
   },
@@ -121,67 +93,36 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tennipri/",
     "begin": "2001-10-10T10:00:00.000Z",
     "end": "2014-10-16T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "40QicvSWLibzmcGoI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk4anph",
-        "begin": "2014-04-09T23:30:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:30:24.000Z"
       },
       {
         "site": "qq",
         "id": "r/rvyijr1mt3r4q6a",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "11313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/princeoftennis",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "103410",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -190,22 +131,12 @@
       {
         "site": "nicovideo",
         "id": "tennipri",
-        "begin": "2012-05-20T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-05-20T13:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5281",
-        "begin": "2001-10-09T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-09T16:00:01.000Z"
       }
     ]
   },
@@ -221,27 +152,16 @@
     "officialSite": "http://www.at-x.com/program_detail/index.html/2594/week",
     "begin": "2001-10-03T00:30:00.000Z",
     "end": "2002-03-25T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CyQfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "c/cqyom1alkttm7bf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -250,12 +170,7 @@
       {
         "site": "bilibili",
         "id": "2098",
-        "begin": "2001-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -271,17 +186,11 @@
     "officialSite": "",
     "begin": "2001-10-14T11:00:00.000Z",
     "end": "2002-10-13T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "burGRKwSgsAjoQk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -301,21 +210,10 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/najica/",
     "begin": "2001-10-04T01:30:00.000Z",
     "end": "2001-12-27T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "2935"
-      },
-      {
-        "site": "bilibili",
-        "id": "2097",
-        "begin": "2001-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -334,7 +232,6 @@
     "officialSite": "http://www.gonzo.co.jp/works/0103.html",
     "begin": "2001-10-05T00:30:00.000Z",
     "end": "2002-01-18T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -343,12 +240,7 @@
       {
         "site": "bilibili",
         "id": "2162",
-        "begin": "2001-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -364,7 +256,6 @@
     "officialSite": "http://hicbc.com/tv/kirby/",
     "begin": "2001-10-05T22:30:00.000Z",
     "end": "2003-09-26T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -373,12 +264,7 @@
       {
         "site": "bilibili",
         "id": "2102",
-        "begin": "2001-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -394,27 +280,16 @@
     "officialSite": "http://www.wonderfarm.co.jp/shippo/",
     "begin": "2001-10-04T12:30:00.000Z",
     "end": "2001-12-20T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IQ75d99FtfNW1Dw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/fataqofbrg3l7y8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -423,12 +298,7 @@
       {
         "site": "bilibili",
         "id": "2094",
-        "begin": "2001-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -440,7 +310,6 @@
     "officialSite": "http://www3.nhk.or.jp/anime/kasumin/",
     "begin": "2001-10-13T22:40:00.000Z",
     "end": "2003-10-01T23:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -460,17 +329,11 @@
     "officialSite": "http://www.tbs.co.jp/snow-sugar/",
     "begin": "2001-10-03T18:00:00.000Z",
     "end": "2002-03-26T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ysu2NJwCcrATkfk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -479,12 +342,7 @@
       {
         "site": "bilibili",
         "id": "2119",
-        "begin": "2001-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -500,17 +358,11 @@
     "officialSite": "http://www.mahoro-matic.com/",
     "begin": "2001-10-05T18:00:00.000Z",
     "end": "2001-12-28T19:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VZlj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -530,7 +382,6 @@
     "officialSite": "http://www.jvcmusic.co.jp/m-serve/tv/kokosho/",
     "begin": "2001-10-11T16:00:00.000Z",
     "end": "2002-02-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -550,17 +401,11 @@
     "officialSite": "",
     "begin": "2001-10-04T16:00:00.000Z",
     "end": "2002-11-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "c/c9hi46vxnx77bkb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -569,12 +414,7 @@
       {
         "site": "bilibili",
         "id": "5285",
-        "begin": "2001-10-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-03T16:00:01.000Z"
       }
     ]
   },
@@ -590,17 +430,11 @@
     "officialSite": "",
     "begin": "2001-10-18T16:00:00.000Z",
     "end": "2002-01-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "l/la2nmgw6f8yy3lw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -609,22 +443,7 @@
       {
         "site": "letv",
         "id": "14590",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2130",
-        "begin": "2001-10-17T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -640,17 +459,11 @@
     "officialSite": "",
     "begin": "2001-10-13T16:00:00.000Z",
     "end": "2002-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "quTgXsYsnNo9uyM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -659,12 +472,7 @@
       {
         "site": "bilibili",
         "id": "2100",
-        "begin": "2001-10-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-10-12T16:00:00.000Z"
       }
     ]
   },
@@ -680,31 +488,15 @@
     "officialSite": "",
     "begin": "2001-10-02T16:00:00.000Z",
     "end": "2002-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "b6GbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "13555"
-      },
-      {
-        "site": "bilibili",
-        "id": "5286",
-        "begin": "2001-10-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2001/11.json
+++ b/data/items/2001/11.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.anime-int.com/works/magic/2d/index-n.html",
     "begin": "2001-11-16T16:00:00.000Z",
     "end": "2002-04-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "2001-11-21T16:00:00.000Z",
     "end": "2002-03-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,12 +38,7 @@
       {
         "site": "bilibili",
         "id": "5278",
-        "begin": "2001-11-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-11-20T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2001/12.json
+++ b/data/items/2001/12.json
@@ -7,7 +7,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/works/archive/akubi_chan.html",
     "begin": "2001-12-11T08:30:00.000Z",
     "end": "2002-11-11T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -30,37 +29,21 @@
     "officialSite": "",
     "begin": "2001-12-15T16:00:00.000Z",
     "end": "2001-12-15T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "m/mkq4b0j56fjmicv",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "45915",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "56MQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -69,12 +52,7 @@
       {
         "site": "netflix",
         "id": "70012316",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   },
@@ -90,17 +68,11 @@
     "officialSite": "",
     "begin": "2001-12-22T16:00:00.000Z",
     "end": "2001-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "w/w3yvgpn0hlea9hc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -109,22 +81,12 @@
       {
         "site": "pptv",
         "id": "RfTgXsYsnNo9uyM",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3910",
-        "begin": "2001-12-21T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-12-21T16:00:01.000Z"
       }
     ]
   },
@@ -140,27 +102,16 @@
     "officialSite": "",
     "begin": "2001-12-29T16:00:00.000Z",
     "end": "2002-03-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zWNe3ESqGlia7OaE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5pat6irkz1zcbem",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -169,12 +120,7 @@
       {
         "site": "nicovideo",
         "id": "rurouni-kenshin-seisou",
-        "begin": "2014-09-13T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-13T06:00:00.000Z"
       }
     ]
   },
@@ -191,27 +137,16 @@
     "officialSite": "",
     "begin": "2001-12-21T16:00:00.000Z",
     "end": "2002-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nLGbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjpa0rp",
-        "begin": "2013-04-18T02:14:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-18T02:14:03.000Z"
       },
       {
         "site": "bangumi",
@@ -231,17 +166,11 @@
     "officialSite": "",
     "begin": "2001-12-22T16:00:00.000Z",
     "end": "2001-12-22T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tVw4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -250,12 +179,7 @@
       {
         "site": "bilibili",
         "id": "3411",
-        "begin": "2001-12-21T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2001-12-21T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2002/01.json
+++ b/data/items/2002/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.broccoli.co.jp/dejiko/panyo/",
     "begin": "2002-01-05T15:30:00.000Z",
     "end": "2002-09-30T03:07:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "http://www.d-rights.com/beyblade/2002/",
     "begin": "2002-01-07T09:00:00.000Z",
     "end": "2002-12-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3WxIxia6UBEKlI4s",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/niku/",
     "begin": "2002-01-09T09:00:00.000Z",
     "end": "2002-12-25T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,7 +73,6 @@
     "officialSite": "http://www.telecom-anime.com/patapata/japanese/",
     "begin": "2002-01-05T22:00:00.000Z",
     "end": "2002-07-29T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -101,17 +92,11 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/rahxephon/index.html",
     "begin": "2002-01-21T15:00:00.000Z",
     "end": "2002-09-10T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3WxX1T2jE1G0Mpo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -120,22 +105,12 @@
       {
         "site": "nicovideo",
         "id": "rahxephon",
-        "begin": "2012-05-02T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-05-02T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2079",
-        "begin": "2002-01-20T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-01-20T16:00:00.000Z"
       }
     ]
   },
@@ -151,47 +126,26 @@
     "officialSite": "http://www.please-please.jp/one/",
     "begin": "2002-01-10T22:00:00.000Z",
     "end": "2002-03-28T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6CEbmQFn1xV49l4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9aqwp",
-        "begin": "2017-02-28T16:01:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-28T16:01:13.000Z"
       },
       {
         "site": "qq",
         "id": "0/0kaee397yk6ou0e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "37048",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -200,12 +154,7 @@
       {
         "site": "bilibili",
         "id": "2068",
-        "begin": "2002-01-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -221,31 +170,15 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/mirage/",
     "begin": "2002-01-07T13:30:00.000Z",
     "end": "2002-04-01T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZaehH4ftXZvibfOQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2914"
-      },
-      {
-        "site": "bilibili",
-        "id": "2078",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
       }
     ]
   },
@@ -261,7 +194,6 @@
     "officialSite": "http://www.tdd-1.com/",
     "begin": "2002-01-15T01:30:00.000Z",
     "end": "2002-06-25T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -281,17 +213,11 @@
     "officialSite": "http://www.fujitv.co.jp/jp/b_hp/kanon/index.html",
     "begin": "2002-01-30T18:25:00.000Z",
     "end": "2002-03-27T18:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qox39V3DM3HUUro",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -300,12 +226,7 @@
       {
         "site": "bilibili",
         "id": "1374",
-        "begin": "2002-01-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-01-29T16:00:00.000Z"
       }
     ]
   },
@@ -321,21 +242,10 @@
     "officialSite": "http://web.archive.org/*/http://www.tv-tokyo.co.jp/anime/nana/main_index.html",
     "begin": "2002-01-10T16:00:00.000Z",
     "end": "2002-06-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "74906"
-      },
-      {
-        "site": "bilibili",
-        "id": "5251",
-        "begin": "2002-01-09T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -351,41 +261,20 @@
     "officialSite": "",
     "begin": "2002-01-03T16:00:00.000Z",
     "end": "2002-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Wt6pJ4ic1ZaMGhOw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "c/cojjinwv7myueh1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "11514"
-      },
-      {
-        "site": "bilibili",
-        "id": "2044",
-        "begin": "2002-01-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -401,7 +290,6 @@
     "officialSite": "",
     "begin": "2002-01-17T16:00:00.000Z",
     "end": "2002-04-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -410,12 +298,7 @@
       {
         "site": "pptv",
         "id": "ooWAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2002/02.json
+++ b/data/items/2002/02.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/doremi_D/",
     "begin": "2002-02-02T23:30:00.000Z",
     "end": "2003-01-26T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb13bp",
-        "begin": "2015-08-14T17:07:41.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:07:41.000Z"
       },
       {
         "site": "bangumi",
@@ -42,7 +36,6 @@
     "officialSite": "http://www.madhouse.co.jp/works/2003-2002/works_tv_galaxyange2.html",
     "begin": "2002-02-03T10:00:00.000Z",
     "end": "2002-03-31T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,12 +44,7 @@
       {
         "site": "bilibili",
         "id": "1943",
-        "begin": "2002-02-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-02-02T16:00:00.000Z"
       }
     ]
   },
@@ -72,17 +60,11 @@
     "officialSite": "",
     "begin": "2002-02-02T16:00:00.000Z",
     "end": "2002-02-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "17266",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -91,12 +73,7 @@
       {
         "site": "nicovideo",
         "id": "hoshinokoe",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2002/03.json
+++ b/data/items/2002/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/archive/rockman/",
     "begin": "2002-03-04T09:30:00.000Z",
     "end": "2003-03-31T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "http://www.shopro.co.jp/tv/archive/rockman/",
     "begin": "2002-03-09T16:00:00.000Z",
     "end": "2003-03-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80962",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,32 +43,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mrdl",
-        "begin": "2018-05-31T16:00:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:00:12.000Z"
       }
     ]
   },
@@ -91,31 +69,15 @@
     "officialSite": "",
     "begin": "2002-03-29T16:00:00.000Z",
     "end": "2002-07-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/ouf9a0601tiexsy",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "95526"
-      },
-      {
-        "site": "bilibili",
-        "id": "5247",
-        "begin": "2002-03-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -131,17 +93,11 @@
     "officialSite": "",
     "begin": "2002-03-29T16:00:00.000Z",
     "end": "2002-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "u/ug20xje2k1ueg8n",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -161,17 +117,11 @@
     "officialSite": "",
     "begin": "2002-03-30T16:00:00.000Z",
     "end": "2002-03-30T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "a/aj5o1l8zjhv7etb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -180,12 +130,7 @@
       {
         "site": "bilibili",
         "id": "4017",
-        "begin": "2002-03-29T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-03-29T16:00:01.000Z"
       }
     ]
   },
@@ -201,7 +146,6 @@
     "officialSite": "",
     "begin": "2002-03-02T16:00:00.000Z",
     "end": "2002-03-02T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -221,7 +165,6 @@
     "officialSite": "",
     "begin": "2002-03-02T16:00:00.000Z",
     "end": "2002-03-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -230,12 +173,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tgp",
-        "begin": "2015-08-06T12:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-06T12:03:19.000Z"
       }
     ]
   },
@@ -251,17 +189,11 @@
     "officialSite": "",
     "begin": "2002-03-30T16:00:00.000Z",
     "end": "2002-03-30T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sYVv7VW7K2nMSrI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -270,12 +202,7 @@
       {
         "site": "bilibili",
         "id": "5266",
-        "begin": "2002-03-29T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-03-29T16:00:01.000Z"
       }
     ]
   },
@@ -291,21 +218,10 @@
     "officialSite": "http://www.starchild.co.jp/special/aura/index.html",
     "begin": "2002-03-29T16:00:00.000Z",
     "end": "2002-09-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "4210"
-      },
-      {
-        "site": "bilibili",
-        "id": "5169",
-        "begin": "2002-09-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -321,31 +237,15 @@
     "officialSite": "",
     "begin": "2002-03-28T16:00:00.000Z",
     "end": "2002-06-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2BHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "69698"
-      },
-      {
-        "site": "bilibili",
-        "id": "3153",
-        "begin": "2002-03-27T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -361,7 +261,6 @@
     "officialSite": "",
     "begin": "2002-03-22T16:00:00.000Z",
     "end": "2002-03-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -370,12 +269,7 @@
       {
         "site": "nicovideo",
         "id": "ch61002",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2002/04.json
+++ b/data/items/2002/04.json
@@ -11,27 +11,16 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-tokyo.co.jp/anime/tenshi/main_index.html",
     "begin": "2002-04-06T15:45:00.000Z",
     "end": "2003-03-29T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Iwz3dd1DsicFU0jo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bkwnwgi75yqk7zs",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2042",
-        "begin": "2002-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mirumo/story/story_mirumo.htm",
     "begin": "2002-04-05T23:30:00.000Z",
     "end": "2004-03-30T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,17 +64,11 @@
     "officialSite": "http://www.tv-aichi.co.jp/mewmew/",
     "begin": "2002-04-05T23:00:00.000Z",
     "end": "2003-03-28T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "v6SQDnbcTIrta9M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "2040",
-        "begin": "2002-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -121,7 +93,6 @@
     "officialSite": "http://www.toho-a-park.com/character/hikari/index.html",
     "begin": "2002-04-06T23:30:00.000Z",
     "end": "2003-03-30T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,12 +101,7 @@
       {
         "site": "bilibili",
         "id": "2032",
-        "begin": "2002-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -151,7 +117,6 @@
     "officialSite": "http://www.starchild.co.jp/special/azuma/index.html",
     "begin": "2002-04-08T16:25:00.000Z",
     "end": "2002-09-30T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -171,7 +136,6 @@
     "officialSite": "http://www.atashinchi.net/",
     "begin": "2002-04-19T10:30:00.000Z",
     "end": "2009-09-19T02:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -180,32 +144,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgcn2kp",
-        "begin": "2013-08-07T01:39:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-07T01:39:12.000Z"
       },
       {
         "site": "qq",
         "id": "l/lp7n9hjirt1b2ig",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "6qESkPhezgxv7VU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -222,17 +171,11 @@
     "officialSite": "http://www.fujitv.co.jp/jp/b_hp/digimonf/",
     "begin": "2002-04-07T00:00:00.000Z",
     "end": "2003-03-30T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1d8t",
-        "begin": "2015-09-17T05:39:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:18.000Z"
       },
       {
         "site": "bangumi",
@@ -252,17 +195,11 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-tokyo.co.jp/anime/fullmoon/main_index.html",
     "begin": "2002-04-05T22:30:00.000Z",
     "end": "2003-03-28T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HTkEgupQwP5h30c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -271,22 +208,12 @@
       {
         "site": "letv",
         "id": "41889",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2021",
-        "begin": "2002-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -302,27 +229,16 @@
     "officialSite": "http://www.aiyoriaoshi.com/aiao_index.html",
     "begin": "2002-04-10T00:00:00.000Z",
     "end": "2002-09-25T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PW5a2ECmFlS3NZ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/us1x4gwz0ud1ih0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -331,22 +247,12 @@
       {
         "site": "nicovideo",
         "id": "aiyoriaoshi_",
-        "begin": "2012-08-29T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-29T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2018",
-        "begin": "2002-04-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-09T16:00:00.000Z"
       }
     ]
   },
@@ -362,17 +268,11 @@
     "officialSite": "http://dothack.com/",
     "begin": "2002-04-03T13:00:00.000Z",
     "end": "2002-09-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hsmzMZnicb60QjvY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -392,7 +292,6 @@
     "officialSite": "http://www.ponycanyon.co.jp/pc-moe/rizeru/",
     "begin": "2002-04-02T04:00:00.000Z",
     "end": "2002-06-25T04:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -412,7 +311,6 @@
     "officialSite": "http://www.madhouse.co.jp/works/2002-2001/works_tv_pitaten.html",
     "begin": "2002-04-07T02:00:00.000Z",
     "end": "2002-09-29T05:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -421,12 +319,7 @@
       {
         "site": "bilibili",
         "id": "2075",
-        "begin": "2002-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -446,37 +339,21 @@
     "officialSite": "http://www.tbs.co.jp/chobits/",
     "begin": "2002-04-02T18:00:00.000Z",
     "end": "2002-09-24T19:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qo149l7ENHLVU7s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "g/go0ywjh393l0jm5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "38691",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -485,22 +362,12 @@
       {
         "site": "bilibili",
         "id": "2061",
-        "begin": "2002-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-01T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhuee75",
-        "begin": "2019-01-25T03:14:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-25T03:14:50.000Z"
       }
     ]
   },
@@ -516,27 +383,16 @@
     "officialSite": "http://www6.nhk.or.jp/anime/program/detail.html?i=12kokuki",
     "begin": "2002-04-09T10:00:00.000Z",
     "end": "2003-08-30T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ooRicicWXLO3ncWsI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0299",
-        "begin": "2014-11-03T10:06:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-03T10:06:18.000Z"
       },
       {
         "site": "bangumi",
@@ -545,32 +401,17 @@
       {
         "site": "qq",
         "id": "7/7phtjz7q03995kj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2069",
-        "begin": "2002-04-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-08T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "44845",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -586,7 +427,6 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_2000/tv_057.html",
     "begin": "2002-04-02T16:00:00.000Z",
     "end": "2002-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -595,12 +435,7 @@
       {
         "site": "bilibili",
         "id": "2035",
-        "begin": "2002-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -616,17 +451,11 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2002-04-20T16:00:00.000Z",
     "end": "2002-04-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/48ffcf0034a37957.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/48ffcf0034a37957.html"
       },
       {
         "site": "bangumi",
@@ -635,22 +464,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3881",
-        "begin": "2002-04-19T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "39112",
+        "begin": "2002-04-19T16:00:01.000Z"
       }
     ]
   },
@@ -666,17 +485,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2002-04-20T16:00:00.000Z",
     "end": "2002-04-20T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -685,22 +498,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -716,7 +519,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2002-04-01T08:35:00.000Z",
     "end": "2002-07-19T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -736,17 +538,11 @@
     "officialSite": "",
     "begin": "2002-04-01T16:00:00.000Z",
     "end": "2002-05-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jb6KCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -766,31 +562,15 @@
     "officialSite": "",
     "begin": "2002-04-02T16:00:00.000Z",
     "end": "2002-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qibXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "56626"
-      },
-      {
-        "site": "bilibili",
-        "id": "1616",
-        "begin": "2002-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -806,17 +586,11 @@
     "officialSite": "http://www.gainax.co.jp/anime/abesho/",
     "begin": "2002-04-04T16:00:00.000Z",
     "end": "2002-06-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8VsmpAxy4iaCDAWk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -825,12 +599,7 @@
       {
         "site": "bilibili",
         "id": "2043",
-        "begin": "2002-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -846,7 +615,6 @@
     "officialSite": "http://www.gonzo.co.jp/works/0002.html",
     "begin": "2002-04-24T16:00:00.000Z",
     "end": "2003-01-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -855,22 +623,7 @@
       {
         "site": "pptv",
         "id": "mNKuLJT6aqgLiafE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5237",
-        "begin": "2002-04-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -886,7 +639,6 @@
     "officialSite": "",
     "begin": "2002-04-03T16:00:00.000Z",
     "end": "2002-04-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -895,22 +647,12 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3933",
-        "begin": "2002-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-04-02T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2002/05.json
+++ b/data/items/2002/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/jing/index.html",
     "begin": "2002-05-15T16:00:00.000Z",
     "end": "2002-08-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NHZS0DiaeDkyvLZU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "jing",
-        "begin": "2018-05-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-16T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2071",
-        "begin": "2002-05-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-05-14T16:00:00.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "",
     "begin": "2002-05-06T16:00:00.000Z",
     "end": "2003-02-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "nicovideo",
         "id": "whistle",
-        "begin": "2017-01-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-01T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2002/06.json
+++ b/data/items/2002/06.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.saikano.net/",
     "begin": "2002-06-02T15:30:00.000Z",
     "end": "2002-09-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3Qic5d99FtfNW1Dw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5xpkhs99erx3y89",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "2029",
-        "begin": "2002-06-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-06-01T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2002/07.json
+++ b/data/items/2002/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tokinoyu.net/",
     "begin": "2002-07-04T04:00:00.000Z",
     "end": "2002-09-19T05:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2002-07-26T16:00:00.000Z",
     "end": "2002-07-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,32 +38,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3950",
-        "begin": "2002-07-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-07-25T16:00:01.000Z"
       }
     ]
   },
@@ -84,17 +67,11 @@
     "officialSite": "http://www.bandaivisual.co.jp/robin/",
     "begin": "2002-07-02T16:00:00.000Z",
     "end": "2002-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NATicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -103,12 +80,7 @@
       {
         "site": "bilibili",
         "id": "2028",
-        "begin": "2002-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -124,17 +96,11 @@
     "officialSite": "http://www.starchild.co.jp/special/asagiri/",
     "begin": "2002-07-04T16:00:00.000Z",
     "end": "2002-12-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Jgn0ctpAsO5Rzzc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -143,12 +109,7 @@
       {
         "site": "bilibili",
         "id": "5139",
-        "begin": "2004-07-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-07-18T16:00:01.000Z"
       }
     ]
   },
@@ -164,7 +125,6 @@
     "officialSite": "http://www.starchild.co.jp/special/mao/",
     "begin": "2002-07-03T16:00:00.000Z",
     "end": "2002-12-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -173,12 +133,7 @@
       {
         "site": "bilibili",
         "id": "2024",
-        "begin": "2002-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-07-02T16:00:00.000Z"
       }
     ]
   },
@@ -194,27 +149,16 @@
     "officialSite": "http://www.carddas.com/dragondrive/",
     "begin": "2002-07-04T16:00:00.000Z",
     "end": "2003-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vvPNS7MZiaccqqBA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/zxxfllsgra0n25i",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -223,12 +167,7 @@
       {
         "site": "bilibili",
         "id": "2026",
-        "begin": "2002-07-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -244,7 +183,6 @@
     "officialSite": "",
     "begin": "2002-07-20T16:00:00.000Z",
     "end": "2002-07-20T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -253,12 +191,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tgp",
-        "begin": "2015-08-06T12:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-06T12:03:19.000Z"
       }
     ]
   },
@@ -274,27 +207,16 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2002-07-13T16:00:00.000Z",
     "end": "2002-07-13T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -303,22 +225,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5755",
-        "begin": "2002-07-12T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-07-12T16:00:01.000Z"
       }
     ]
   },
@@ -334,17 +246,11 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2002-07-13T17:10:00.000Z",
     "end": "2002-07-13T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -364,17 +270,11 @@
     "officialSite": "http://www.e-tnk.net/anime/anime_g-on.html",
     "begin": "2002-07-02T16:00:00.000Z",
     "end": "2002-10-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9TcRjicddzQtu7FQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -394,41 +294,20 @@
     "officialSite": "",
     "begin": "2002-07-01T16:00:00.000Z",
     "end": "2002-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91olowtx4RibCAGg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4164"
       },
       {
-        "site": "bilibili",
-        "id": "2025",
-        "begin": "2002-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "14538",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -444,7 +323,6 @@
     "officialSite": "",
     "begin": "2002-07-06T16:00:00.000Z",
     "end": "2002-07-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -453,12 +331,7 @@
       {
         "site": "nicovideo",
         "id": "six-angels",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -474,7 +347,6 @@
     "officialSite": "",
     "begin": "2002-07-26T16:00:00.000Z",
     "end": "2002-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -483,12 +355,7 @@
       {
         "site": "nicovideo",
         "id": "ch61034",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2002/08.json
+++ b/data/items/2002/08.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.kids-station.com/minisite/tokushu/princess/index.html",
     "begin": "2002-08-26T22:00:00.000Z",
     "end": "2003-05-23T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7iaMdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "letv",
         "id": "29192",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2030",
-        "begin": "2002-08-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-08-15T16:00:00.000Z"
       }
     ]
   },
@@ -61,27 +45,16 @@
     "officialSite": "",
     "begin": "2002-08-25T16:00:00.000Z",
     "end": "2005-08-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vicHLSbEXh8Uopg4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/fqbm8xkyfsuxjh7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -90,12 +63,7 @@
       {
         "site": "bilibili",
         "id": "2702",
-        "begin": "2002-08-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-08-24T16:00:00.000Z"
       }
     ]
   },
@@ -111,7 +79,6 @@
     "officialSite": "",
     "begin": "2002-08-23T16:00:00.000Z",
     "end": "2004-04-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -120,12 +87,7 @@
       {
         "site": "nicovideo",
         "id": "komugite",
-        "begin": "2016-04-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-26T06:00:00.000Z"
       }
     ]
   },
@@ -141,7 +103,6 @@
     "officialSite": "",
     "begin": "2002-08-17T16:00:00.000Z",
     "end": "2002-08-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -150,12 +111,7 @@
       {
         "site": "pptv",
         "id": "ibEkjoQlv3x2AicmY",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2002/09.json
+++ b/data/items/2002/09.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.wowow.co.jp/drama_anime/king/contents.html",
     "begin": "2002-09-07T10:00:00.000Z",
     "end": "2003-03-22T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6SMdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2020",
-        "begin": "2002-09-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-09-06T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://www.mahoro-matic.com/mahoro2/index2.html",
     "begin": "2002-09-26T02:00:00.000Z",
     "end": "2003-01-16T02:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gc23NZ0Dc7EUkvo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -85,17 +68,11 @@
     "officialSite": "http://web.archive.org/*/www.yucie.com/",
     "begin": "2002-09-30T20:00:00.000Z",
     "end": "2003-03-24T20:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "bJ5q6FC2JmTHRa0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -104,22 +81,12 @@
       {
         "site": "letv",
         "id": "18549",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5228",
-        "begin": "2002-09-29T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-09-29T16:00:01.000Z"
       }
     ]
   },
@@ -136,17 +103,11 @@
     "officialSite": "",
     "begin": "2002-09-25T16:00:00.000Z",
     "end": "2004-01-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "W5Nt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -166,17 +127,11 @@
     "officialSite": "",
     "begin": "2002-09-11T16:00:00.000Z",
     "end": "2003-09-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6iaQgngZs3Bp9ib2M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2002/10.json
+++ b/data/items/2002/10.json
@@ -11,31 +11,15 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-osaka.co.jp/galaxyangel/",
     "begin": "2002-10-06T00:30:00.000Z",
     "end": "2003-03-30T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "l9iakIorwYJ4Bfibc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "18082"
-      },
-      {
-        "site": "bilibili",
-        "id": "1944",
-        "begin": "2002-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -51,7 +35,6 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-tokyo.co.jp/anime/dchildren/",
     "begin": "2002-10-05T00:00:00.000Z",
     "end": "2003-09-27T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,17 +54,11 @@
     "officialSite": "http://www.avexmovie.jp/lineup/asobot/asobot.html",
     "begin": "2002-10-01T09:30:00.000Z",
     "end": "2003-09-23T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iasib5N58FdbMWlPw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,7 +78,6 @@
     "officialSite": "http://www.hudson.co.jp/gamenavi/gamedb/softinfo/bomb_jetters/anime/",
     "begin": "2002-10-02T09:30:00.000Z",
     "end": "2003-09-24T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -121,17 +97,11 @@
     "officialSite": "http://gangan.square-enix.co.jp/spiral/",
     "begin": "2002-10-01T09:00:00.000Z",
     "end": "2003-03-25T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2n1Ixia6UBEKlI4s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,22 +110,12 @@
       {
         "site": "nicovideo",
         "id": "spiral_anime",
-        "begin": "2018-05-24T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-24T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2070",
-        "begin": "2002-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -174,17 +134,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/naruto2002/",
     "begin": "2002-10-03T09:30:00.000Z",
     "end": "2007-02-08T10:57:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10017794",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -193,22 +147,12 @@
       {
         "site": "nicovideo",
         "id": "naruto",
-        "begin": "2015-07-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-15T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70205012",
-        "begin": "2017-02-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-01T08:00:00.000Z"
       }
     ]
   },
@@ -224,17 +168,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/haibane/",
     "begin": "2002-10-09T17:43:00.000Z",
     "end": "2002-12-18T18:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2w76eOBGtvRX1T0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -243,12 +181,7 @@
       {
         "site": "bilibili",
         "id": "2074",
-        "begin": "2002-10-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-10-08T16:00:00.000Z"
       }
     ]
   },
@@ -264,17 +197,11 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/gravion/",
     "begin": "2002-10-07T15:30:00.000Z",
     "end": "2002-12-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FVYysBhib7iayPDXU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -283,12 +210,7 @@
       {
         "site": "bilibili",
         "id": "1948",
-        "begin": "2002-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -304,27 +226,16 @@
     "officialSite": "http://www.kiddygrade.com/1/index2.html",
     "begin": "2002-10-08T02:00:00.000Z",
     "end": "2003-03-18T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5U86uCCG9jSXFX0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/l04yo553nhn1rca",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -344,27 +255,16 @@
     "officialSite": "http://www.ntv.co.jp/hanada/index.html",
     "begin": "2002-10-01T07:00:00.000Z",
     "end": "2003-03-25T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Flgkogpw4B6Bic2c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "n/npl0hynuel8e3bn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -373,22 +273,12 @@
       {
         "site": "letv",
         "id": "14059",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2825",
-        "begin": "2002-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -404,21 +294,10 @@
     "officialSite": "http://www.tbs.co.jp/heat-guy/",
     "begin": "2002-10-01T23:00:00.000Z",
     "end": "2003-03-25T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "4123"
-      },
-      {
-        "site": "bilibili",
-        "id": "2056",
-        "begin": "2002-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -434,27 +313,16 @@
     "officialSite": "http://www.gundam-seed.net/",
     "begin": "2002-10-05T17:57:00.000Z",
     "end": "2003-09-27T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HTYRjicddzQtu7FQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/76rndqu0bl4mzrb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -474,17 +342,11 @@
     "officialSite": "http://www.kokaku-s.com/",
     "begin": "2002-10-01T13:00:00.000Z",
     "end": "2003-11-30T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wWpV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -493,22 +355,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh16xd1",
-        "begin": "2017-12-07T08:58:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-07T08:58:06.000Z"
       },
       {
         "site": "bilibili",
         "id": "1564",
-        "begin": "2002-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -524,21 +376,10 @@
     "officialSite": "http://www.starchild.co.jp/special/repure/",
     "begin": "2002-10-02T16:00:00.000Z",
     "end": "2002-12-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "49119"
-      },
-      {
-        "site": "bilibili",
-        "id": "2129",
-        "begin": "2002-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -554,17 +395,11 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-tokyo.co.jp/anime/platonic_c/main_index.html",
     "begin": "2002-10-04T16:00:00.000Z",
     "end": "2003-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LF4qqBB25iaSHBW0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -584,17 +419,11 @@
     "officialSite": "http://www.tbs.co.jp/getbackers/",
     "begin": "2002-10-05T16:00:00.000Z",
     "end": "2003-09-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "a8SicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -603,12 +432,7 @@
       {
         "site": "bilibili",
         "id": "2073",
-        "begin": "2002-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -624,7 +448,6 @@
     "officialSite": "",
     "begin": "2002-10-21T16:00:00.000Z",
     "end": "2003-04-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -633,12 +456,7 @@
       {
         "site": "nicovideo",
         "id": "duelmasters01",
-        "begin": "2014-11-27T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-27T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/2002/11.json
+++ b/data/items/2002/11.json
@@ -12,57 +12,31 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_ag/",
     "begin": "2002-11-21T10:00:00.000Z",
     "end": "2006-09-14T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AyMNiaicNZyQdq6FA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb7bx9",
-        "begin": "2015-09-17T05:39:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:26.000Z"
       },
       {
         "site": "qq",
         "id": "9/9yfjl0rjm0l5tys",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10006375",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2017/dhpjlbkm2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,12 +45,7 @@
       {
         "site": "bilibili",
         "id": "6161",
-        "begin": "2002-11-20T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-11-20T16:00:01.000Z"
       }
     ]
   },
@@ -95,17 +64,11 @@
     "officialSite": "http://www.marine-e.co.jp/sakuhin/piano/p_index.htm",
     "begin": "2002-11-11T07:00:00.000Z",
     "end": "2003-01-13T08:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TPzHRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -114,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "2058",
-        "begin": "2002-11-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-11-10T16:00:00.000Z"
       }
     ]
   },
@@ -135,7 +93,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/tsuribaka/",
     "begin": "2002-11-02T16:00:00.000Z",
     "end": "2003-09-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -155,31 +112,15 @@
     "officialSite": "http://www.starchild.co.jp/special/rouran/top.html",
     "begin": "2002-11-15T16:00:00.000Z",
     "end": "2003-05-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "joNt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "19612"
-      },
-      {
-        "site": "bilibili",
-        "id": "2049",
-        "begin": "2002-11-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -195,31 +136,15 @@
     "officialSite": "",
     "begin": "2002-11-28T16:00:00.000Z",
     "end": "2003-02-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aaKeHITqWpj7eeE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "39001"
-      },
-      {
-        "site": "bilibili",
-        "id": "2084",
-        "begin": "2002-11-27T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2002/12.json
+++ b/data/items/2002/12.json
@@ -14,27 +14,16 @@
     "officialSite": "",
     "begin": "2002-12-28T16:00:00.000Z",
     "end": "2002-12-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "a/acpxdje8xzn3jp4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "46372",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -43,12 +32,7 @@
       {
         "site": "netflix",
         "id": "70018513",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   },
@@ -64,17 +48,11 @@
     "officialSite": "",
     "begin": "2002-12-18T16:00:00.000Z",
     "end": "2003-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0gYCgOhOvvxf3UU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -94,17 +72,11 @@
     "officialSite": "http://www.macross.co.jp/zero/",
     "begin": "2002-12-21T16:00:00.000Z",
     "end": "2004-10-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Q5Rw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -113,12 +85,7 @@
       {
         "site": "bilibili",
         "id": "3566",
-        "begin": "2002-12-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-12-20T16:00:01.000Z"
       }
     ]
   },
@@ -134,7 +101,6 @@
     "officialSite": "",
     "begin": "2002-12-18T16:00:00.000Z",
     "end": "2002-12-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -143,12 +109,7 @@
       {
         "site": "bilibili",
         "id": "3407",
-        "begin": "2002-12-17T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-12-17T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2003/01.json
+++ b/data/items/2003/01.json
@@ -11,18 +11,7 @@
     "officialSite": "http://web.archive.org/*/http://www.tv-tokyo.co.jp/anime/transformer/",
     "begin": "2003-01-10T09:00:00.000Z",
     "end": "2003-12-26T09:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "49141",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "189382"
@@ -30,32 +19,17 @@
       {
         "site": "qq",
         "id": "l/lxb9a1bnf0d0s0k",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1987",
-        "begin": "2003-01-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-01-10T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "46063",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -71,7 +45,6 @@
     "officialSite": "http://www.sunrise-inc.co.jp/mrr/",
     "begin": "2003-01-08T09:00:00.000Z",
     "end": "2003-12-24T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,17 +64,11 @@
     "officialSite": "http://www.d-rights.com/beyblade/",
     "begin": "2003-01-06T09:00:00.000Z",
     "end": "2003-12-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5VRAviaaMicDqdG4M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -121,27 +88,16 @@
     "officialSite": "http://www.bandaivisual.co.jp/hack_udeden/",
     "begin": "2003-01-08T15:55:00.000Z",
     "end": "2003-03-26T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GToFgibtRwf9ia4Eg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "4/4vzudrrru0v91wp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,12 +106,7 @@
       {
         "site": "bilibili",
         "id": "1959",
-        "begin": "2003-01-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -171,31 +122,15 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/l-r/",
     "begin": "2003-01-08T01:00:00.000Z",
     "end": "2003-03-26T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pibjUUrogkM4xrxc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "21104"
-      },
-      {
-        "site": "bilibili",
-        "id": "1988",
-        "begin": "2003-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -211,7 +146,6 @@
     "officialSite": "http://www.limeiro.com/",
     "begin": "2003-01-03T00:30:00.000Z",
     "end": "2003-03-28T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -231,37 +165,21 @@
     "officialSite": "http://www.bones.co.jp/works/tv04/index.html",
     "begin": "2003-01-06T15:30:00.000Z",
     "end": "2003-07-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Pwr1c9tBse9S0Dg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhabe4d",
-        "begin": "2016-01-08T10:12:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T10:12:34.000Z"
       },
       {
         "site": "qq",
         "id": "m/mj8qml4x7d80r7x",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -270,12 +188,7 @@
       {
         "site": "bilibili",
         "id": "2913",
-        "begin": "2003-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -291,17 +204,11 @@
     "officialSite": "http://www.jcstaff.co.jp/sho-sai/maho-shokai/maho-story.htm",
     "begin": "2003-01-09T07:00:00.000Z",
     "end": "2003-03-27T17:37:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "p5Vw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -310,12 +217,7 @@
       {
         "site": "bilibili",
         "id": "1234",
-        "begin": "2003-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -332,31 +234,15 @@
     "officialSite": "http://www.stratos4.jp/",
     "begin": "2003-01-04T15:15:00.000Z",
     "end": "2003-03-29T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DT0Ihu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "10414"
-      },
-      {
-        "site": "bilibili",
-        "id": "1991",
-        "begin": "2003-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -372,18 +258,7 @@
     "officialSite": "http://www.starchild.co.jp/special/nanaka/",
     "begin": "2003-01-08T16:00:00.000Z",
     "end": "2003-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1463942",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "19521"
@@ -403,17 +278,11 @@
     "officialSite": "http://www.toei-anim.co.jp/ova/seiya/",
     "begin": "2003-01-25T16:00:00.000Z",
     "end": "2003-07-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1bux",
-        "begin": "2015-08-14T17:06:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:06:44.000Z"
       },
       {
         "site": "bangumi",
@@ -433,31 +302,15 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/mouse/",
     "begin": "2003-01-05T16:00:00.000Z",
     "end": "2003-03-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8z0Hhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "58719"
-      },
-      {
-        "site": "bilibili",
-        "id": "1989",
-        "begin": "2003-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -473,7 +326,6 @@
     "officialSite": "",
     "begin": "2003-01-22T16:00:00.000Z",
     "end": "2003-05-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -482,12 +334,7 @@
       {
         "site": "pptv",
         "id": "laGcGoLoWJb5d98",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2003/02.json
+++ b/data/items/2003/02.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/nadja/",
     "begin": "2003-02-01T23:30:00.000Z",
     "end": "2004-01-25T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "grGMCnLYSIbpZ88",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1992",
-        "begin": "2003-02-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-02-01T16:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://www.crushgear-nitro.net/",
     "begin": "2003-02-01T22:00:00.000Z",
     "end": "2004-01-24T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -67,7 +55,6 @@
     "officialSite": "",
     "begin": "2003-02-05T16:00:00.000Z",
     "end": "2003-02-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -76,12 +63,7 @@
       {
         "site": "nicovideo",
         "id": "it-supermilk-chan",
-        "begin": "2011-06-17T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-06-17T12:00:00.000Z"
       }
     ]
   },
@@ -97,7 +79,6 @@
     "officialSite": "",
     "begin": "2003-02-05T16:00:00.000Z",
     "end": "2003-04-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -106,12 +87,7 @@
       {
         "site": "pptv",
         "id": "o4RicicWXLO3ncWsI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2003/03.json
+++ b/data/items/2003/03.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.wonderfarm.co.jp/shippo/contents/shippo2.htm",
     "begin": "2003-03-06T16:00:00.000Z",
     "end": "2003-06-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "4/43sultn2fajty7a",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "2003-03-01T16:00:00.000Z",
     "end": "2003-03-01T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,17 +54,11 @@
     "officialSite": "",
     "begin": "2003-03-08T16:00:00.000Z",
     "end": "2003-03-08T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "80963",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,32 +67,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2567",
-        "begin": "2003-03-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-03-07T16:00:00.000Z"
       }
     ]
   },
@@ -121,7 +93,6 @@
     "officialSite": "",
     "begin": "2003-03-19T16:00:00.000Z",
     "end": "2003-08-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,22 +101,12 @@
       {
         "site": "pptv",
         "id": "0BnjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3408",
-        "begin": "2003-03-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-03-18T16:00:01.000Z"
       }
     ]
   },
@@ -161,7 +122,6 @@
     "officialSite": "http://www.munto.com/",
     "begin": "2003-03-18T16:00:00.000Z",
     "end": "2005-04-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,12 +130,7 @@
       {
         "site": "pptv",
         "id": "yvicJR68VhcMmpAw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2003/04.json
+++ b/data/items/2003/04.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.sonicteam.com/sonicx/",
     "begin": "2003-04-05T23:30:00.000Z",
     "end": "2004-03-28T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "bilibili",
         "id": "1982",
-        "begin": "2003-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-05T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7lnt1",
-        "begin": "2018-10-13T16:00:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-13T16:00:26.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-osaka.co.jp/ip/digicharat/",
     "begin": "2003-04-06T00:30:00.000Z",
     "end": "2004-03-28T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,31 +59,15 @@
     "officialSite": "http://www.wonderfarm.co.jp/wandaba/",
     "begin": "2003-04-07T15:05:00.000Z",
     "end": "2003-06-23T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JGZia4EiauHlyicPaU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "104176"
-      },
-      {
-        "site": "bilibili",
-        "id": "1981",
-        "begin": "2003-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -112,17 +84,11 @@
     "officialSite": "http://web.archive.org/web/*/http://www.gekkanmagazine.com/dearboys_anime/",
     "begin": "2003-04-07T16:00:00.000Z",
     "end": "2003-09-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mdOtK5P5aacKiaPA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -131,12 +97,7 @@
       {
         "site": "bilibili",
         "id": "1957",
-        "begin": "2003-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -152,17 +113,11 @@
     "officialSite": "http://www.jvcmusic.co.jp/flyingdog/last-exile/",
     "begin": "2003-04-07T16:30:00.000Z",
     "end": "2003-09-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MnxIxia6UBEKlI4s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -171,22 +126,12 @@
       {
         "site": "nicovideo",
         "id": "lastexile",
-        "begin": "2011-11-18T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-18T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2014",
-        "begin": "2003-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -205,17 +150,11 @@
     "officialSite": "http://www.vap.co.jp/airmaster/",
     "begin": "2003-04-01T16:18:00.000Z",
     "end": "2003-09-30T16:23:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NwH8euJIuPZZ1z8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -235,17 +174,11 @@
     "officialSite": "http://www.starchild.co.jp/special/stellvia/",
     "begin": "2003-04-02T16:00:00.000Z",
     "end": "2003-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iaKKdG4PpWZf6eOA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -254,22 +187,12 @@
       {
         "site": "nicovideo",
         "id": "stellvia",
-        "begin": "2013-12-27T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-27T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1985",
-        "begin": "2003-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -285,21 +208,10 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/gadguard/",
     "begin": "2003-04-16T17:58:00.000Z",
     "end": "2004-03-05T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "10748"
-      },
-      {
-        "site": "bilibili",
-        "id": "1979",
-        "begin": "2003-04-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -315,17 +227,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/TEXHNOLYZE/",
     "begin": "2003-04-16T18:28:00.000Z",
     "end": "2003-09-24T19:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "c76JB2icVRYPmZMw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -334,12 +240,7 @@
       {
         "site": "bilibili",
         "id": "1984",
-        "begin": "2003-04-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-15T16:00:00.000Z"
       }
     ]
   },
@@ -355,17 +256,11 @@
     "officialSite": "http://www.bestack.co.jp/narue/",
     "begin": "2003-04-12T16:15:00.000Z",
     "end": "2003-06-28T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9D0Hhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -385,7 +280,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/loki/",
     "begin": "2003-04-05T00:30:00.000Z",
     "end": "2003-09-26T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -405,31 +299,15 @@
     "officialSite": "http://web.archive.org/*/www.tv-tokyo.co.jp/anime/es/main_index.html",
     "begin": "2003-04-01T09:00:00.000Z",
     "end": "2003-09-23T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tvvFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "35382"
-      },
-      {
-        "site": "bilibili",
-        "id": "5179",
-        "begin": "2003-03-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -445,27 +323,16 @@
     "officialSite": "http://www.jvcmusic.co.jp/m-serve/tv/dn_angel/",
     "begin": "2003-04-03T09:30:00.000Z",
     "end": "2003-09-25T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "03RPzTWbC0msKpI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/u4f89xlbq16zfjy",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -474,32 +341,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhbpezl",
-        "begin": "2017-11-30T16:01:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-30T16:01:14.000Z"
       },
       {
         "site": "bilibili",
         "id": "2012",
-        "begin": "2003-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-02T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "14965",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -515,17 +367,11 @@
     "officialSite": "http://www.gonzo.co.jp/archives/kaleido-star/",
     "begin": "2003-04-03T08:25:00.000Z",
     "end": "2004-09-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qpFs6lK4KGbJR68",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -534,32 +380,17 @@
       {
         "site": "bilibili",
         "id": "1995",
-        "begin": "2003-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-02T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "29567",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "kaleido-star",
-        "begin": "2019-02-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-04T15:00:00.000Z"
       }
     ]
   },
@@ -575,17 +406,11 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-aichi.co.jp/pichi/",
     "begin": "2003-04-04T23:00:00.000Z",
     "end": "2004-03-26T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "71QvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -594,12 +419,7 @@
       {
         "site": "bilibili",
         "id": "1875",
-        "begin": "2003-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -615,17 +435,11 @@
     "officialSite": "http://www.obkikaku.com/human/",
     "begin": "2003-04-05T15:55:00.000Z",
     "end": "2003-06-28T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Y865N58FdbMWlPw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -645,7 +459,6 @@
     "officialSite": "http://www.sunrise-anime.jp/sunrise-inc/works/detail.php?cid=142",
     "begin": "2003-04-04T22:30:00.000Z",
     "end": "2004-03-26T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -665,7 +478,6 @@
     "officialSite": "http://web.archive.org/web/*/www.nhk.or.jp/anime/alacarte/zentoronix.html",
     "begin": "2003-04-04T23:06:00.000Z",
     "end": "2003-09-26T23:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -685,7 +497,6 @@
     "officialSite": "http://web.archive.org/web/*/http://www.tv-tokyo.co.jp/anime/pluster/",
     "begin": "2003-04-03T09:00:00.000Z",
     "end": "2004-03-25T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -694,12 +505,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrifu0m1",
-        "begin": "2013-08-06T06:33:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-06T06:33:06.000Z"
       }
     ]
   },
@@ -715,7 +521,6 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-tokyo.co.jp/anime/firestorm/main_index.html",
     "begin": "2003-04-06T00:00:00.000Z",
     "end": "2003-09-28T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -735,17 +540,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/GB/",
     "begin": "2003-04-06T00:00:00.000Z",
     "end": "2006-03-26T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb14at",
-        "begin": "2015-08-14T17:07:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:07:21.000Z"
       },
       {
         "site": "bangumi",
@@ -754,12 +553,7 @@
       {
         "site": "nicovideo",
         "id": "tv-GB",
-        "begin": "2017-05-29T11:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-05-29T11:30:00.000Z"
       }
     ]
   },
@@ -775,17 +569,11 @@
     "officialSite": "http://astroboy.jp/c/009/",
     "begin": "2003-04-06T00:30:00.000Z",
     "end": "2004-03-28T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1byYFn7kVJL1c9s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -794,12 +582,7 @@
       {
         "site": "bilibili",
         "id": "2450",
-        "begin": "2003-04-06T00:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-06T00:30:00.000Z"
       }
     ]
   },
@@ -815,17 +598,11 @@
     "officialSite": "http://web.archive.org/web/*/www.sutepri.com/",
     "begin": "2003-04-08T09:00:00.000Z",
     "end": "2003-10-07T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BzMOjPRayghr6VE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -834,22 +611,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh7sqil",
-        "begin": "2017-06-14T16:19:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T16:19:17.000Z"
       },
       {
         "site": "bilibili",
         "id": "3414",
-        "begin": "2003-04-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-07T16:00:01.000Z"
       }
     ]
   },
@@ -865,7 +632,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/archive/croket/index.html",
     "begin": "2003-04-07T09:30:00.000Z",
     "end": "2005-03-28T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -885,17 +651,11 @@
     "officialSite": "http://www.tbs.co.jp/tantei-q/",
     "begin": "2003-04-15T09:55:00.000Z",
     "end": "2004-03-20T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qphj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -904,12 +664,7 @@
       {
         "site": "bilibili",
         "id": "5158",
-        "begin": "2003-04-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-14T16:00:01.000Z"
       }
     ]
   },
@@ -925,17 +680,11 @@
     "officialSite": "http://www.kinonotabi.com/",
     "begin": "2003-04-08T03:00:00.000Z",
     "end": "2003-07-08T04:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "L2Fb2UGnF1W4Np4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -944,22 +693,12 @@
       {
         "site": "nicovideo",
         "id": "kinonotabi01",
-        "begin": "2017-08-19T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-19T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2013",
-        "begin": "2003-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -975,41 +714,20 @@
     "officialSite": "",
     "begin": "2003-04-14T16:00:00.000Z",
     "end": "2003-07-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dcSicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "6/6ozal9rvwxpouvd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "36484"
-      },
-      {
-        "site": "bilibili",
-        "id": "1973",
-        "begin": "2003-04-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1025,27 +743,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2003-04-19T16:00:00.000Z",
     "end": "2003-04-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/6dadff58ef87d703.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/6dadff58ef87d703.html"
       },
       {
         "site": "bangumi",
@@ -1054,22 +761,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3882",
-        "begin": "2003-04-18T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "11632",
+        "begin": "2003-04-18T16:00:01.000Z"
       }
     ]
   },
@@ -1085,17 +782,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2003-04-19T16:00:00.000Z",
     "end": "2003-04-19T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -1104,22 +795,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1135,7 +816,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2003-04-07T08:35:00.000Z",
     "end": "2003-07-25T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1155,7 +835,6 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/rahxephon/movie/index.html",
     "begin": "2003-04-19T16:00:00.000Z",
     "end": "2003-04-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1164,22 +843,7 @@
       {
         "site": "nicovideo",
         "id": "rahxephon-m",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3959",
-        "begin": "2003-04-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1195,7 +859,6 @@
     "officialSite": "",
     "begin": "2003-04-18T16:00:00.000Z",
     "end": "2003-04-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1204,12 +867,7 @@
       {
         "site": "pptv",
         "id": "pEUvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2003/05.json
+++ b/data/items/2003/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.wonderfarm.co.jp/s-beast/",
     "begin": "2003-05-08T15:00:00.000Z",
     "end": "2003-06-12T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "g6iaTEXnfT43wbtY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "letv",
         "id": "10004746",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1975",
-        "begin": "2003-05-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-05-07T16:00:00.000Z"
       }
     ]
   },
@@ -64,17 +48,11 @@
     "officialSite": "http://www.starchild.co.jp/special/urumani/",
     "begin": "2003-05-20T13:00:00.000Z",
     "end": "2003-11-11T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wHBLyTGXB0WoJo4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -83,12 +61,7 @@
       {
         "site": "letv",
         "id": "19106",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -104,7 +77,6 @@
     "officialSite": "http://www.leiji-matsumoto.ne.jp/ss99/",
     "begin": "2003-05-08T01:30:00.000Z",
     "end": "2003-07-31T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -124,17 +96,11 @@
     "officialSite": "",
     "begin": "2003-05-25T16:00:00.000Z",
     "end": "2004-02-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rN6qKJD2ZqQHhe0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2003/06.json
+++ b/data/items/2003/06.json
@@ -13,31 +13,15 @@
     "officialSite": "http://cinderellaboy.at-x.com/",
     "begin": "2003-06-21T01:30:00.000Z",
     "end": "2003-09-13T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "bqGbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "47145"
-      },
-      {
-        "site": "bilibili",
-        "id": "2007",
-        "begin": "2003-06-20T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -53,17 +37,11 @@
     "officialSite": "http://www.jcstaff.co.jp/sho-sai/gpm-shokai/gpm-index.htm",
     "begin": "2003-06-04T15:00:00.000Z",
     "end": "2003-04-23T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kKCbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2003/07.json
+++ b/data/items/2003/07.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.kids-station.com/minisite/narutaru/",
     "begin": "2003-07-07T15:00:00.000Z",
     "end": "2003-09-29T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1xrmZMwyouBDwSk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -31,12 +25,7 @@
       {
         "site": "bilibili",
         "id": "3050",
-        "begin": "2003-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-06T16:00:00.000Z"
       }
     ]
   },
@@ -52,7 +41,6 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/ikki/",
     "begin": "2003-07-30T02:30:00.000Z",
     "end": "2003-10-22T03:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -75,7 +63,6 @@
     "officialSite": "http://www.ponycanyon.co.jp/greengreen/",
     "begin": "2003-07-14T15:05:00.000Z",
     "end": "2003-09-29T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -84,12 +71,7 @@
       {
         "site": "bilibili",
         "id": "2006",
-        "begin": "2003-07-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-14T16:00:00.000Z"
       }
     ]
   },
@@ -108,27 +90,16 @@
     "officialSite": "http://www.hatsunejima.com/dc/",
     "begin": "2003-07-05T15:45:00.000Z",
     "end": "2003-12-27T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hLOODHTaSojradE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "0/0e5vbeoe011lsdk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -137,22 +108,12 @@
       {
         "site": "nicovideo",
         "id": "dc",
-        "begin": "2012-07-11T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-11T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "656",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -171,17 +132,11 @@
     "officialSite": "http://www.d-eve.net/story/1st_story/",
     "begin": "2003-07-02T01:00:00.000Z",
     "end": "2003-09-24T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fMfCQKgOfrwfnQU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -190,12 +145,7 @@
       {
         "site": "bilibili",
         "id": "5146",
-        "begin": "2004-01-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-01-06T16:00:01.000Z"
       }
     ]
   },
@@ -211,7 +161,6 @@
     "officialSite": "http://www.tms-e.com/library/on_air_back/rumiko/",
     "begin": "2003-07-05T15:55:00.000Z",
     "end": "2003-09-27T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -220,12 +169,7 @@
       {
         "site": "bilibili",
         "id": "1970",
-        "begin": "2003-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -241,17 +185,11 @@
     "officialSite": "",
     "begin": "2003-07-06T16:00:00.000Z",
     "end": "2003-09-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jsG7OaEHd7UYlv4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -271,7 +209,6 @@
     "officialSite": "http://www.mediaworks.co.jp/d_original/cosmos/",
     "begin": "2003-07-12T16:15:00.000Z",
     "end": "2003-09-27T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -280,12 +217,7 @@
       {
         "site": "bilibili",
         "id": "3342",
-        "begin": "2003-07-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-05T16:00:01.000Z"
       }
     ]
   },
@@ -301,27 +233,16 @@
     "officialSite": "http://www.please-please.jp/one2/",
     "begin": "2003-07-15T09:30:00.000Z",
     "end": "2008-08-23T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yW5Z1ziblFVO2NJw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9aqgd",
-        "begin": "2017-02-28T16:01:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-28T16:01:05.000Z"
       },
       {
         "site": "bangumi",
@@ -330,12 +251,7 @@
       {
         "site": "bilibili",
         "id": "1971",
-        "begin": "2003-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-14T16:00:00.000Z"
       }
     ]
   },
@@ -351,7 +267,6 @@
     "officialSite": "http://www.bandaivisual.co.jp/popotan/",
     "begin": "2003-07-17T15:30:00.000Z",
     "end": "2003-10-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -372,27 +287,16 @@
     "officialSite": "http://www.vap.co.jp/nasu/main.html",
     "begin": "2003-07-26T16:00:00.000Z",
     "end": "2003-07-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4kompAxy4iaCDAWk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "p/phdveh4l16eaonj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -401,12 +305,7 @@
       {
         "site": "bilibili",
         "id": "2622",
-        "begin": "2003-07-25T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-25T16:00:00.000Z"
       }
     ]
   },
@@ -422,7 +321,6 @@
     "officialSite": "http://c-you.jp/momoko/",
     "begin": "2003-07-23T16:00:00.000Z",
     "end": "2003-07-23T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -431,12 +329,7 @@
       {
         "site": "bilibili",
         "id": "5127",
-        "begin": "2003-07-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-22T16:00:01.000Z"
       }
     ]
   },
@@ -453,17 +346,11 @@
     "officialSite": "http://c-you.jp/momoko/",
     "begin": "2003-07-24T16:00:00.000Z",
     "end": "2004-05-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgincbp",
-        "begin": "2014-09-12T06:27:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:27:35.000Z"
       },
       {
         "site": "bangumi",
@@ -483,27 +370,16 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2003-07-19T16:00:00.000Z",
     "end": "2003-07-19T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -512,22 +388,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5754",
-        "begin": "2003-07-18T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-18T16:00:01.000Z"
       }
     ]
   },
@@ -543,17 +409,11 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2003-07-19T17:10:00.000Z",
     "end": "2003-07-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",

--- a/data/items/2003/08.json
+++ b/data/items/2003/08.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/fullmeta/",
     "begin": "2003-08-25T17:28:00.000Z",
     "end": "2003-11-17T18:23:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "291729",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "qq",
         "id": "f/ftkqogti5jszz3n",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://www.ytv.co.jp/massugu03/",
     "begin": "2003-08-18T00:55:00.000Z",
     "end": "2003-08-21T01:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,7 +59,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2003-08-01T16:00:00.000Z",
     "end": "2003-08-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,32 +67,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3952",
-        "begin": "2003-07-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-07-31T16:00:01.000Z"
       }
     ]
   },
@@ -121,7 +93,6 @@
     "officialSite": "",
     "begin": "2003-08-22T16:00:00.000Z",
     "end": "2003-08-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,22 +101,12 @@
       {
         "site": "pptv",
         "id": "CjsGhOxSwgBj4Uk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3969",
-        "begin": "2003-08-21T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-08-21T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2003/09.json
+++ b/data/items/2003/09.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.nippon-animation.co.jp/na/papuwa/",
     "begin": "2003-09-30T09:00:00.000Z",
     "end": "2004-03-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "S4VicicWXLO3ncWsI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,17 +35,11 @@
     "officialSite": "http://www.enterbrain.co.jp/game_site/tls/tlss/top.htm",
     "begin": "2003-09-26T16:00:00.000Z",
     "end": "2004-04-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GVIurBR66iaiaLCXE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,7 +59,6 @@
     "officialSite": "",
     "begin": "2003-09-05T16:00:00.000Z",
     "end": "2003-09-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,12 +67,7 @@
       {
         "site": "pptv",
         "id": "bpJu7FS6KmjLSbE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2003/10.json
+++ b/data/items/2003/10.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.jcstaff.co.jp/sho-sai/aie-shokai/aie-index.htm",
     "begin": "2003-10-12T16:00:00.000Z",
     "end": "2003-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JXNNyzOZCUeqKJA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "e/elvvgfnye3nmber",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,22 +29,12 @@
       {
         "site": "nicovideo",
         "id": "aiyoriaoshi-enishi_",
-        "begin": "2012-08-24T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-24T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2019",
-        "begin": "2003-10-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-10T16:00:00.000Z"
       }
     ]
   },
@@ -71,17 +50,11 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/rodthetv/",
     "begin": "2003-10-15T17:58:00.000Z",
     "end": "2004-03-01T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icUo1sxuB8SibSEHg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -90,12 +63,7 @@
       {
         "site": "bilibili",
         "id": "1967",
-        "begin": "2003-08-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-08-31T16:00:00.000Z"
       }
     ]
   },
@@ -111,27 +79,16 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/hagaren/",
     "begin": "2003-10-04T09:00:00.000Z",
     "end": "2004-10-02T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "o4149l7ENHLVU7s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "17623",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,22 +97,12 @@
       {
         "site": "nicovideo",
         "id": "hagaren",
-        "begin": "2015-04-03T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70204980",
-        "begin": "2018-01-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-01T08:00:00.000Z"
       }
     ]
   },
@@ -171,27 +118,16 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/tsukihime/",
     "begin": "2003-10-09T15:30:00.000Z",
     "end": "2003-12-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Q4139V3DM3HUUro",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/wxc75mxvz7m2dxu",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -200,12 +136,7 @@
       {
         "site": "bilibili",
         "id": "1983",
-        "begin": "2003-10-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-08T16:00:00.000Z"
       }
     ]
   },
@@ -222,7 +153,6 @@
     "officialSite": "http://www.kiminozo.com/",
     "begin": "2003-10-04T15:40:00.000Z",
     "end": "2004-01-05T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -231,12 +161,7 @@
       {
         "site": "letv",
         "id": "17519",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -252,17 +177,11 @@
     "officialSite": "http://www.bandaivisual.co.jp/avenger/",
     "begin": "2003-10-01T16:00:00.000Z",
     "end": "2003-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rZpl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -282,27 +201,16 @@
     "officialSite": "http://www.wowow.co.jp/drama_anime/maburaho/",
     "begin": "2003-10-14T09:00:00.000Z",
     "end": "2004-04-06T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LxznZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "13894",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -328,17 +236,11 @@
     "officialSite": "http://www.planet-es.net/",
     "begin": "2003-10-03T23:05:00.000Z",
     "end": "2004-04-16T23:36:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DDwHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -347,12 +249,7 @@
       {
         "site": "bilibili",
         "id": "1996",
-        "begin": "2003-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -368,17 +265,11 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_2000/tv_064.html",
     "begin": "2003-10-02T09:30:00.000Z",
     "end": "2004-03-25T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "l7aRD3fdTYvubNQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -387,22 +278,12 @@
       {
         "site": "nicovideo",
         "id": "saiyuki_r",
-        "begin": "2017-01-10T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2145",
-        "begin": "2003-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -420,17 +301,11 @@
     "officialSite": "http://www.jvcmusic.co.jp/m-serve/tv/gungrave/",
     "begin": "2003-10-06T16:30:00.000Z",
     "end": "2004-03-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dMXAPqYMfLodmwM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -439,12 +314,7 @@
       {
         "site": "bilibili",
         "id": "1994",
-        "begin": "2003-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -460,7 +330,6 @@
     "officialSite": "http://www.tokinoyu.net/",
     "begin": "2003-10-04T16:15:00.000Z",
     "end": "2003-12-20T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -480,7 +349,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/f-zero/main_index.html",
     "begin": "2003-10-07T09:30:00.000Z",
     "end": "2004-09-28T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -500,17 +368,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cromartie/main_index.html",
     "begin": "2003-10-02T16:00:00.000Z",
     "end": "2004-03-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibUZBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -519,12 +381,7 @@
       {
         "site": "bilibili",
         "id": "5177",
-        "begin": "2003-10-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-01T16:00:01.000Z"
       }
     ]
   },
@@ -544,27 +401,16 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/gsgirl/",
     "begin": "2003-10-08T18:48:00.000Z",
     "end": "2004-02-18T18:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Fj0Ihu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "e/edwoou1vt6764cb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -573,22 +419,7 @@
       {
         "site": "netflix",
         "id": "70204989",
-        "begin": "2018-01-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1264",
-        "begin": "2003-10-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-01T08:00:00.000Z"
       }
     ]
   },
@@ -604,7 +435,6 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-tokyo.co.jp/anime/popolocrois/",
     "begin": "2003-10-05T00:00:00.000Z",
     "end": "2004-03-28T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -624,17 +454,11 @@
     "officialSite": "http://www.gonzo.co.jp/works/0301.html",
     "begin": "2003-10-07T17:12:00.000Z",
     "end": "2004-03-23T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GCwXlf1j0xF08lo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -654,27 +478,16 @@
     "officialSite": "http://www.tms-e.com/library/on_air_back/rumiko02/",
     "begin": "2003-10-04T15:55:00.000Z",
     "end": "2003-12-20T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "K2Vf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "m/m49iooz6xjgnvjr",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -683,12 +496,7 @@
       {
         "site": "letv",
         "id": "9857",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -704,7 +512,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/rockmanexe_axess/main_index.html",
     "begin": "2003-10-03T23:30:00.000Z",
     "end": "2004-09-25T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -724,17 +531,11 @@
     "officialSite": "http://www.planet-e.co.jp/galaxy_railways/",
     "begin": "2003-10-04T15:00:00.000Z",
     "end": "2004-06-23T18:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JQjzcdkicrib1QzjY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -743,12 +544,7 @@
       {
         "site": "bilibili",
         "id": "1312",
-        "begin": "2003-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -766,17 +562,11 @@
     "officialSite": "http://www3.nhk.or.jp/anime/survive/",
     "begin": "2003-10-16T10:30:00.000Z",
     "end": "2004-10-28T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Tf3IRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -785,12 +575,7 @@
       {
         "site": "bilibili",
         "id": "2662",
-        "begin": "2003-10-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-15T16:00:00.000Z"
       }
     ]
   },
@@ -806,17 +591,11 @@
     "officialSite": "http://www.imagicatv.jp/content/godannar/",
     "begin": "2003-10-01T01:00:00.000Z",
     "end": "2003-12-24T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yXlEwiaqQAD6hH4c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -836,17 +615,11 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/gilgamesh/",
     "begin": "2003-10-11T18:58:00.000Z",
     "end": "2004-03-20T19:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NwPibfORKuvhb2UE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -854,13 +627,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25368",
-        "begin": "2003-10-10T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "125872",
+        "begin": "2003-10-10T16:00:01.000Z"
       }
     ]
   },
@@ -876,31 +644,15 @@
     "officialSite": "http://web.archive.org/web/*/www.avexmovie.jp/lineup/yamibou/yamibou.html",
     "begin": "2003-10-08T15:05:00.000Z",
     "end": "2004-01-07T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DzQPjfVbywls6lI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1906"
-      },
-      {
-        "site": "bilibili",
-        "id": "1961",
-        "begin": "2003-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -916,17 +668,11 @@
     "officialSite": "http://www.hicbc.com/tv/kousetsu/main.htm",
     "begin": "2003-10-19T17:20:00.000Z",
     "end": "2004-01-11T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "e8m0MpoAcK4Rjicc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -935,12 +681,7 @@
       {
         "site": "bilibili",
         "id": "1964",
-        "begin": "2003-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -956,7 +697,6 @@
     "officialSite": "http://www.so-nanda.net/",
     "begin": "2003-10-04T22:00:00.000Z",
     "end": "2004-03-27T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -976,7 +716,6 @@
     "officialSite": "http://www.vap.co.jp/herlock/",
     "begin": "2003-10-07T16:23:00.000Z",
     "end": "2003-12-30T18:09:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -996,17 +735,11 @@
     "officialSite": "http://www.enterbrain.co.jp/jp/p_pickup/bindume/bin.html",
     "begin": "2003-10-04T01:00:00.000Z",
     "end": "2003-12-27T01:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3G9a2ECmFlS3NZ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1015,12 +748,7 @@
       {
         "site": "bilibili",
         "id": "2008",
-        "begin": "2003-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -1036,7 +764,6 @@
     "officialSite": "http://www.anime-int.com/works/bps/tv1/",
     "begin": "2003-10-03T15:00:00.000Z",
     "end": "2004-01-03T15:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1045,12 +772,7 @@
       {
         "site": "bilibili",
         "id": "1966",
-        "begin": "2003-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-02T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2003/11.json
+++ b/data/items/2003/11.json
@@ -13,7 +13,6 @@
     "officialSite": "http://www3.nhk.or.jp/anime/spica/",
     "begin": "2003-11-01T00:00:00.000Z",
     "end": "2004-03-27T00:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -22,22 +21,12 @@
       {
         "site": "pptv",
         "id": "Sic3IRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3093",
-        "begin": "2003-10-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-10-31T16:00:00.000Z"
       }
     ]
   },
@@ -53,17 +42,11 @@
     "officialSite": "http://www.bo-bobo.com/",
     "begin": "2003-11-08T10:28:00.000Z",
     "end": "2005-10-29T02:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VPnEQqoQgL4hnwc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -72,22 +55,7 @@
       {
         "site": "nicovideo",
         "id": "bobobo_bo_bo_bobo",
-        "begin": "2018-04-22T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5153",
-        "begin": "2003-11-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-22T03:00:00.000Z"
       }
     ]
   },
@@ -106,17 +74,11 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/chrono/",
     "begin": "2003-11-24T18:08:00.000Z",
     "end": "2004-06-09T18:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uZpl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -139,27 +101,16 @@
     "officialSite": "http://www.sonypictures.jp/archive/movie/worldcinema/tgf/",
     "begin": "2003-11-08T16:00:00.000Z",
     "end": "2003-11-08T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "c/cna8dlk8kzztn41",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "157295",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -168,12 +119,7 @@
       {
         "site": "bilibili",
         "id": "2597",
-        "begin": "2003-11-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-11-07T16:00:00.000Z"
       }
     ]
   },
@@ -189,7 +135,6 @@
     "officialSite": "",
     "begin": "2003-11-27T16:00:00.000Z",
     "end": "2004-01-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -198,12 +143,7 @@
       {
         "site": "nicovideo",
         "id": "ch61035",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2003/12.json
+++ b/data/items/2003/12.json
@@ -14,37 +14,21 @@
     "officialSite": "http://www.inuyasha-movie.com/",
     "begin": "2003-12-20T16:00:00.000Z",
     "end": "2003-12-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "j/jouk3zs06zpvsx1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "46371",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "56MQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -53,12 +37,7 @@
       {
         "site": "netflix",
         "id": "70036200",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   },
@@ -74,17 +53,11 @@
     "officialSite": "http://hareguu.bandaivisual.co.jp/",
     "begin": "2003-12-21T16:00:00.000Z",
     "end": "2004-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9VgjoQlv3x2AicmY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -93,22 +66,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgj957t",
-        "begin": "2014-04-09T23:31:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:31:05.000Z"
       },
       {
         "site": "bilibili",
         "id": "2093",
-        "begin": "2003-12-20T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-12-20T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2004/01.json
+++ b/data/items/2004/01.json
@@ -11,41 +11,20 @@
     "officialSite": "http://www.gokigenyou.com/",
     "begin": "2004-01-07T16:00:00.000Z",
     "end": "2004-03-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KhnkYsowoN5Bvyc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4214"
       },
       {
-        "site": "bilibili",
-        "id": "1096",
-        "begin": "2004-01-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "19255",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -62,31 +41,15 @@
     "officialSite": "http://anime.powerbean.jp/yumeria/",
     "begin": "2004-01-08T15:30:00.000Z",
     "end": "2004-03-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aqSgHobsXJr9eibM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3328"
-      },
-      {
-        "site": "bilibili",
-        "id": "5484",
-        "begin": "2004-01-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -103,31 +66,15 @@
     "officialSite": "http://web.archive.org/web/*/http://www.kita-he.com/",
     "begin": "2004-01-20T01:00:00.000Z",
     "end": "2004-04-06T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1BbycNgibruxPzTU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1977"
-      },
-      {
-        "site": "bilibili",
-        "id": "1912",
-        "begin": "2004-01-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -143,7 +90,6 @@
     "officialSite": "http://www.d-eve.net/",
     "begin": "2004-01-02T15:30:00.000Z",
     "end": "2004-03-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -163,17 +109,11 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/gravion/",
     "begin": "2004-01-08T15:15:00.000Z",
     "end": "2004-03-25T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FlkjoQlv3x2AicmY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -182,12 +122,7 @@
       {
         "site": "bilibili",
         "id": "1949",
-        "begin": "2004-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -203,31 +138,15 @@
     "officialSite": "http://www.anime-int.com/works/burn-up/scramble/",
     "begin": "2004-01-12T16:25:00.000Z",
     "end": "2004-03-29T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NQH8euJIuPZZ1z8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "29278"
-      },
-      {
-        "site": "bilibili",
-        "id": "2286",
-        "begin": "1997-12-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -243,21 +162,10 @@
     "officialSite": "http://www.thedaphne.jp/",
     "begin": "2004-01-16T15:30:00.000Z",
     "end": "2004-07-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "2274"
-      },
-      {
-        "site": "bilibili",
-        "id": "1916",
-        "begin": "2004-01-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -273,17 +181,11 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_2000/tv_065.html",
     "begin": "2004-01-04T14:30:00.000Z",
     "end": "2004-03-28T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FyQfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -292,22 +194,7 @@
       {
         "site": "nicovideo",
         "id": "mezzo",
-        "begin": "2014-03-21T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5145",
-        "begin": "2004-01-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-21T03:00:00.000Z"
       }
     ]
   },
@@ -324,27 +211,11 @@
     "officialSite": "http://www.takaratomy.co.jp/products/superlink/",
     "begin": "2004-01-09T09:00:00.000Z",
     "end": "2004-12-24T09:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "49142",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "48644",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -353,12 +224,7 @@
       {
         "site": "qq",
         "id": "2/2kyavecmhlds8qx",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -374,7 +240,6 @@
     "officialSite": "http://www.vap.co.jp/monkey/",
     "begin": "2004-01-10T15:55:00.000Z",
     "end": "2004-06-26T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -394,7 +259,6 @@
     "officialSite": "http://web.archive.org/web/*/www.sdgundamforce.com/",
     "begin": "2004-01-07T09:00:00.000Z",
     "end": "2004-12-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -414,17 +278,11 @@
     "officialSite": "http://www.starchild.co.jp/special/j2/",
     "begin": "2004-01-07T16:30:00.000Z",
     "end": "2004-03-31T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HC0Ylv5k1BJ181s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -433,12 +291,7 @@
       {
         "site": "bilibili",
         "id": "1947",
-        "begin": "2004-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -454,21 +307,10 @@
     "officialSite": "http://www.nifty.com/moe/cosprayers/index.html",
     "begin": "2004-01-12T15:05:00.000Z",
     "end": "2004-03-01T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "35981"
-      },
-      {
-        "site": "bilibili",
-        "id": "5152",
-        "begin": "2004-01-11T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -484,17 +326,11 @@
     "officialSite": "http://www.ntv.co.jp/a-gokusen/",
     "begin": "2004-01-06T16:23:00.000Z",
     "end": "2004-03-30T17:49:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "U9ibqKJD2ZqQHhe0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -503,12 +339,7 @@
       {
         "site": "bilibili",
         "id": "1913",
-        "begin": "2004-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -527,27 +358,16 @@
     "officialSite": "http://mv.avex.jp/area88/",
     "begin": "2004-01-08T17:12:00.000Z",
     "end": "2004-03-25T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dteyMJjibbqwPjfU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "q/q84tu73o73en361",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -567,7 +387,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/bedaman/",
     "begin": "2004-01-05T09:00:00.000Z",
     "end": "2004-12-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -587,17 +406,11 @@
     "officialSite": "http://www.production-ig.co.jp/contents/works_sp/1120_/index.html",
     "begin": "2004-01-01T16:59:00.000Z",
     "end": "2005-01-08T17:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "46118",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -606,22 +419,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1818d",
-        "begin": "2017-12-11T07:45:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-11T07:45:39.000Z"
       },
       {
         "site": "bilibili",
         "id": "1565",
-        "begin": "2003-12-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2003-12-31T16:00:00.000Z"
       }
     ]
   },
@@ -638,17 +441,11 @@
     "officialSite": "http://asahi.co.jp/precure/",
     "begin": "2004-01-31T23:30:00.000Z",
     "end": "2005-01-30T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1261",
-        "begin": "2015-08-19T01:34:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-19T01:34:40.000Z"
       },
       {
         "site": "bangumi",
@@ -657,12 +454,7 @@
       {
         "site": "nicovideo",
         "id": "futariha-precure",
-        "begin": "2018-10-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-12T15:00:00.000Z"
       }
     ]
   },
@@ -678,7 +470,6 @@
     "officialSite": "http://www.zorori.jp/",
     "begin": "2004-01-31T22:00:00.000Z",
     "end": "2005-02-05T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -687,12 +478,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh64zjt",
-        "begin": "2018-07-26T16:03:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-26T16:03:05.000Z"
       }
     ]
   },
@@ -708,7 +494,6 @@
     "officialSite": "",
     "begin": "2004-01-21T16:00:00.000Z",
     "end": "2004-04-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -717,22 +502,12 @@
       {
         "site": "pptv",
         "id": "h8mzMZnicb60QjvY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "jing_seventh_heaven",
-        "begin": "2018-05-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-16T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2004/02.json
+++ b/data/items/2004/02.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.mousou.tv/",
     "begin": "2004-02-02T15:05:00.000Z",
     "end": "2004-05-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DCEcmgJo2BZ5918",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1917",
-        "begin": "2004-02-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-02-01T16:00:00.000Z"
       }
     ]
   },
@@ -51,31 +40,15 @@
     "officialSite": "http://www.yu-go.jp/",
     "begin": "2004-02-24T15:00:00.000Z",
     "end": "2004-05-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uIeCAGjOPnzfXcU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3305"
-      },
-      {
-        "site": "bilibili",
-        "id": "1933",
-        "begin": "2004-02-23T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -91,17 +64,11 @@
     "officialSite": "",
     "begin": "2004-02-21T16:00:00.000Z",
     "end": "2004-02-21T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xayIBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -121,7 +88,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2004_seiya/index.html",
     "begin": "2004-02-14T16:00:00.000Z",
     "end": "2004-02-14T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,22 +96,12 @@
       {
         "site": "nicovideo",
         "id": "saint_seiya",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4um9",
-        "begin": "2016-02-16T07:22:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-16T07:22:34.000Z"
       }
     ]
   }

--- a/data/items/2004/03.json
+++ b/data/items/2004/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.nifty.com/moe/hit/index.html",
     "begin": "2004-03-08T15:05:00.000Z",
     "end": "2004-04-26T15:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://www.ytv.co.jp/massugu/index.html",
     "begin": "2004-03-27T02:00:00.000Z",
     "end": "2004-04-01T02:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,17 +49,11 @@
     "officialSite": "http://www.gundam-seed.net/",
     "begin": "2004-03-22T01:30:00.000Z",
     "end": "2004-10-22T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HzgDgelPvic1g3kY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -81,41 +73,20 @@
     "officialSite": "http://www.shall-luck.co.jp/interlude",
     "begin": "2004-03-25T16:00:00.000Z",
     "end": "2004-08-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "12Rf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bwjz1tr8hgjt8yw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3498"
-      },
-      {
-        "site": "bilibili",
-        "id": "5943",
-        "begin": "2004-03-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -131,17 +102,11 @@
     "officialSite": "",
     "begin": "2004-03-06T16:00:00.000Z",
     "end": "2004-03-06T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "81022",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,32 +115,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2568",
-        "begin": "2004-03-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-03-05T16:00:00.000Z"
       }
     ]
   },
@@ -191,7 +141,6 @@
     "officialSite": "",
     "begin": "2004-03-03T16:00:00.000Z",
     "end": "2004-08-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -200,12 +149,7 @@
       {
         "site": "pptv",
         "id": "pH9KyDCWBkSnJY0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2004/04.json
+++ b/data/items/2004/04.json
@@ -7,7 +7,6 @@
     "officialSite": "http://www.tv-osaka.co.jp/marshmallow/index.html",
     "begin": "2004-04-04T00:30:00.000Z",
     "end": "2005-03-27T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -27,27 +26,16 @@
     "officialSite": "http://www.ragnarokonline.jp/",
     "begin": "2004-04-06T16:30:00.000Z",
     "end": "2004-09-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BSEcmgJo2BZ5918",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "q/q2vw7kszrhwwask",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -56,12 +44,7 @@
       {
         "site": "bilibili",
         "id": "1896",
-        "begin": "2004-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -77,17 +60,11 @@
     "officialSite": "http://www.tbs.co.jp/boukyaku/",
     "begin": "2004-04-06T17:59:00.000Z",
     "end": "2004-09-21T18:44:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "a8OibPKQKergbmQE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -96,12 +73,7 @@
       {
         "site": "bilibili",
         "id": "1900",
-        "begin": "2004-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -118,27 +90,16 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/konomini/",
     "begin": "2004-04-01T15:30:00.000Z",
     "end": "2004-06-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pOfhX8ctndsibvCQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "t/tk3anhnbwweipfm",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -158,17 +119,11 @@
     "officialSite": "http://web.archive.org/web/*/www.pugyuru.jp/",
     "begin": "2004-04-12T16:00:00.000Z",
     "end": "2004-07-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zgD8euJIuPZZ1z8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -188,27 +143,16 @@
     "officialSite": "http://www.tms-e.com/on_air/beibe/",
     "begin": "2004-04-03T10:00:00.000Z",
     "end": "2004-10-09T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uJ9591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "i/iz6m1djp4h2xrsa",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -217,22 +161,12 @@
       {
         "site": "letv",
         "id": "9279",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1905",
-        "begin": "2004-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -248,17 +182,11 @@
     "officialSite": "http://www3.nhk.or.jp/anime/hinotori/main.html",
     "begin": "2004-04-04T10:30:00.000Z",
     "end": "2004-06-27T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4CkTkflfzw1w7lY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -267,12 +195,7 @@
       {
         "site": "bilibili",
         "id": "1903",
-        "begin": "2004-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -288,7 +211,6 @@
     "officialSite": "http://www.panda-z.net/",
     "begin": "2004-04-11T22:30:00.000Z",
     "end": "2004-11-01T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -308,31 +230,15 @@
     "officialSite": "http://www.vap.co.jp/monster/",
     "begin": "2004-04-06T15:40:00.000Z",
     "end": "2005-09-27T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pibnTUbkfj80wrhY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1959"
-      },
-      {
-        "site": "bilibili",
-        "id": "1909",
-        "begin": "2004-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -348,27 +254,16 @@
     "officialSite": "http://pierrot.jp/archives/tv_list_2000/tv_067.html",
     "begin": "2004-04-03T15:30:00.000Z",
     "end": "2004-06-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qoJ9ib2PJOXfaWMA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "13932",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -391,7 +286,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/keroro/",
     "begin": "2004-04-03T01:00:00.000Z",
     "end": "2012-03-27T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -400,12 +294,7 @@
       {
         "site": "bilibili",
         "id": "103",
-        "begin": "2004-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -421,17 +310,11 @@
     "officialSite": "http://www.tfc-anime.net/tweeny-witches/index.html",
     "begin": "2004-04-09T09:20:00.000Z",
     "end": "2005-03-25T09:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icjMNiaicNZyQdq6FA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -451,7 +334,6 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/legendz/index.html",
     "begin": "2004-04-04T00:30:00.000Z",
     "end": "2005-03-27T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -460,12 +342,7 @@
       {
         "site": "bilibili",
         "id": "1907",
-        "begin": "2004-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -481,21 +358,10 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/hanaukyo/",
     "begin": "2004-04-04T15:00:00.000Z",
     "end": "2004-06-20T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "84547"
-      },
-      {
-        "site": "bilibili",
-        "id": "5143",
-        "begin": "2004-04-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -511,31 +377,15 @@
     "officialSite": "http://www.starchild.co.jp/special/sensei/",
     "begin": "2004-04-04T16:30:00.000Z",
     "end": "2004-06-27T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cb6JB2icVRYPmZMw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "22517"
-      },
-      {
-        "site": "bilibili",
-        "id": "1899",
-        "begin": "2004-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -551,17 +401,11 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/koikaze/",
     "begin": "2004-04-01T17:27:00.000Z",
     "end": "2004-06-17T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "8/87h71uq2p55brm3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -570,12 +414,7 @@
       {
         "site": "bilibili",
         "id": "1901",
-        "begin": "2004-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -591,31 +430,15 @@
     "officialSite": "http://www.avexmovie.jp/lineup/tenten/",
     "begin": "2004-04-01T17:57:00.000Z",
     "end": "2004-09-16T18:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "4371"
       },
       {
-        "site": "bilibili",
-        "id": "1923",
-        "begin": "2004-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "20755",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -631,7 +454,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/amdriver/main_index.html",
     "begin": "2004-04-05T09:30:00.000Z",
     "end": "2005-03-28T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -651,37 +473,21 @@
     "officialSite": "http://www.maru-ma.com/",
     "begin": "2004-04-03T00:00:00.000Z",
     "end": "2005-02-12T00:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XvHMSrIYiaMYppw8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "2/2pqukl3ql245jfw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "8356",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -701,17 +507,11 @@
     "officialSite": "http://www.imagicatv.jp/content/godannar/",
     "begin": "2004-04-06T16:05:00.000Z",
     "end": "2004-06-29T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1WVg3kasHFq9O6M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -720,12 +520,7 @@
       {
         "site": "bilibili",
         "id": "3985",
-        "begin": "2004-04-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-04T16:00:01.000Z"
       }
     ]
   },
@@ -741,17 +536,11 @@
     "officialSite": "http://www.maql.co.jp/special/shura/",
     "begin": "2004-04-06T09:00:00.000Z",
     "end": "2004-09-28T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9jsFgibtRwf9ia4Eg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -760,12 +549,7 @@
       {
         "site": "bilibili",
         "id": "1904",
-        "begin": "2004-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -781,7 +565,6 @@
     "officialSite": "http://web.archive.org/web/*/www.gantz.net/",
     "begin": "2004-04-12T17:43:00.000Z",
     "end": "2004-06-22T17:43:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -804,21 +587,10 @@
     "officialSite": "http://web.archive.org/web/*/www.baku-ten.com/TV/top.html",
     "begin": "2004-04-06T17:12:00.000Z",
     "end": "2004-09-21T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "4471"
-      },
-      {
-        "site": "bilibili",
-        "id": "1290",
-        "begin": "2004-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -834,7 +606,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/niku/",
     "begin": "2004-04-07T16:00:00.000Z",
     "end": "2004-06-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -854,21 +625,10 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/kenran/main_index.html",
     "begin": "2004-04-01T09:30:00.000Z",
     "end": "2004-09-23T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "2169"
-      },
-      {
-        "site": "bilibili",
-        "id": "1926",
-        "begin": "2004-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -884,17 +644,11 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-aichi.co.jp/pichi/index.html",
     "begin": "2004-04-02T23:00:00.000Z",
     "end": "2004-12-24T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8UZBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -914,17 +668,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/dandoh/main_index.html",
     "begin": "2004-04-03T00:30:00.000Z",
     "end": "2004-09-25T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "b9ynJY3zY6EEguo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -933,12 +681,7 @@
       {
         "site": "bilibili",
         "id": "5414",
-        "begin": "2004-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-02T16:00:01.000Z"
       }
     ]
   },
@@ -950,7 +693,6 @@
     "officialSite": "http://www.jagainukun.net/",
     "begin": "2004-04-03T22:00:00.000Z",
     "end": "2004-07-18T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -966,7 +708,6 @@
     "officialSite": "http://www.zukkoke.net/",
     "begin": "2004-04-04T00:00:00.000Z",
     "end": "2004-10-03T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -988,17 +729,11 @@
     "officialSite": "http://www.jvcmusic.co.jp/m-serve/madlax/",
     "begin": "2004-04-05T17:00:00.000Z",
     "end": "2004-09-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KBfycNgibruxPzTU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1007,12 +742,7 @@
       {
         "site": "bilibili",
         "id": "1902",
-        "begin": "2004-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -1028,7 +758,6 @@
     "officialSite": "http://www.tetsujin28.tv/",
     "begin": "2004-04-07T16:30:00.000Z",
     "end": "2004-09-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1037,12 +766,7 @@
       {
         "site": "bilibili",
         "id": "1953",
-        "begin": "2004-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1058,17 +782,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/saiyuki_rg/",
     "begin": "2004-04-01T16:30:00.000Z",
     "end": "2004-09-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mLWQDnbcTIrta9M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1077,22 +795,12 @@
       {
         "site": "nicovideo",
         "id": "saiyuki_rg",
-        "begin": "2017-01-10T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2146",
-        "begin": "2004-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -1108,21 +816,10 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mirumo/main_index.htm",
     "begin": "2004-04-06T10:30:00.000Z",
     "end": "2005-04-05T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "139340"
-      },
-      {
-        "site": "bilibili",
-        "id": "3916",
-        "begin": "2004-04-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1141,37 +838,21 @@
     "officialSite": "http://mv.avex.jp/initial/initial.html",
     "begin": "2004-04-17T16:00:00.000Z",
     "end": "2006-02-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QPTPTbUbia8ksqhI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "m/mypnbgb1fsnnk0a",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "41918",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1191,17 +872,11 @@
     "officialSite": "http://www.appleseedthemovie.com/",
     "begin": "2004-04-17T16:00:00.000Z",
     "end": "2004-04-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "8/8ke57ytm8knfd6b",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1221,27 +896,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2004-04-17T16:00:00.000Z",
     "end": "2004-04-17T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/v_19rrifx022.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/v_19rrifx022.html"
       },
       {
         "site": "bangumi",
@@ -1250,32 +914,17 @@
       {
         "site": "mgtv",
         "id": "49627",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3885",
-        "begin": "2004-04-16T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "35572",
+        "begin": "2004-04-16T16:00:01.000Z"
       }
     ]
   },
@@ -1291,17 +940,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2004-04-17T16:00:00.000Z",
     "end": "2004-04-17T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -1310,22 +953,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1341,7 +974,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2004-04-05T08:35:00.000Z",
     "end": "2004-07-23T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1361,17 +993,11 @@
     "officialSite": "",
     "begin": "2004-04-09T16:00:00.000Z",
     "end": "2004-09-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YaqWFHziaUpDzcdk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1391,17 +1017,11 @@
     "officialSite": "http://www.oaks-soft.co.jp/princess-soft/natsuiro/",
     "begin": "2004-04-23T16:00:00.000Z",
     "end": "2004-07-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lreSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1421,7 +1041,6 @@
     "officialSite": "",
     "begin": "2004-04-23T16:00:00.000Z",
     "end": "2004-07-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1430,12 +1049,7 @@
       {
         "site": "pptv",
         "id": "ddiajIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2004/05.json
+++ b/data/items/2004/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.samuraichamploo.com/",
     "begin": "2004-05-19T17:28:00.000Z",
     "end": "2004-09-22T18:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AUo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "letv",
         "id": "14591",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1869",
-        "begin": "2004-05-18T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-05-18T16:00:00.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "http://www.nifty.com/moe/love/index.html",
     "begin": "2004-05-03T15:35:00.000Z",
     "end": "2004-06-28T15:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "f/f37kqm5x0l8li6u",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -91,17 +69,11 @@
     "officialSite": "",
     "begin": "2004-05-28T16:00:00.000Z",
     "end": "2004-10-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xwj0ctpAsO5Rzzc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -121,7 +93,6 @@
     "officialSite": "",
     "begin": "2004-05-28T16:00:00.000Z",
     "end": "2004-08-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -141,17 +112,11 @@
     "officialSite": "http://www.cossette.jp/",
     "begin": "2004-05-26T16:00:00.000Z",
     "end": "2004-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "k6CbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -160,12 +125,7 @@
       {
         "site": "nicovideo",
         "id": "cossette",
-        "begin": "2015-11-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-06T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/2004/06.json
+++ b/data/items/2004/06.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.samurai-7.com/index.html",
     "begin": "2004-06-11T21:00:00.000Z",
     "end": "2005-05-02T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9Fkkogpw4B6Bic2c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1908",
-        "begin": "2004-06-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-06-11T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://web.archive.org/web/*/www.kazunecity.tv/",
     "begin": "2004-06-30T02:45:00.000Z",
     "end": "2004-09-22T03:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FFcxrxd97SuODHQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "1891",
-        "begin": "2004-06-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-06-29T16:00:00.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "http://web.archive.org/web/*/www.hanihani.tv/",
     "begin": "2004-06-30T02:30:00.000Z",
     "end": "2004-09-22T02:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "5138",
-        "begin": "2004-06-29T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-06-29T16:00:01.000Z"
       }
     ]
   },
@@ -121,17 +93,11 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/kurau/",
     "begin": "2004-06-24T17:12:00.000Z",
     "end": "2004-12-15T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "btumJIzyYqADgek",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,12 +106,7 @@
       {
         "site": "bilibili",
         "id": "1873",
-        "begin": "2004-06-24T17:12:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-06-24T17:12:00.000Z"
       }
     ]
   },
@@ -161,17 +122,11 @@
     "officialSite": "",
     "begin": "2004-06-26T16:00:00.000Z",
     "end": "2004-12-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "710opg505CKFA2s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2004/07.json
+++ b/data/items/2004/07.json
@@ -11,21 +11,10 @@
     "officialSite": "http://web.archive.org/web/*/ufotable.com/2x2/",
     "begin": "2004-07-09T15:30:00.000Z",
     "end": "2004-09-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "7618"
-      },
-      {
-        "site": "bilibili",
-        "id": "1936",
-        "begin": "2004-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -41,17 +30,11 @@
     "officialSite": "http://web.archive.org/web/*/http://www.team-dears.com/anime.html",
     "begin": "2004-07-10T15:30:00.000Z",
     "end": "2004-09-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AzcSkPhezgxv7VU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -74,7 +57,6 @@
     "officialSite": "http://www.vap.co.jp/elfenlied/",
     "begin": "2004-07-25T13:30:00.000Z",
     "end": "2004-10-17T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -83,12 +65,7 @@
       {
         "site": "nicovideo",
         "id": "elfenlied",
-        "begin": "2018-01-30T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-30T06:00:00.000Z"
       }
     ]
   },
@@ -104,37 +81,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/fafner/main_index.html",
     "begin": "2004-07-04T16:30:00.000Z",
     "end": "2004-12-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BjINiaicNZyQdq6FA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha0t8x",
-        "begin": "2016-11-30T16:02:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-30T16:02:02.000Z"
       },
       {
         "site": "qq",
         "id": "0/0ajd4gsjoufyje1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -143,12 +104,7 @@
       {
         "site": "nicovideo",
         "id": "fafner",
-        "begin": "2011-12-02T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-12-02T06:00:00.000Z"
       }
     ]
   },
@@ -164,17 +120,11 @@
     "officialSite": "http://www3.nhk.or.jp/anime/agatha/main.html",
     "begin": "2004-07-04T10:30:00.000Z",
     "end": "2005-05-15T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AEs1sxuB8SibSEHg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -183,12 +133,7 @@
       {
         "site": "bilibili",
         "id": "5136",
-        "begin": "2004-07-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-07-03T16:00:01.000Z"
       }
     ]
   },
@@ -204,31 +149,15 @@
     "officialSite": "http://web.archive.org/web/*/www.tv-osaka.co.jp/galaxyangel_4th/main2.html",
     "begin": "2004-07-07T16:00:00.000Z",
     "end": "2004-09-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EFslowtx4RibCAGg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "18083"
-      },
-      {
-        "site": "bilibili",
-        "id": "1945",
-        "begin": "2004-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -244,17 +173,11 @@
     "officialSite": "http://www.production-ig.co.jp/contents/works_sp/1170_/index.html",
     "begin": "2004-07-06T16:40:00.000Z",
     "end": "2005-03-29T17:24:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7VsmpAxy4iaCDAWk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -263,12 +186,7 @@
       {
         "site": "bilibili",
         "id": "1895",
-        "begin": "2004-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -284,7 +202,6 @@
     "officialSite": "http://www.vap.co.jp/monkey/v/flash.html",
     "begin": "2004-07-03T15:55:00.000Z",
     "end": "2004-12-18T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -304,31 +221,15 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mariasama_haru/main.html",
     "begin": "2004-07-03T22:30:00.000Z",
     "end": "2004-09-25T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icC4amABm1hR39V0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4215"
-      },
-      {
-        "site": "bilibili",
-        "id": "2703",
-        "begin": "2004-07-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -344,21 +245,10 @@
     "officialSite": "http://web.archive.org/web/*/http://www.girls-bravo.tv/",
     "begin": "2004-07-05T17:53:00.000Z",
     "end": "2004-09-27T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "3619"
-      },
-      {
-        "site": "bilibili",
-        "id": "1892",
-        "begin": "2004-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -370,7 +260,6 @@
     "officialSite": "http://www.wowow.co.jp/mankatsu/",
     "begin": "2004-07-31T16:05:00.000Z",
     "end": "2005-06-26T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -390,7 +279,6 @@
     "officialSite": "http://mbs.jp/future-b/index2.html",
     "begin": "2004-07-31T22:00:00.000Z",
     "end": "2004-12-19T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -410,7 +298,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2004-07-30T16:00:00.000Z",
     "end": "2004-07-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -419,32 +306,17 @@
       {
         "site": "nicovideo",
         "id": "lupin-3rd-SP",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3954",
-        "begin": "2004-07-29T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-07-29T16:00:01.000Z"
       }
     ]
   },
@@ -460,27 +332,16 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2004-07-17T16:00:00.000Z",
     "end": "2004-07-17T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -489,22 +350,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5753",
-        "begin": "2004-07-16T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-07-16T16:00:01.000Z"
       }
     ]
   },
@@ -520,7 +371,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2004-07-17T17:10:00.000Z",
     "end": "2004-07-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -540,7 +390,6 @@
     "officialSite": "http://www.steamboy.net/top.shtml",
     "begin": "2004-07-17T16:00:00.000Z",
     "end": "2004-07-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -549,32 +398,17 @@
       {
         "site": "letv",
         "id": "10002013",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7trr9",
-        "begin": "2017-06-14T16:19:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T16:19:10.000Z"
       },
       {
         "site": "bilibili",
         "id": "5137",
-        "begin": "2004-07-16T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-07-16T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2004/08.json
+++ b/data/items/2004/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://web.archive.org/web/*/www.gantz.net/",
     "begin": "2004-08-26T01:00:00.000Z",
     "end": "2004-11-18T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "",
     "begin": "2004-08-13T16:00:00.000Z",
     "end": "2004-08-13T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "h/hzpqa8gpad1x7mz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "letv",
         "id": "39667",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -71,31 +59,15 @@
     "officialSite": "",
     "begin": "2004-08-04T16:00:00.000Z",
     "end": "2005-02-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ga6ZF3iclVZP2dNw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "55603"
-      },
-      {
-        "site": "bilibili",
-        "id": "3968",
-        "begin": "2004-08-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -114,7 +86,6 @@
     "officialSite": "https://web.archive.org/web/20090416194756/http://pierrot.jp/title/naruto/movie/index.html",
     "begin": "2004-08-20T16:00:00.000Z",
     "end": "2004-08-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -123,12 +94,7 @@
       {
         "site": "netflix",
         "id": "70074559",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2004/09.json
+++ b/data/items/2004/09.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/maihime/main_index.html",
     "begin": "2004-09-30T16:30:00.000Z",
     "end": "2005-03-31T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "1922",
-        "begin": "2004-09-29T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-09-29T16:00:00.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "http://web.archive.org/web/*/www.windy-tales.com/",
     "begin": "2004-09-10T21:00:00.000Z",
     "end": "2005-07-23T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MicicKSLAWhsQnpQ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "bilibili",
         "id": "1934",
-        "begin": "2004-09-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-09-10T16:00:00.000Z"
       }
     ]
   },
@@ -81,17 +64,11 @@
     "officialSite": "http://www.vandelbuster.net/",
     "begin": "2004-09-30T09:30:00.000Z",
     "end": "2005-09-29T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kNqmJIzyYqADgek",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -111,17 +88,11 @@
     "officialSite": "http://www.onmyoutaisenki.net/",
     "begin": "2004-09-30T09:00:00.000Z",
     "end": "2005-09-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8kA7uSGH9zWYFn4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -130,12 +101,7 @@
       {
         "site": "bilibili",
         "id": "1929",
-        "begin": "2004-09-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-09-29T16:00:00.000Z"
       }
     ]
   },
@@ -151,17 +117,11 @@
     "officialSite": "http://web.archive.org/web/20080207035147/http://www.mediaworks.co.jp/d_original/hoihoisan/",
     "begin": "2004-09-30T16:00:00.000Z",
     "end": "2004-09-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CPXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -181,17 +141,11 @@
     "officialSite": "",
     "begin": "2004-09-23T16:00:00.000Z",
     "end": "2004-10-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "soJ9ib2PJOXfaWMA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -211,7 +165,6 @@
     "officialSite": "",
     "begin": "2004-09-10T16:00:00.000Z",
     "end": "2005-09-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -220,12 +173,7 @@
       {
         "site": "nicovideo",
         "id": "komugi_Z",
-        "begin": "2016-04-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-26T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/2004/10.json
+++ b/data/items/2004/10.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yugioh2004/",
     "begin": "2004-10-06T09:30:00.000Z",
     "end": "2008-03-26T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gbOODHTaSojradE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "yugioh2004",
-        "begin": "2017-10-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-01T03:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "18401",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -64,27 +48,16 @@
     "officialSite": "http://www.tbs.co.jp/rozen-maiden/part1/index-j.html",
     "begin": "2004-10-07T17:10:00.000Z",
     "end": "2004-12-23T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SYN9ib2PJOXfaWMA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/j1xkd2ntloqir3z",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -93,32 +66,17 @@
       {
         "site": "nicovideo",
         "id": "rozen1",
-        "begin": "2014-01-24T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-24T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "522",
-        "begin": "2004-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-06T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7kqwt",
-        "begin": "2018-12-13T07:30:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-13T07:30:59.000Z"
       }
     ]
   },
@@ -135,17 +93,11 @@
     "officialSite": "http://www.maql.co.jp/special/school-rumble/anime01/index.html",
     "begin": "2004-10-05T09:00:00.000Z",
     "end": "2005-03-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "031Ixia6UBEKlI4s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -154,12 +106,7 @@
       {
         "site": "bilibili",
         "id": "1446",
-        "begin": "2004-10-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-09T16:00:00.000Z"
       }
     ]
   },
@@ -175,27 +122,16 @@
     "officialSite": "http://www.starchild.co.jp/special/hutakoi/tel/index.html",
     "begin": "2004-10-06T16:00:00.000Z",
     "end": "2004-12-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dcXAPqYMfLodmwM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jvyqjfw72ze1ncj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -204,12 +140,7 @@
       {
         "site": "bilibili",
         "id": "1937",
-        "begin": "2004-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -225,27 +156,16 @@
     "officialSite": "http://web.archive.org/web/*/www.genshiken.info/",
     "begin": "2004-10-10T15:00:00.000Z",
     "end": "2004-12-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TfbRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "c/cngva81rdw5b2sw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -254,22 +174,12 @@
       {
         "site": "nicovideo",
         "id": "genshiken",
-        "begin": "2013-08-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-08T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "517",
-        "begin": "2004-10-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-09T16:00:00.000Z"
       }
     ]
   },
@@ -285,7 +195,6 @@
     "officialSite": "http://www.wonderfarm.co.jp/musume/",
     "begin": "2004-10-03T15:30:00.000Z",
     "end": "2004-12-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -305,31 +214,15 @@
     "officialSite": "http://e-tnk.net/anime/anime_kannnaduki_frame.html",
     "begin": "2004-10-01T15:30:00.000Z",
     "end": "2004-12-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "a/a1m4fhkjjqoxshe",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2451"
-      },
-      {
-        "site": "bilibili",
-        "id": "1872",
-        "begin": "2004-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -345,17 +238,11 @@
     "officialSite": "http://www.gundam-seed-d.net/",
     "begin": "2004-10-09T09:00:00.000Z",
     "end": "2005-10-01T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aNeyMJjibbqwPjfU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -375,17 +262,11 @@
     "officialSite": "http://www.gankutsuou.com/",
     "begin": "2004-10-05T17:12:00.000Z",
     "end": "2005-03-29T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xA33dd1DsicFU0jo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -394,22 +275,12 @@
       {
         "site": "nicovideo",
         "id": "gankutsuou",
-        "begin": "2012-07-04T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-04T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1890",
-        "begin": "2004-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -425,7 +296,6 @@
     "officialSite": "http://anime.softgarage.com/kakyusei2/index.html",
     "begin": "2004-10-01T16:30:00.000Z",
     "end": "2004-12-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -445,17 +315,11 @@
     "officialSite": "http://www.jvcmusic.co.jp/m-serve/tsukuyomi/",
     "begin": "2004-10-04T16:30:00.000Z",
     "end": "2010-04-30T03:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Lh3oZs40pOJFwys",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -464,12 +328,7 @@
       {
         "site": "bilibili",
         "id": "1920",
-        "begin": "2004-10-04T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-04T16:30:00.000Z"
       }
     ]
   },
@@ -485,51 +344,25 @@
     "officialSite": "http://www.yakitate-japan.com/",
     "begin": "2004-10-12T10:00:00.000Z",
     "end": "2006-03-14T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SOPeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hhg3z4i1crzuhg2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3287"
       },
       {
-        "site": "bilibili",
-        "id": "1887",
-        "begin": "2004-10-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "43214",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -548,21 +381,10 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/zoids/main_index.html",
     "begin": "2004-10-02T23:30:00.000Z",
     "end": "2005-04-03T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "26016"
-      },
-      {
-        "site": "bilibili",
-        "id": "5450",
-        "begin": "2004-10-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -581,17 +403,11 @@
     "officialSite": "http://beck.ne.jp/",
     "begin": "2004-10-06T16:30:00.000Z",
     "end": "2005-03-30T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GTUQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -614,7 +430,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/bleach/",
     "begin": "2004-10-05T09:30:00.000Z",
     "end": "2012-03-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -623,12 +438,7 @@
       {
         "site": "netflix",
         "id": "70204957",
-        "begin": "2016-12-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-01T08:00:00.000Z"
       }
     ]
   },
@@ -644,27 +454,16 @@
     "officialSite": "http://www.uta-kata.com/",
     "begin": "2004-10-02T15:30:00.000Z",
     "end": "2006-07-10T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1B3nZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/9piqmfg0ucvetxr",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -673,12 +472,7 @@
       {
         "site": "bilibili",
         "id": "1874",
-        "begin": "2004-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -694,17 +488,11 @@
     "officialSite": "http://haruka8tv.gamecity.ne.jp/",
     "begin": "2004-10-05T16:00:00.000Z",
     "end": "2005-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "upJt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -713,22 +501,12 @@
       {
         "site": "bilibili",
         "id": "1882",
-        "begin": "2004-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-04T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "41919",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -744,27 +522,16 @@
     "officialSite": "http://www.toheart-r.net/",
     "begin": "2004-10-02T01:00:00.000Z",
     "end": "2004-12-25T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FyMenARq2hh7ibWE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "t/th0f3ia0w6izyus",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -773,12 +540,7 @@
       {
         "site": "bilibili",
         "id": "1941",
-        "begin": "2004-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -797,7 +559,6 @@
     "officialSite": "",
     "begin": "2004-10-02T16:30:00.000Z",
     "end": "2004-12-25T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -806,12 +567,7 @@
       {
         "site": "bilibili",
         "id": "1925",
-        "begin": "2004-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -831,17 +587,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/f-children/",
     "begin": "2004-10-04T16:00:00.000Z",
     "end": "2005-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zQQAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -850,12 +600,7 @@
       {
         "site": "bilibili",
         "id": "1889",
-        "begin": "2004-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -872,27 +617,16 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/alice/",
     "begin": "2004-10-29T23:06:00.000Z",
     "end": "2005-05-13T23:31:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "t5Fs6lK4KGbJR68",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "g/gmz8h0384itbh0f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -901,22 +635,12 @@
       {
         "site": "nicovideo",
         "id": "gakuen-alice",
-        "begin": "2018-06-19T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-06-19T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1921",
-        "begin": "2004-10-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-29T16:00:00.000Z"
       }
     ]
   },
@@ -932,21 +656,10 @@
     "officialSite": "http://www.tbs.co.jp/anime-zipang/",
     "begin": "2004-10-07T16:40:00.000Z",
     "end": "2005-03-31T17:09:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "19390"
-      },
-      {
-        "site": "bilibili",
-        "id": "1888",
-        "begin": "2004-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -962,7 +675,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tactics/main_index.html",
     "begin": "2004-10-05T16:30:00.000Z",
     "end": "2005-03-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -982,27 +694,16 @@
     "officialSite": "http://www.nanoha.com/archive/index.html",
     "begin": "2004-10-02T15:30:00.000Z",
     "end": "2004-12-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lL2IBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "3/3hzdypb3ot6tmb0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1011,12 +712,7 @@
       {
         "site": "bilibili",
         "id": "1535",
-        "begin": "2004-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -1032,18 +728,7 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/vj/main_index.html",
     "begin": "2004-10-02T00:30:00.000Z",
     "end": "2005-09-24T01:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464011",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "9981"
@@ -1065,21 +750,10 @@
     "officialSite": "http://mv.avex.jp/samurai/",
     "begin": "2004-10-04T18:12:00.000Z",
     "end": "2004-12-13T19:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "102713"
-      },
-      {
-        "site": "bilibili",
-        "id": "4969",
-        "begin": "2004-10-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1099,17 +773,11 @@
     "officialSite": "http://blackjack.jp/",
     "begin": "2004-10-11T10:00:00.000Z",
     "end": "2006-03-06T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjth0f5",
-        "begin": "2017-10-13T08:18:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-13T08:18:14.000Z"
       },
       {
         "site": "bangumi",
@@ -1129,7 +797,6 @@
     "officialSite": "http://www.kappanokaikata.com/",
     "begin": "2004-10-04T09:55:00.000Z",
     "end": "2005-04-04T10:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1138,12 +805,7 @@
       {
         "site": "bilibili",
         "id": "4994",
-        "begin": "2005-10-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-03T16:00:01.000Z"
       }
     ]
   },
@@ -1159,7 +821,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/rockmanexe_st/",
     "begin": "2004-10-01T23:30:00.000Z",
     "end": "2005-09-24T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1179,17 +840,11 @@
     "officialSite": "http://www.sunabozu.com/",
     "begin": "2004-10-05T16:00:00.000Z",
     "end": "2005-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UenUUrogkM4xrxc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1212,17 +867,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/rin-kake1/",
     "begin": "2004-10-06T18:42:00.000Z",
     "end": "2004-12-15T18:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "90QicvSWLibzmcGoI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1242,31 +891,15 @@
     "officialSite": "http://www.ehrgeiz.co.jp/gindex.html",
     "begin": "2004-10-14T15:40:00.000Z",
     "end": "2005-01-13T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ynZRzzedDUuuLJQ",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "7991"
-      },
-      {
-        "site": "bilibili",
-        "id": "1868",
-        "begin": "2004-10-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1282,31 +915,15 @@
     "officialSite": "",
     "begin": "2004-10-07T16:00:00.000Z",
     "end": "2004-12-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PG9Z1ziblFVO2NJw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "31034"
-      },
-      {
-        "site": "bilibili",
-        "id": "1880",
-        "begin": "2004-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1322,17 +939,11 @@
     "officialSite": "",
     "begin": "2004-10-27T16:00:00.000Z",
     "end": "2005-06-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Upxo5k60JGLFQ6s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1352,17 +963,11 @@
     "officialSite": "",
     "begin": "2004-10-02T16:00:00.000Z",
     "end": "2005-01-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zAXicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1382,7 +987,6 @@
     "officialSite": "",
     "begin": "2004-10-20T16:00:00.000Z",
     "end": "2005-03-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1391,12 +995,7 @@
       {
         "site": "bilibili",
         "id": "3409",
-        "begin": "2004-10-19T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-10-19T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2004/11.json
+++ b/data/items/2004/11.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.beetrain.co.jp/contents/works/meineliebe/",
     "begin": "2004-11-04T13:30:00.000Z",
     "end": "2005-02-03T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Yc24Np4EdLIVkics",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1878",
-        "begin": "2004-11-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-11-03T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://www.kumonomukou.com",
     "begin": "2004-11-20T16:00:00.000Z",
     "end": "2004-11-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "87679",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "nicovideo",
         "id": "kumonomukou",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -92,27 +70,16 @@
     "officialSite": "",
     "begin": "2004-11-13T16:00:00.000Z",
     "end": "2005-05-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IQ34dt5EtPJV0zs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc067l",
-        "begin": "2014-11-07T07:19:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-07T07:19:01.000Z"
       },
       {
         "site": "bangumi",
@@ -132,17 +99,11 @@
     "officialSite": "",
     "begin": "2004-11-20T16:00:00.000Z",
     "end": "2004-11-20T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "bangumi",
@@ -162,17 +123,11 @@
     "officialSite": "http://www.ova-top.com",
     "begin": "2004-11-25T16:00:00.000Z",
     "end": "2006-02-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WZVv7VW7K2nMSrI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -181,12 +136,7 @@
       {
         "site": "nicovideo",
         "id": "ova-top",
-        "begin": "2016-07-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T06:00:00.000Z"
       }
     ]
   },
@@ -202,31 +152,15 @@
     "officialSite": "http://www.gainax.co.jp/anime/top2/index.html",
     "begin": "2004-11-26T16:00:00.000Z",
     "end": "2006-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VZdx71e9LWvOTLQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "768"
-      },
-      {
-        "site": "bilibili",
-        "id": "2665",
-        "begin": "2004-11-25T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2004/12.json
+++ b/data/items/2004/12.json
@@ -14,37 +14,21 @@
     "officialSite": "",
     "begin": "2004-12-23T16:00:00.000Z",
     "end": "2004-12-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "c/ccqcpxt90o1ykxn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "46370",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "56MQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -53,12 +37,7 @@
       {
         "site": "netflix",
         "id": "70052492",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2005/01.json
+++ b/data/items/2005/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.starchild.co.jp/special/negima/index.html",
     "begin": "2005-01-05T16:00:00.000Z",
     "end": "2005-06-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vPXPTbUbia8ksqhI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "negima01",
-        "begin": "2014-12-25T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-25T06:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "15634",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -64,27 +48,16 @@
     "officialSite": "http://www.tbs.co.jp/anime/air/",
     "begin": "2005-01-06T15:30:00.000Z",
     "end": "2005-03-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pH5JxyibVBUOmJIw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jsawpdhyfo7906j",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -93,22 +66,12 @@
       {
         "site": "bilibili",
         "id": "1816",
-        "begin": "2005-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-05T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "air_anime",
-        "begin": "2018-12-27T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-27T15:00:00.000Z"
       }
     ]
   },
@@ -124,17 +87,11 @@
     "officialSite": "http://www.starchild.co.jp/special/jinki/",
     "begin": "2005-01-05T17:12:00.000Z",
     "end": "2008-02-10T15:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ntGrKZH3Z6UIhu4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -143,12 +100,7 @@
       {
         "site": "bilibili",
         "id": "1852",
-        "begin": "2005-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -164,37 +116,21 @@
     "officialSite": "http://www.tbs.co.jp/megamisama/megami1/index-j.html",
     "begin": "2005-01-06T16:55:00.000Z",
     "end": "2006-09-28T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6k04th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bskp4vp3h7tzhs0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "8605",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -203,22 +139,12 @@
       {
         "site": "bilibili",
         "id": "1448",
-        "begin": "2005-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-05T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7pjk5",
-        "begin": "2019-01-25T03:47:29.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-25T03:47:29.000Z"
       }
     ]
   },
@@ -234,7 +160,6 @@
     "officialSite": "http://www.girls-bravo.tv/",
     "begin": "2005-01-27T15:30:00.000Z",
     "end": "2005-04-21T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -255,17 +180,11 @@
     "officialSite": "http://www.starchild.co.jp/special/mahoraba/",
     "begin": "2005-01-09T16:30:00.000Z",
     "end": "2005-06-26T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GCciaoAhu3hxicicWU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -274,12 +193,7 @@
       {
         "site": "bilibili",
         "id": "1864",
-        "begin": "2005-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-08T16:00:00.000Z"
       }
     ]
   },
@@ -295,17 +209,11 @@
     "officialSite": "http://www.aniplex.co.jp/galleryfake/",
     "begin": "2005-01-08T15:55:00.000Z",
     "end": "2005-09-24T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vo5591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -314,12 +222,7 @@
       {
         "site": "bilibili",
         "id": "1851",
-        "begin": "2005-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -335,51 +238,25 @@
     "officialSite": "http://web.archive.org/web/*/http://sukisyo.tv/",
     "begin": "2005-01-08T15:30:00.000Z",
     "end": "2010-04-08T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UJpm5EyyImDDQak",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "q/qoy263ioaan7g0e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "21861",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "9871"
-      },
-      {
-        "site": "bilibili",
-        "id": "5129",
-        "begin": "2005-01-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -395,7 +272,6 @@
     "officialSite": "http://www.tv-asahi.co.jp/xenosaga/",
     "begin": "2005-01-05T17:42:00.000Z",
     "end": "2005-03-23T18:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -404,12 +280,7 @@
       {
         "site": "bilibili",
         "id": "1854",
-        "begin": "2005-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -425,7 +296,6 @@
     "officialSite": "http://www.tv-aichi.co.jp/TF/",
     "begin": "2005-01-07T23:00:00.000Z",
     "end": "2005-12-30T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -434,12 +304,7 @@
       {
         "site": "bilibili",
         "id": "1830",
-        "begin": "2005-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-08T16:00:00.000Z"
       }
     ]
   },
@@ -455,7 +320,6 @@
     "officialSite": "http://web.archive.org/web/*/http://www.magical-canan.com/",
     "begin": "2005-01-01T01:00:00.000Z",
     "end": "2005-03-26T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -475,21 +339,10 @@
     "officialSite": "http://www.ponycanyon.co.jp/pc-moe/ug/index.html",
     "begin": "2005-01-09T15:00:00.000Z",
     "end": "2005-03-27T15:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "7860"
-      },
-      {
-        "site": "bilibili",
-        "id": "1861",
-        "begin": "2005-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -505,17 +358,11 @@
     "officialSite": "http://www.limeirox.com/",
     "begin": "2005-01-04T16:55:00.000Z",
     "end": "2005-03-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Z9KtK5P5aacKiaPA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -535,17 +382,11 @@
     "officialSite": "http://www.kids-station.com/minisite/damekko/",
     "begin": "2005-01-17T14:30:00.000Z",
     "end": "2005-02-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cLibKCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -554,12 +395,7 @@
       {
         "site": "bilibili",
         "id": "2829",
-        "begin": "2004-12-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2004-12-31T16:00:00.000Z"
       }
     ]
   },
@@ -575,17 +411,11 @@
     "officialSite": "http://web.archive.org/web/*/http://www.starshipoperators.com/home/index.html",
     "begin": "2005-01-05T09:00:00.000Z",
     "end": "2005-03-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ticrGRKwSgsAjoQk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -594,12 +424,7 @@
       {
         "site": "bilibili",
         "id": "1853",
-        "begin": "2005-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -615,17 +440,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/peachgirl/",
     "begin": "2005-01-07T22:00:00.000Z",
     "end": "2005-06-24T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8T8KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -634,12 +453,7 @@
       {
         "site": "bilibili",
         "id": "2958",
-        "begin": "2005-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -655,7 +469,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/b-daman_fs/",
     "begin": "2005-01-10T09:00:00.000Z",
     "end": "2005-12-26T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -675,7 +488,6 @@
     "officialSite": "http://www.animax.co.jp/program/program.php3?naiyo=m_pandarian",
     "begin": "2005-01-07T22:30:00.000Z",
     "end": "2005-07-08T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -695,37 +507,21 @@
     "officialSite": "",
     "begin": "2005-01-29T16:00:00.000Z",
     "end": "2005-01-29T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "bMiakIorwYJ4Bfibc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/h9ytlsw3uflqoub",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "53231",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -745,37 +541,21 @@
     "officialSite": "",
     "begin": "2005-01-29T16:00:00.000Z",
     "end": "2005-01-29T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "e9u1M5sBca8SkPg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/luke12y3zia8yfo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "53232",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2005/02.json
+++ b/data/items/2005/02.json
@@ -7,7 +7,6 @@
     "officialSite": "http://www.zorori.jp/",
     "begin": "2005-02-12T22:00:00.000Z",
     "end": "2007-01-27T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -28,17 +27,11 @@
     "officialSite": "http://asahi.co.jp/precure_ss/oldsite/",
     "begin": "2005-02-05T23:30:00.000Z",
     "end": "2006-01-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1569",
-        "begin": "2015-09-07T03:05:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-07T03:05:48.000Z"
       },
       {
         "site": "bangumi",
@@ -59,27 +52,16 @@
     "officialSite": "http://www.wowow.co.jp/anime/buzzer/",
     "begin": "2005-02-05T10:00:00.000Z",
     "end": "2005-04-30T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "v45591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgi9s11",
-        "begin": "2014-09-12T06:37:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:37:11.000Z"
       },
       {
         "site": "bangumi",
@@ -88,12 +70,7 @@
       {
         "site": "bilibili",
         "id": "1373",
-        "begin": "2005-02-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-02-04T16:00:00.000Z"
       }
     ]
   },
@@ -110,57 +87,31 @@
     "officialSite": "http://www.kids-station.com/minisite/gyagumanga/",
     "begin": "2005-02-07T21:40:00.000Z",
     "end": "2005-04-25T21:47:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7DoGhOxSwgBj4Uk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjbqeh",
-        "begin": "2014-09-12T06:32:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:32:05.000Z"
       },
       {
         "site": "qq",
         "id": "e/edpitqdue7x1va1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15959",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "42748",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -169,12 +120,7 @@
       {
         "site": "bilibili",
         "id": "1593",
-        "begin": "2005-02-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-02-06T16:00:00.000Z"
       }
     ]
   },
@@ -190,27 +136,16 @@
     "officialSite": "http://www.toei-anim.co.jp/animeister/iriya/",
     "begin": "2005-02-25T10:00:00.000Z",
     "end": "2005-07-29T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ysib6OKAGdrQXlf0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "p/pcwetsd9pmmroio",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -219,12 +154,7 @@
       {
         "site": "bilibili",
         "id": "5099",
-        "begin": "2005-02-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-02-24T16:00:01.000Z"
       }
     ]
   },
@@ -240,17 +170,11 @@
     "officialSite": "",
     "begin": "2005-02-05T16:00:00.000Z",
     "end": "2005-02-05T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "m/mheldsnut21ohut",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -259,12 +183,7 @@
       {
         "site": "bilibili",
         "id": "3783",
-        "begin": "2005-02-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-02-04T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2005/03.json
+++ b/data/items/2005/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.onepiece-movie.com/",
     "begin": "2005-03-04T16:00:00.000Z",
     "end": "2005-03-04T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "",
     "begin": "2005-03-25T16:00:00.000Z",
     "end": "2006-01-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,17 +49,11 @@
     "officialSite": "http://www.bin-kan.com/",
     "begin": "2005-03-25T16:00:00.000Z",
     "end": "2005-09-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vo96ibGDGNnTXVb0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2005/04.json
+++ b/data/items/2005/04.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/gosyujinsama/",
     "begin": "2005-04-07T15:30:00.000Z",
     "end": "2005-06-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JhPubNQ6quhLyTE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "n/n1oqhzy74v589uo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -52,27 +41,16 @@
     "officialSite": "http://www.emma-victorian.com/",
     "begin": "2005-04-02T15:30:00.000Z",
     "end": "2005-06-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aMSicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifuaqn",
-        "begin": "2013-07-31T09:18:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-31T09:18:31.000Z"
       },
       {
         "site": "bangumi",
@@ -81,12 +59,7 @@
       {
         "site": "bilibili",
         "id": "2998",
-        "begin": "2005-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -102,27 +75,16 @@
     "officialSite": "http://www3.nhk.or.jp/anime/tsubasa/",
     "begin": "2005-04-09T09:30:00.000Z",
     "end": "2005-10-15T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JAD7eeFHticVY1j4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/lafr6118jwe8vju",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -131,22 +93,12 @@
       {
         "site": "bilibili",
         "id": "1463",
-        "begin": "2005-04-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-08T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10385",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -162,27 +114,16 @@
     "officialSite": "http://www.gonzo.co.jp/archives/basilisk/",
     "begin": "2005-04-12T17:00:00.000Z",
     "end": "2005-09-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DSAbmQFn1xV49l4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/wcuqxhr4knw402g",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -191,32 +132,17 @@
       {
         "site": "nicovideo",
         "id": "basilisk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "18858",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1855",
-        "begin": "2005-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -232,27 +158,16 @@
     "officialSite": "http://www.eureka-prj.net/",
     "begin": "2005-04-16T22:00:00.000Z",
     "end": "2012-04-05T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TH9JxyibVBUOmJIw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "790",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -261,12 +176,7 @@
       {
         "site": "nicovideo",
         "id": "k-eureka",
-        "begin": "2018-03-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-26T06:00:00.000Z"
       }
     ]
   },
@@ -282,27 +192,16 @@
     "officialSite": "http://www.aquarion.info/",
     "begin": "2005-04-04T16:00:00.000Z",
     "end": "2005-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ib0E8uiaKIibDaZF38",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/wc6mhxbhgqk6ysp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -311,22 +210,12 @@
       {
         "site": "nicovideo",
         "id": "aquarion",
-        "begin": "2011-12-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-12-03T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "695",
-        "begin": "2005-04-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -342,17 +231,11 @@
     "officialSite": "http://www.mag-garden.co.jp/erementar-gerad/",
     "begin": "2005-04-05T09:00:00.000Z",
     "end": "2005-09-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uZVw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -361,12 +244,7 @@
       {
         "site": "bilibili",
         "id": "1836",
-        "begin": "2005-04-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -382,17 +260,11 @@
     "officialSite": "http://trinet.cata.jp/izumo/",
     "begin": "2005-04-02T16:30:00.000Z",
     "end": "2005-06-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SicfSULgejswvrRU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -401,12 +273,7 @@
       {
         "site": "bilibili",
         "id": "1849",
-        "begin": "2005-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -422,7 +289,6 @@
     "officialSite": "http://trinet.cata.jp/koikoi7/",
     "begin": "2005-04-01T16:30:00.000Z",
     "end": "2005-06-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -431,12 +297,7 @@
       {
         "site": "bilibili",
         "id": "5090",
-        "begin": "2005-03-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-03-31T16:00:01.000Z"
       }
     ]
   },
@@ -452,27 +313,16 @@
     "officialSite": "http://www.maru-ma.com/",
     "begin": "2005-04-02T00:00:00.000Z",
     "end": "2006-02-25T00:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3nhDwSmPicz2gHoY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "e/ei52veosuyas2li",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -481,12 +331,7 @@
       {
         "site": "bilibili",
         "id": "3765",
-        "begin": "2005-04-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-01T16:00:01.000Z"
       }
     ]
   },
@@ -502,7 +347,6 @@
     "officialSite": "http://futagohime.jp/",
     "begin": "2005-04-02T01:00:00.000Z",
     "end": "2006-03-25T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -511,12 +355,7 @@
       {
         "site": "bilibili",
         "id": "1476",
-        "begin": "2005-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -532,31 +371,15 @@
     "officialSite": "http://web.archive.org/web/*/www.comicparty-r.com/",
     "begin": "2005-04-04T17:15:00.000Z",
     "end": "2005-06-27T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MiawIhu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2079"
-      },
-      {
-        "site": "bilibili",
-        "id": "2134",
-        "begin": "2003-12-21T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -573,31 +396,15 @@
     "officialSite": "http://www.websunday.net/mar/index.html",
     "begin": "2005-04-03T01:00:00.000Z",
     "end": "2007-03-25T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbyukx",
-        "begin": "2014-11-27T03:51:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-27T03:51:38.000Z"
       },
       {
         "site": "bangumi",
         "id": "9397"
-      },
-      {
-        "site": "bilibili",
-        "id": "1835",
-        "begin": "2005-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -613,27 +420,16 @@
     "officialSite": "http://www.hachikuro.net/",
     "begin": "2005-04-14T15:50:00.000Z",
     "end": "2005-09-26T17:44:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ib10opg505CKFA2s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "r/rcqyceserheukav",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -642,12 +438,7 @@
       {
         "site": "bilibili",
         "id": "3317",
-        "begin": "2005-04-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-13T16:00:01.000Z"
       }
     ]
   },
@@ -663,27 +454,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/ueki/",
     "begin": "2005-04-04T09:30:00.000Z",
     "end": "2006-03-27T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OhrlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rriftzty",
-        "begin": "2013-07-31T09:15:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-31T09:15:43.000Z"
       },
       {
         "site": "bangumi",
@@ -692,12 +472,7 @@
       {
         "site": "bilibili",
         "id": "2659",
-        "begin": "2005-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -714,18 +489,7 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/eyeshield21/main_index.html",
     "begin": "2005-04-06T10:00:00.000Z",
     "end": "2008-03-19T10:26:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1463857",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "2776"
@@ -747,7 +511,6 @@
     "officialSite": "http://www.kadokawa.co.jp/toribla/index.php",
     "begin": "2005-04-28T15:00:00.000Z",
     "end": "2005-10-27T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -767,51 +530,25 @@
     "officialSite": "http://www.starchild.co.jp/special/hutakoi/ufo/index.html",
     "begin": "2005-04-06T18:10:00.000Z",
     "end": "2005-06-29T18:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "soWAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "a/az3toiudw8foo6p",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2643"
       },
       {
-        "site": "bilibili",
-        "id": "2769",
-        "begin": "2005-04-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "20119",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -830,21 +567,10 @@
     "officialSite": "http://www.gonzo.co.jp/archives/speed-grapher/index.html",
     "begin": "2005-04-07T17:40:00.000Z",
     "end": "2005-09-29T18:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "3825"
-      },
-      {
-        "site": "bilibili",
-        "id": "5086",
-        "begin": "2005-04-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -860,17 +586,11 @@
     "officialSite": "http://www.gokujo.konami.jp/",
     "begin": "2005-04-06T16:30:00.000Z",
     "end": "2005-09-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2BLubNQ6quhLyTE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -890,17 +610,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/garasunokamen/",
     "begin": "2005-04-05T16:30:00.000Z",
     "end": "2006-03-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "toNibicGTKOnjbWcE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -909,22 +623,12 @@
       {
         "site": "letv",
         "id": "38143",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1763",
-        "begin": "2005-04-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-24T16:00:00.000Z"
       }
     ]
   },
@@ -940,37 +644,21 @@
     "officialSite": "http://www.loveless.tv/",
     "begin": "2005-04-06T17:40:00.000Z",
     "end": "2005-06-29T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LRrlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5ki0btzt134j9az",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15658",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -979,12 +667,7 @@
       {
         "site": "bilibili",
         "id": "1839",
-        "begin": "2005-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -1000,21 +683,10 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mirumo/main_index.htm",
     "begin": "2005-04-19T10:30:00.000Z",
     "end": "2005-09-27T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "139341"
-      },
-      {
-        "site": "bilibili",
-        "id": "3917",
-        "begin": "2005-04-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1030,7 +702,6 @@
     "officialSite": "http://www.tms-e.com/search/index.php?pdt_no=48",
     "begin": "2005-04-06T09:00:00.000Z",
     "end": "2006-03-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1039,22 +710,7 @@
       {
         "site": "nicovideo",
         "id": "mushiking",
-        "begin": "2011-09-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5088",
-        "begin": "2005-04-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-20T06:00:00.000Z"
       }
     ]
   },
@@ -1070,41 +726,20 @@
     "officialSite": "http://mv.avex.jp/ichigo/",
     "begin": "2005-04-05T17:40:00.000Z",
     "end": "2006-08-07T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ynFMyjKYCEapJ48",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1415"
       },
       {
-        "site": "bilibili",
-        "id": "1863",
-        "begin": "2005-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "12907",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1120,7 +755,6 @@
     "officialSite": "http://www.gaogaigar.net/",
     "begin": "2005-04-11T16:30:00.000Z",
     "end": "2005-06-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1129,12 +763,7 @@
       {
         "site": "bilibili",
         "id": "3958",
-        "begin": "2005-04-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-10T16:00:01.000Z"
       }
     ]
   },
@@ -1150,17 +779,11 @@
     "officialSite": "http://www.shopro.co.jp/tv/program/zoids/index.html",
     "begin": "2005-04-09T23:30:00.000Z",
     "end": "2006-03-26T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "51QvrRV76ymMCnI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1169,12 +792,7 @@
       {
         "site": "bilibili",
         "id": "1837",
-        "begin": "2005-04-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-04-09T16:00:00.000Z"
       }
     ]
   },
@@ -1190,7 +808,6 @@
     "officialSite": "http://www.tv-osaka.co.jp/mymelo/",
     "begin": "2005-04-03T00:30:00.000Z",
     "end": "2006-03-26T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1210,37 +827,21 @@
     "officialSite": "http://www.tv-asahi.co.jp/doraemon/",
     "begin": "2005-04-22T10:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jJeBic2fNPXveXMQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk25kq9",
-        "begin": "2014-04-10T01:14:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T01:14:15.000Z"
       },
       {
         "site": "letv",
         "id": "24008",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1249,12 +850,7 @@
       {
         "site": "sohu",
         "id": "s2015/doraemonqj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1270,27 +866,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2005-04-16T16:00:00.000Z",
     "end": "2005-04-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/e3372f4570168270.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/e3372f4570168270.html"
       },
       {
         "site": "bangumi",
@@ -1299,22 +884,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3886",
-        "begin": "2005-04-15T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "46092",
+        "begin": "2005-04-15T16:00:01.000Z"
       }
     ]
   },
@@ -1330,17 +905,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2005-04-09T16:00:00.000Z",
     "end": "2005-04-09T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -1349,22 +918,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1380,7 +939,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2005-04-04T08:35:00.000Z",
     "end": "2005-06-20T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1400,7 +958,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2005_precure/",
     "begin": "2005-04-16T16:00:00.000Z",
     "end": "2005-04-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1409,22 +966,12 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   }

--- a/data/items/2005/05.json
+++ b/data/items/2005/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www3.nhk.or.jp/anime/snowqueen/",
     "begin": "2005-05-22T10:30:00.000Z",
     "end": "2006-02-12T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1mVg3kasHFq9O6M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "5081",
-        "begin": "2005-05-21T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-05-21T16:00:01.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://web.archive.org/web/*/www.zettai-shonen.com/",
     "begin": "2005-05-20T23:06:00.000Z",
     "end": "2005-11-18T23:32:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "bilibili",
         "id": "3260",
-        "begin": "2005-05-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-05-20T16:00:01.000Z"
       }
     ]
   },
@@ -81,31 +64,15 @@
     "officialSite": "http://www.sanada10.com/",
     "begin": "2005-05-07T10:00:00.000Z",
     "end": "2005-07-23T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ESEcmgJo2BZ5918",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "102525"
-      },
-      {
-        "site": "bilibili",
-        "id": "1833",
-        "begin": "2005-05-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -121,27 +88,16 @@
     "officialSite": "http://www.ponycanyon.co.jp/tpic/boku_imoto/",
     "begin": "2005-05-08T16:00:00.000Z",
     "end": "2005-05-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "4/4lz3b5jl9iaf2hm",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "22161",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -161,17 +117,11 @@
     "officialSite": "http://www.z-gundam.net/",
     "begin": "2005-05-28T16:00:00.000Z",
     "end": "2005-05-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "2/286vuymzp0bvolj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -191,7 +141,6 @@
     "officialSite": "http://www.ggvp.net/usagi/",
     "begin": "2005-05-14T16:00:00.000Z",
     "end": "2005-05-14T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -200,22 +149,12 @@
       {
         "site": "letv",
         "id": "10008174",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5116",
-        "begin": "2005-05-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-05-13T16:00:01.000Z"
       }
     ]
   },
@@ -231,17 +170,11 @@
     "officialSite": "http://www.thekaras.net/",
     "begin": "2005-05-28T16:00:00.000Z",
     "end": "2007-10-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VdibqKJD2ZqQHhe0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -250,22 +183,12 @@
       {
         "site": "letv",
         "id": "29095",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1857",
-        "begin": "2005-05-27T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-05-27T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2005/06.json
+++ b/data/items/2005/06.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.aniplex.co.jp/kamichu/archive/index.html",
     "begin": "2005-06-28T17:40:00.000Z",
     "end": "2012-07-21T00:02:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kt2nJY3zY6EEguo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1858",
-        "begin": "2005-06-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-06-28T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://www.patalliro.com/anime/",
     "begin": "2005-06-06T15:30:00.000Z",
     "end": "2006-03-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eMC7OaEHd7UYlv4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "1832",
-        "begin": "2005-06-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-06-05T16:00:00.000Z"
       }
     ]
   },
@@ -91,31 +69,15 @@
     "officialSite": "",
     "begin": "2005-06-20T16:00:00.000Z",
     "end": "2005-10-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "40002",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "6752"
-      },
-      {
-        "site": "bilibili",
-        "id": "5078",
-        "begin": "2005-06-19T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -131,17 +93,11 @@
     "officialSite": "",
     "begin": "2005-06-17T16:00:00.000Z",
     "end": "2005-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yic7KSLAWhsQnpQ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2005/07.json
+++ b/data/items/2005/07.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/gunsword/",
     "begin": "2005-07-04T16:30:00.000Z",
     "end": "2005-12-26T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibzQQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,12 +27,7 @@
       {
         "site": "bilibili",
         "id": "1862",
-        "begin": "2005-07-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -54,27 +43,16 @@
     "officialSite": "http://www.tbs.co.jp/ichigomashimaro/",
     "begin": "2005-07-14T17:05:00.000Z",
     "end": "2005-10-13T17:31:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TPrFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "s/skgqxqsq2uiylee",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -83,12 +61,7 @@
       {
         "site": "bilibili",
         "id": "1856",
-        "begin": "2005-07-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-07-13T16:00:00.000Z"
       }
     ]
   },
@@ -104,7 +77,6 @@
     "officialSite": "http://www.vap.co.jp/amae/",
     "begin": "2005-07-01T01:00:00.000Z",
     "end": "2005-09-16T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -127,27 +99,16 @@
     "officialSite": "http://www.shuffle-tv.com/",
     "begin": "2005-07-07T15:30:00.000Z",
     "end": "2006-01-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rohz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "s/sm1ig1vymgt2wsr",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -167,7 +128,6 @@
     "officialSite": "http://www.tdd-1.com/",
     "begin": "2005-07-13T15:00:00.000Z",
     "end": "2005-10-19T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -187,31 +147,15 @@
     "officialSite": "http://web.archive.org/web/*/www.petopeto.com/",
     "begin": "2005-07-08T17:00:00.000Z",
     "end": "2005-09-30T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UZtl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "14086"
-      },
-      {
-        "site": "bilibili",
-        "id": "5011",
-        "begin": "2005-07-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -227,31 +171,15 @@
     "officialSite": "http://web.archive.org/web/*/www.gedou.net/",
     "begin": "2005-07-04T17:15:00.000Z",
     "end": "2005-09-26T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BEdBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "50681"
-      },
-      {
-        "site": "bilibili",
-        "id": "5071",
-        "begin": "2005-07-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -267,17 +195,11 @@
     "officialSite": "http://www.maql.co.jp/special/suzuka-tv/",
     "begin": "2005-07-06T16:00:00.000Z",
     "end": "2005-12-28T16:37:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TePeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -286,12 +208,7 @@
       {
         "site": "bilibili",
         "id": "1843",
-        "begin": "2005-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -307,27 +224,16 @@
     "officialSite": "http://www.hatsunejima.com/dcss/",
     "begin": "2005-07-02T15:30:00.000Z",
     "end": "2005-12-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7l0opg505CKFA2s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "o/oqhu3ia2kb0his5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -336,22 +242,12 @@
       {
         "site": "nicovideo",
         "id": "dcss",
-        "begin": "2012-07-11T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-11T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "657",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -367,7 +263,6 @@
     "officialSite": "http://www.maql.co.jp/special/sugarune/",
     "begin": "2005-07-01T22:00:00.000Z",
     "end": "2006-06-23T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -387,31 +282,15 @@
     "officialSite": "http://www.mahousyoujo.com/",
     "begin": "2005-07-03T15:00:00.000Z",
     "end": "2005-09-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8DkDgelPvic1g3kY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "23536"
-      },
-      {
-        "site": "bilibili",
-        "id": "1860",
-        "begin": "2005-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -427,17 +306,11 @@
     "officialSite": "http://trinet.cata.jp/moeken/",
     "begin": "2005-07-01T16:30:00.000Z",
     "end": "2005-09-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Hia8amABm1hR39V0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -446,12 +319,7 @@
       {
         "site": "bilibili",
         "id": "1841",
-        "begin": "2005-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -467,7 +335,6 @@
     "officialSite": "http://www.imagicatv.jp/content/anime-playball/index1.html",
     "begin": "2005-07-04T17:00:00.000Z",
     "end": "2005-09-26T18:14:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -487,17 +354,11 @@
     "officialSite": "http://www.paniponi-dash.com/",
     "begin": "2005-07-03T16:30:00.000Z",
     "end": "2005-12-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IGtV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -506,12 +367,7 @@
       {
         "site": "bilibili",
         "id": "1844",
-        "begin": "2005-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-07-02T16:00:00.000Z"
       }
     ]
   },
@@ -527,21 +383,10 @@
     "officialSite": "http://mv.avex.jp/okusama/",
     "begin": "2005-07-02T16:30:00.000Z",
     "end": "2005-09-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "8295"
-      },
-      {
-        "site": "bilibili",
-        "id": "5073",
-        "begin": "2005-07-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -560,31 +405,15 @@
     "officialSite": "http://www.tlblue.com/",
     "begin": "2005-07-06T17:40:00.000Z",
     "end": "2006-09-18T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HysWlPxia0hBz8Vk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "6804"
-      },
-      {
-        "site": "bilibili",
-        "id": "5009",
-        "begin": "2005-07-29T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -600,7 +429,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2005-07-22T16:00:00.000Z",
     "end": "2005-07-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -609,22 +437,12 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3940",
-        "begin": "2005-07-21T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-07-21T16:00:01.000Z"
       }
     ]
   },
@@ -640,27 +458,16 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2005-07-16T16:00:00.000Z",
     "end": "2005-07-16T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -669,22 +476,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5752",
-        "begin": "2005-07-15T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-07-15T16:00:01.000Z"
       }
     ]
   },
@@ -700,7 +497,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2005-07-16T17:10:00.000Z",
     "end": "2005-07-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -720,7 +516,6 @@
     "officialSite": "",
     "begin": "2005-07-23T16:00:00.000Z",
     "end": "2005-07-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -729,22 +524,12 @@
       {
         "site": "nicovideo",
         "id": "hagaren-shamballa",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "6379",
-        "begin": "2005-07-22T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-07-22T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2005/08.json
+++ b/data/items/2005/08.json
@@ -14,27 +14,16 @@
     "officialSite": "http://web.archive.org/web/*/www.guyver.jp/",
     "begin": "2005-08-06T10:00:00.000Z",
     "end": "2006-02-18T10:24:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6CIenARq2hh7ibWE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "2/2oxwe76p4ko9gm2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -43,22 +32,12 @@
       {
         "site": "letv",
         "id": "16262",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5007",
-        "begin": "2005-08-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-08-05T16:00:01.000Z"
       }
     ]
   },
@@ -70,7 +49,6 @@
     "officialSite": "http://www.shin-ei-animation.jp/sensoudouwashu/modules/bokugo/",
     "begin": "2005-08-13T16:00:00.000Z",
     "end": "2005-08-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -90,17 +68,11 @@
     "officialSite": "",
     "begin": "2005-08-05T16:00:00.000Z",
     "end": "2005-09-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "0/0ci2guo4k6dj9ni",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -120,17 +92,11 @@
     "officialSite": "",
     "begin": "2005-08-28T16:00:00.000Z",
     "end": "2005-09-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "6/6pnj579h402jj1m",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,7 +116,6 @@
     "officialSite": "http://anime.softgarage.com/prayers/index.html",
     "begin": "2005-08-26T16:00:00.000Z",
     "end": "2005-11-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -159,12 +124,7 @@
       {
         "site": "nicovideo",
         "id": "amg-players",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -183,7 +143,6 @@
     "officialSite": "https://web.archive.org/web/20090220135714/http://pierrot.jp/title/naruto/movie2005/index.html",
     "begin": "2005-08-05T16:00:00.000Z",
     "end": "2005-08-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -192,12 +151,7 @@
       {
         "site": "netflix",
         "id": "70101321",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   },
@@ -213,7 +167,6 @@
     "officialSite": "http://www.production-ig.co.jp/contents/works_sp/1300_/",
     "begin": "2005-08-20T16:00:00.000Z",
     "end": "2005-08-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -222,12 +175,7 @@
       {
         "site": "letv",
         "id": "10765",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2005/09.json
+++ b/data/items/2005/09.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/rockman_beast/",
     "begin": "2005-09-30T23:30:00.000Z",
     "end": "2006-04-01T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,27 +30,16 @@
     "officialSite": "http://www.square-enix.co.jp/dvd/ff7ac/",
     "begin": "2005-09-14T16:00:00.000Z",
     "end": "2005-09-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "comment": "",
-        "url": "http://vip.iqiyi.com/20110909/2fbdedacafd41bd8.html",
-        "exist": null
+        "url": "http://vip.iqiyi.com/20110909/2fbdedacafd41bd8.html"
       },
       {
         "site": "letv",
         "id": "76001",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "bilibili",
         "id": "4720",
-        "begin": "2005-09-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-09-13T16:00:01.000Z"
       }
     ]
   },
@@ -81,7 +64,6 @@
     "officialSite": "",
     "begin": "2005-09-24T16:00:00.000Z",
     "end": "2005-09-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -90,12 +72,7 @@
       {
         "site": "nicovideo",
         "id": "jump-ani-gintama",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2005/10.json
+++ b/data/items/2005/10.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.ariacompany.net/1st/",
     "begin": "2005-10-05T16:30:00.000Z",
     "end": "2005-12-28T17:07:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "ariaani01",
-        "begin": "2015-03-26T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-26T10:00:00.000Z"
       }
     ]
   },
@@ -44,17 +38,11 @@
     "officialSite": "http://www.ytv.co.jp/angelheart/",
     "begin": "2005-10-03T16:34:00.000Z",
     "end": "2006-09-25T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "c9ynJY3zY6EEguo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -63,12 +51,7 @@
       {
         "site": "bilibili",
         "id": "1850",
-        "begin": "2005-10-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -87,27 +70,16 @@
     "officialSite": "http://www.tbs.co.jp/rozen-maiden/part2/index-j.html",
     "begin": "2005-10-20T16:55:00.000Z",
     "end": "2006-01-26T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "72hEwiaqQAD6hH4c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "a/apnuwg9h5qpiayp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -116,32 +88,17 @@
       {
         "site": "nicovideo",
         "id": "rozen2",
-        "begin": "2014-01-24T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-24T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "523",
-        "begin": "2005-10-19T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-19T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7m399",
-        "begin": "2019-01-24T09:16:53.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-24T09:16:53.000Z"
       }
     ]
   },
@@ -160,27 +117,16 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/parakiss/",
     "begin": "2005-10-13T15:50:00.000Z",
     "end": "2005-12-29T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7lwnpQ1z4yGEAmo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5z92op3yvqadpiy",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -189,12 +135,7 @@
       {
         "site": "bilibili",
         "id": "4990",
-        "begin": "2005-10-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-13T16:00:01.000Z"
       }
     ]
   },
@@ -210,31 +151,15 @@
     "officialSite": "http://www.nanoha.com/archive2/",
     "begin": "2005-10-01T16:35:00.000Z",
     "end": "2005-12-24T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kreSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1263"
-      },
-      {
-        "site": "bilibili",
-        "id": "1536",
-        "begin": "2005-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -253,47 +178,26 @@
     "officialSite": "http://www.shakugan.com/",
     "begin": "2005-10-05T15:45:00.000Z",
     "end": "2006-03-22T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QOTfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk069t5",
-        "begin": "2014-04-09T23:06:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:06:15.000Z"
       },
       {
         "site": "qq",
         "id": "p/pd9w2pbdg6ppklj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15739",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -302,22 +206,12 @@
       {
         "site": "nicovideo",
         "id": "ch637",
-        "begin": "2010-10-11T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-11T18:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1600",
-        "begin": "2005-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -333,7 +227,6 @@
     "officialSite": "http://www.idatenjump.com/",
     "begin": "2005-10-01T00:30:00.000Z",
     "end": "2006-09-30T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -353,7 +246,6 @@
     "officialSite": "http://www.my-zhime.net/tv/main.html",
     "begin": "2005-10-06T16:40:00.000Z",
     "end": "2006-03-30T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -362,12 +254,7 @@
       {
         "site": "bilibili",
         "id": "3972",
-        "begin": "2005-10-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -383,7 +270,6 @@
     "officialSite": "http://www.j-blackcat.com/",
     "begin": "2005-10-06T16:25:00.000Z",
     "end": "2006-03-30T17:24:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -392,12 +278,7 @@
       {
         "site": "bilibili",
         "id": "2980",
-        "begin": "2005-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -413,17 +294,11 @@
     "officialSite": "http://www.noein.jp/",
     "begin": "2005-10-11T16:30:00.000Z",
     "end": "2006-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "frCMCnLYSIbpZ88",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -432,12 +307,7 @@
       {
         "site": "bilibili",
         "id": "1782",
-        "begin": "2005-10-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-10T16:00:00.000Z"
       }
     ]
   },
@@ -453,27 +323,16 @@
     "officialSite": "http://www.imagicatv.jp/content/toheart2/index.html",
     "begin": "2005-10-03T17:15:00.000Z",
     "end": "2005-12-30T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ve3YVr4klNI1sxs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/dabyulxptsyv3l2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -482,22 +341,12 @@
       {
         "site": "nicovideo",
         "id": "th2",
-        "begin": "2012-02-27T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-02-27T06:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "81577",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -513,7 +362,6 @@
     "officialSite": "http://www.blood.tv/",
     "begin": "2005-10-08T09:00:00.000Z",
     "end": "2006-09-23T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -522,12 +370,7 @@
       {
         "site": "nicovideo",
         "id": "blood-plus",
-        "begin": "2011-06-26T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-06-26T12:00:00.000Z"
       }
     ]
   },
@@ -543,17 +386,11 @@
     "officialSite": "http://trinet.cata.jp/happy-7/",
     "begin": "2005-10-02T15:30:00.000Z",
     "end": "2005-12-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2RDsatI4qOZJxy8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -562,12 +399,7 @@
       {
         "site": "bilibili",
         "id": "1845",
-        "begin": "2005-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -583,27 +415,16 @@
     "officialSite": "http://www.kadokawa.co.jp/canvas2/index.php",
     "begin": "2005-10-02T15:00:00.000Z",
     "end": "2006-03-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TX5KyDCWBkSnJY0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "t/tgnad37do7x0dd5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -612,12 +433,7 @@
       {
         "site": "letv",
         "id": "15619",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -633,17 +449,11 @@
     "officialSite": "http://www.jigokushoujo.com/top.html",
     "begin": "2005-10-04T15:00:00.000Z",
     "end": "2006-04-04T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "43106",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -652,12 +462,7 @@
       {
         "site": "nicovideo",
         "id": "jigokushoujo01",
-        "begin": "2017-08-22T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-22T15:00:00.000Z"
       }
     ]
   },
@@ -673,17 +478,11 @@
     "officialSite": "http://trinet.cata.jp/lamune/",
     "begin": "2005-10-10T18:25:00.000Z",
     "end": "2005-12-26T18:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QicPOTLQaiasgrqRE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -692,12 +491,7 @@
       {
         "site": "bilibili",
         "id": "1846",
-        "begin": "2005-10-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-09T16:00:00.000Z"
       }
     ]
   },
@@ -713,41 +507,20 @@
     "officialSite": "http://www.igpx.jp/",
     "begin": "2005-10-05T17:40:00.000Z",
     "end": "2006-03-29T18:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SoSAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "i/i1gn0pip7crglcn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "20924"
-      },
-      {
-        "site": "bilibili",
-        "id": "1777",
-        "begin": "2005-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -763,27 +536,16 @@
     "officialSite": "http://www.maql.co.jp/special/mushishi/www/",
     "begin": "2005-10-22T17:55:00.000Z",
     "end": "2006-06-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1nBLyTGXB0WoJo4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "2/2m6bqk3a57pzk1r",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -792,22 +554,12 @@
       {
         "site": "nicovideo",
         "id": "mushishi01",
-        "begin": "2014-04-18T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-18T06:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgxgit1",
-        "begin": "2018-05-31T16:09:20.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:09:20.000Z"
       }
     ]
   },
@@ -823,7 +575,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/aniyoko/",
     "begin": "2005-10-04T09:30:00.000Z",
     "end": "2006-09-26T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -843,17 +594,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/capeta/",
     "begin": "2005-10-04T09:00:00.000Z",
     "end": "2006-09-26T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1xnjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -862,12 +607,7 @@
       {
         "site": "bilibili",
         "id": "1781",
-        "begin": "2007-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -883,17 +623,11 @@
     "officialSite": "http://www.ntv.co.jp/akagi/",
     "begin": "2005-10-04T16:50:00.000Z",
     "end": "2006-03-28T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HTALiafFXxwVo5k4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -902,22 +636,12 @@
       {
         "site": "nicovideo",
         "id": "akagi_anime",
-        "begin": "2014-04-01T06:00:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-01T06:00:01.000Z"
       },
       {
         "site": "bilibili",
         "id": "1776",
-        "begin": "2005-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -933,17 +657,11 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/ginban/",
     "begin": "2005-10-08T17:50:00.000Z",
     "end": "2005-12-24T18:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "U51n5U2zI2HEQqo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -952,12 +670,7 @@
       {
         "site": "bilibili",
         "id": "1779",
-        "begin": "2005-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -973,17 +686,11 @@
     "officialSite": "http://www.cluster-edge.net/",
     "begin": "2005-10-04T16:00:00.000Z",
     "end": "2006-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rJtm5EyyImDDQak",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -992,12 +699,7 @@
       {
         "site": "bilibili",
         "id": "4993",
-        "begin": "2005-10-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-03T16:00:01.000Z"
       }
     ]
   },
@@ -1016,7 +718,6 @@
     "officialSite": "http://www.solty.net/",
     "begin": "2005-10-06T17:40:00.000Z",
     "end": "2006-03-30T18:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1025,22 +726,12 @@
       {
         "site": "bilibili",
         "id": "1848",
-        "begin": "2005-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-05T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "soltyrei-anime",
-        "begin": "2019-06-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-06-04T15:00:00.000Z"
       }
     ]
   },
@@ -1056,17 +747,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/wulong/",
     "begin": "2005-10-01T15:55:00.000Z",
     "end": "2006-03-25T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "v4t29FzCMnDTUbk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1075,12 +760,7 @@
       {
         "site": "bilibili",
         "id": "1478",
-        "begin": "2005-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -1096,17 +776,11 @@
     "officialSite": "http://www.at-x.com/program/detail/3638",
     "begin": "2005-10-04T17:40:00.000Z",
     "end": "2006-03-28T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8GhEwiaqQAD6hH4c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1115,12 +789,7 @@
       {
         "site": "bilibili",
         "id": "4992",
-        "begin": "2005-10-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-10-03T16:00:01.000Z"
       }
     ]
   },
@@ -1136,7 +805,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/beet_ex/",
     "begin": "2005-10-06T09:30:00.000Z",
     "end": "2006-03-30T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1156,17 +824,11 @@
     "officialSite": "http://www.z-gundam.net/z2/",
     "begin": "2005-10-29T16:00:00.000Z",
     "end": "2005-10-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "b/bkgr23ixigue23f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1186,17 +848,11 @@
     "officialSite": "",
     "begin": "2005-10-29T16:00:00.000Z",
     "end": "2006-04-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Nwv2dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2005/11.json
+++ b/data/items/2005/11.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.kadokawa.co.jp/karin/index.php",
     "begin": "2005-11-03T15:00:00.000Z",
     "end": "2006-05-11T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "1847",
-        "begin": "2005-11-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-11-02T16:00:00.000Z"
       }
     ]
   },
@@ -44,17 +38,11 @@
     "officialSite": "http://www.tv-asahi.co.jp/gaiking/",
     "begin": "2005-11-12T01:50:00.000Z",
     "end": "2006-09-23T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1ebd",
-        "begin": "2015-08-14T17:06:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:06:47.000Z"
       },
       {
         "site": "bangumi",
@@ -74,7 +62,6 @@
     "officialSite": "",
     "begin": "2005-11-03T13:30:00.000Z",
     "end": "2006-05-11T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -94,41 +81,20 @@
     "officialSite": "",
     "begin": "2005-11-01T16:00:00.000Z",
     "end": "2006-06-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QIt181vBMWicSULg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/ff8gwhoafxcojuz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3393"
-      },
-      {
-        "site": "bilibili",
-        "id": "2782",
-        "begin": "2005-10-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2005/12.json
+++ b/data/items/2005/12.json
@@ -11,21 +11,10 @@
     "officialSite": "http://www.rean-wings.net/",
     "begin": "2005-12-15T21:00:00.000Z",
     "end": "2006-09-07T21:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "3417"
-      },
-      {
-        "site": "bilibili",
-        "id": "1842",
-        "begin": "2005-12-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -42,27 +31,16 @@
     "officialSite": "http://www3.nhk.or.jp/anime/major/",
     "begin": "2005-12-10T09:00:00.000Z",
     "end": "2006-06-10T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Igr1c9tBse9S0Dg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc03et",
-        "begin": "2014-11-07T07:21:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-07T07:21:10.000Z"
       },
       {
         "site": "bangumi",
@@ -82,7 +60,6 @@
     "officialSite": "http://www.xebec-inc.co.jp/anime/dinobreaker/index.html",
     "begin": "2005-12-06T09:30:00.000Z",
     "end": "2006-09-19T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -102,17 +79,11 @@
     "officialSite": "http://mmv.co.jp/special/school-rumble/anime01/catalog/index.html",
     "begin": "2005-12-22T16:00:00.000Z",
     "end": "2005-12-22T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "t/tu9pg41hpdd7rq1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -121,12 +92,7 @@
       {
         "site": "bilibili",
         "id": "3752",
-        "begin": "2005-12-21T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-12-21T16:00:01.000Z"
       }
     ]
   },
@@ -143,27 +109,16 @@
     "officialSite": "http://www.starchild.co.jp/fafner/",
     "begin": "2005-12-29T16:00:00.000Z",
     "end": "2005-12-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yHxY1j6kFFK1M5s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha3e7d",
-        "begin": "2016-12-08T03:04:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-08T03:04:59.000Z"
       },
       {
         "site": "bangumi",
@@ -184,17 +139,11 @@
     "officialSite": "http://www.toei-anim.co.jp/sp/seiya_zenshou/",
     "begin": "2005-12-17T16:00:00.000Z",
     "end": "2006-02-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb24b9",
-        "begin": "2015-08-14T17:04:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:04:40.000Z"
       },
       {
         "site": "bangumi",
@@ -214,21 +163,10 @@
     "officialSite": "",
     "begin": "2005-12-07T16:00:00.000Z",
     "end": "2005-12-07T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "10277"
-      },
-      {
-        "site": "bilibili",
-        "id": "4982",
-        "begin": "2005-12-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -244,17 +182,11 @@
     "officialSite": "",
     "begin": "2005-12-17T16:00:00.000Z",
     "end": "2006-03-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6Folowtx4RibCAGg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -263,12 +195,7 @@
       {
         "site": "bilibili",
         "id": "1976",
-        "begin": "2005-12-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-12-16T16:00:00.000Z"
       }
     ]
   },
@@ -280,7 +207,6 @@
     "officialSite": "",
     "begin": "2005-12-17T16:00:00.000Z",
     "end": "2005-12-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -289,12 +215,7 @@
       {
         "site": "nicovideo",
         "id": "mushiking-movie01",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -310,7 +231,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2005_precureMH2/",
     "begin": "2005-12-10T16:00:00.000Z",
     "end": "2005-12-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -319,22 +239,12 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   }

--- a/data/items/2006/01.json
+++ b/data/items/2006/01.json
@@ -15,37 +15,21 @@
     "officialSite": "http://web.archive.org/web/*/www.staynight.com/",
     "begin": "2006-01-06T16:30:00.000Z",
     "end": "2006-06-16T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WpRw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrharxtp",
-        "begin": "2016-07-13T09:33:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-13T09:33:31.000Z"
       },
       {
         "site": "letv",
         "id": "54069",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -54,22 +38,12 @@
       {
         "site": "nicovideo",
         "id": "fatestaynight",
-        "begin": "2011-08-23T12:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-08-23T12:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "25210",
-        "begin": "2006-01-06T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "120732",
+        "begin": "2006-01-06T16:30:00.000Z"
       }
     ]
   },
@@ -85,41 +59,20 @@
     "officialSite": "http://kasimasi.com/",
     "begin": "2006-01-11T16:30:00.000Z",
     "end": "2011-03-30T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DjsGhOxSwgBj4Uk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "14335",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "8227"
-      },
-      {
-        "site": "bilibili",
-        "id": "1398",
-        "begin": "2006-01-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -135,7 +88,6 @@
     "officialSite": "http://www.rakugo-tennyo.com/",
     "begin": "2006-01-05T17:00:00.000Z",
     "end": "2006-03-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -144,12 +96,7 @@
       {
         "site": "bilibili",
         "id": "1400",
-        "begin": "2006-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -165,31 +112,15 @@
     "officialSite": "http://mv.avex.jp/remon/",
     "begin": "2006-01-06T17:05:00.000Z",
     "end": "2006-03-29T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5Ek0shqA8C6RD3c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "47539"
-      },
-      {
-        "site": "bilibili",
-        "id": "1402",
-        "begin": "2006-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -206,27 +137,16 @@
     "officialSite": "http://www.hantsuki.com/",
     "begin": "2006-01-12T15:30:00.000Z",
     "end": "2006-02-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VibvWVLwiaktAzsRk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "s/s1rh268oro7uo8c",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -235,12 +155,7 @@
       {
         "site": "bilibili",
         "id": "1391",
-        "begin": "2006-01-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-01-11T16:00:00.000Z"
       }
     ]
   },
@@ -259,7 +174,6 @@
     "officialSite": "http://www.tactical-roar.com/",
     "begin": "2006-01-07T15:30:00.000Z",
     "end": "2006-04-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -268,12 +182,7 @@
       {
         "site": "bilibili",
         "id": "4954",
-        "begin": "2006-01-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-01-06T16:00:01.000Z"
       }
     ]
   },
@@ -289,17 +198,11 @@
     "officialSite": "http://trinet.cata.jp/kagihime/",
     "begin": "2006-01-03T16:45:00.000Z",
     "end": "2006-03-28T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SIN9ib2PJOXfaWMA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -319,7 +222,6 @@
     "officialSite": "http://www.gonzo.co.jp/archives/majikano/",
     "begin": "2006-01-01T14:00:00.000Z",
     "end": "2006-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -339,7 +241,6 @@
     "officialSite": "http://www.ndbrothers.com/",
     "begin": "2006-01-09T16:30:00.000Z",
     "end": "2006-03-27T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -348,12 +249,7 @@
       {
         "site": "bilibili",
         "id": "4948",
-        "begin": "2006-01-08T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-01-08T16:00:01.000Z"
       }
     ]
   },
@@ -369,21 +265,10 @@
     "officialSite": "http://www.rescue-w.jp/",
     "begin": "2006-01-08T16:30:00.000Z",
     "end": "2009-05-08T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "4256"
-      },
-      {
-        "site": "bilibili",
-        "id": "1393",
-        "begin": "2006-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -399,7 +284,6 @@
     "officialSite": "http://www.aniplex.co.jp/kagemamo/",
     "begin": "2006-01-07T17:50:00.000Z",
     "end": "2006-03-25T19:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -408,12 +292,7 @@
       {
         "site": "bilibili",
         "id": "1399",
-        "begin": "2006-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -429,7 +308,6 @@
     "officialSite": "http://www.vap.co.jp/amae/",
     "begin": "2006-01-04T02:00:00.000Z",
     "end": "2006-03-22T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -449,7 +327,6 @@
     "officialSite": "http://www.kinnikuman.jp/",
     "begin": "2006-01-04T17:00:00.000Z",
     "end": "2006-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -469,17 +346,11 @@
     "officialSite": "http://www.beetrain.co.jp/contents/works/meineliebe/",
     "begin": "2006-01-22T14:30:00.000Z",
     "end": "2006-04-16T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZsbBP6cNfbsenAQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -488,12 +359,7 @@
       {
         "site": "bilibili",
         "id": "1879",
-        "begin": "2006-01-21T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-01-21T16:00:00.000Z"
       }
     ]
   },
@@ -509,17 +375,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/ayakashi/",
     "begin": "2006-01-12T15:50:00.000Z",
     "end": "2006-03-23T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xgnzcdkicrib1QzjY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -528,12 +388,7 @@
       {
         "site": "bilibili",
         "id": "1396",
-        "begin": "2006-01-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-01-11T16:00:00.000Z"
       }
     ]
   },
@@ -549,7 +404,6 @@
     "officialSite": "http://www.mxtv.co.jp/playball2/",
     "begin": "2006-01-09T17:45:00.000Z",
     "end": "2006-03-27T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -569,7 +423,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/crash_b-daman/",
     "begin": "2006-01-09T09:00:00.000Z",
     "end": "2006-12-25T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -578,12 +431,7 @@
       {
         "site": "bilibili",
         "id": "4951",
-        "begin": "2006-01-08T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-01-08T16:00:01.000Z"
       }
     ]
   },
@@ -599,7 +447,6 @@
     "officialSite": "http://www.tv-aichi.co.jp/tetsunoshin/",
     "begin": "2006-01-06T23:00:00.000Z",
     "end": "2006-12-30T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -619,17 +466,11 @@
     "officialSite": "http://studio-rikka.com/pale/",
     "begin": "2006-01-18T16:00:00.000Z",
     "end": "2006-01-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "k49p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -638,12 +479,7 @@
       {
         "site": "bilibili",
         "id": "4970",
-        "begin": "2005-12-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2005-12-31T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2006/02.json
+++ b/data/items/2006/02.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.mxtv.co.jp/papiyon/index.html",
     "begin": "2006-02-09T18:23:00.000Z",
     "end": "2006-03-16T19:08:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "http://www.tbs.co.jp/rec-aka/",
     "begin": "2006-02-02T17:10:00.000Z",
     "end": "2006-04-06T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UOjTUbkfj80wrhY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "1397",
-        "begin": "2006-02-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-02-01T16:00:00.000Z"
       }
     ]
   },
@@ -74,7 +62,6 @@
     "officialSite": "http://www.ergoproxy.com/",
     "begin": "2006-02-05T08:30:00.000Z",
     "end": "2006-08-12T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -94,17 +81,11 @@
     "officialSite": "http://asahi.co.jp/precure_ss/",
     "begin": "2006-02-04T23:30:00.000Z",
     "end": "2007-01-28T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb156x",
-        "begin": "2015-09-02T04:11:36.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-02T04:11:36.000Z"
       },
       {
         "site": "bangumi",
@@ -124,17 +105,11 @@
     "officialSite": "http://www.tbs.co.jp/bincho/",
     "begin": "2006-02-02T03:00:00.000Z",
     "end": "2006-03-30T03:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8D8KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -143,12 +118,7 @@
       {
         "site": "bilibili",
         "id": "1394",
-        "begin": "2006-02-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-02-01T16:00:00.000Z"
       }
     ]
   },
@@ -164,31 +134,15 @@
     "officialSite": "http://www.geneon-ent.co.jp/rondorobe/anime/hellsing/index.html",
     "begin": "2006-02-10T16:00:00.000Z",
     "end": "2012-12-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "46008",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "493"
-      },
-      {
-        "site": "bilibili",
-        "id": "2131",
-        "begin": "2006-02-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2006/03.json
+++ b/data/items/2006/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.momo100100.com/",
     "begin": "2006-03-02T15:30:00.000Z",
     "end": "2006-04-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "1395",
-        "begin": "2006-03-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-03-01T16:00:00.000Z"
       }
     ]
   },
@@ -42,47 +36,26 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tennipri/ova/index.html",
     "begin": "2006-03-24T16:00:00.000Z",
     "end": "2009-01-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JicicZV78lldM2tBw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjtiagp",
-        "begin": "2012-12-12T03:29:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-12T03:29:06.000Z"
       },
       {
         "site": "qq",
         "id": "a/acfk5vfysdwag2u",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "18425",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -91,22 +64,12 @@
       {
         "site": "mgtv",
         "id": "103475",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "4934",
-        "begin": "2006-03-23T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "33232",
+        "begin": "2006-03-23T16:00:01.000Z"
       }
     ]
   },
@@ -122,17 +85,11 @@
     "officialSite": "http://doraeiga.com/2006/",
     "begin": "2006-03-04T16:00:00.000Z",
     "end": "2006-03-04T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "81023",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -141,32 +98,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6miux",
-        "begin": "2018-05-31T16:00:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:00:11.000Z"
       }
     ]
   },
@@ -182,17 +124,11 @@
     "officialSite": "http://www.z-gundam.net/z3/",
     "begin": "2006-03-04T16:00:00.000Z",
     "end": "2006-03-04T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "v/vtivtiq6tmaojet",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -212,17 +148,11 @@
     "officialSite": "http://www.amuse-s-e.co.jp/hokuto/",
     "begin": "2006-03-11T16:00:00.000Z",
     "end": "2006-03-11T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "p/prx8eje3t5q99mm",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -231,12 +161,7 @@
       {
         "site": "nicovideo",
         "id": "hokuto-no-ken",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -252,7 +177,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2006_onepiece/",
     "begin": "2006-03-04T16:00:00.000Z",
     "end": "2006-03-04T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -272,17 +196,11 @@
     "officialSite": "http://ar-tonelico.jp",
     "begin": "2006-03-22T16:00:00.000Z",
     "end": "2006-03-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RywIhu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -302,31 +220,15 @@
     "officialSite": "http://mv.avex.jp/5-2/index.html",
     "begin": "2006-03-24T16:00:00.000Z",
     "end": "2007-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UYaCAGjOPnzfXcU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "764"
-      },
-      {
-        "site": "bilibili",
-        "id": "3762",
-        "begin": "2006-03-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -342,7 +244,6 @@
     "officialSite": "http://www.keroro-movie.net/",
     "begin": "2006-03-11T16:00:00.000Z",
     "end": "2006-03-11T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -351,12 +252,7 @@
       {
         "site": "pptv",
         "id": "9LQdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2006/04.json
+++ b/data/items/2006/04.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.imagicatv.jp/content/utaware/index.html",
     "begin": "2006-04-03T17:40:00.000Z",
     "end": "2006-09-25T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "h59q6FC2JmTHRa0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/lg7cgeun8f09agt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,32 +29,17 @@
       {
         "site": "nicovideo",
         "id": "utawarerumono",
-        "begin": "2015-10-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-15T06:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7srvp",
-        "begin": "2017-06-14T16:17:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T16:17:40.000Z"
       },
       {
         "site": "bilibili",
         "id": "1388",
-        "begin": "2006-04-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -81,17 +55,11 @@
     "officialSite": "http://www.oyashirosama.com/web/top/index.htm",
     "begin": "2006-04-04T17:35:00.000Z",
     "end": "2006-09-26T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "7/70bhsvctwwo7jta",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,22 +68,7 @@
       {
         "site": "nicovideo",
         "id": "oyashirosama",
-        "begin": "2016-08-23T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3554",
-        "begin": "2006-04-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-23T03:00:00.000Z"
       }
     ]
   },
@@ -131,17 +84,11 @@
     "officialSite": "http://disgaea.jp/akaitsuki/index.html",
     "begin": "2006-04-04T15:15:00.000Z",
     "end": "2006-06-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5iagUkvpg0A5x71c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,22 +97,12 @@
       {
         "site": "letv",
         "id": "18491",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1390",
-        "begin": "2006-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -181,27 +118,16 @@
     "officialSite": "http://www.starchild.co.jp/special/inukami/",
     "begin": "2006-04-05T16:00:00.000Z",
     "end": "2006-09-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qOLeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "1/1z6104o1qv6nhbl",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -221,37 +147,21 @@
     "officialSite": "http://www.tbs.co.jp/holic/",
     "begin": "2006-04-06T16:25:00.000Z",
     "end": "2013-01-20T19:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sppl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "o/ok0tlyqtts6vg0q",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1239",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -260,12 +170,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh7ks0d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -281,21 +186,10 @@
     "officialSite": "http://web.archive.org/web/*/www.girls-high.net/",
     "begin": "2006-04-03T16:30:00.000Z",
     "end": "2006-06-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "5881"
-      },
-      {
-        "site": "bilibili",
-        "id": "1483",
-        "begin": "2006-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -311,17 +205,11 @@
     "officialSite": "http://www.vap.co.jp/sasami-club/",
     "begin": "2006-04-13T09:00:00.000Z",
     "end": "2006-07-13T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibEdCwCiaOicjyfHYU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -341,17 +229,11 @@
     "officialSite": "http://trinet.cata.jp/garkun/",
     "begin": "2006-04-01T17:05:00.000Z",
     "end": "2006-06-24T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Y6yYFn7kVJL1c9s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -371,17 +253,11 @@
     "officialSite": "http://hicbc.com/tv/ray/index.htm",
     "begin": "2006-04-05T17:15:00.000Z",
     "end": "2006-06-28T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "O3RQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -390,22 +266,12 @@
       {
         "site": "letv",
         "id": "42483",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1482",
-        "begin": "2006-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -421,27 +287,16 @@
     "officialSite": "http://www.tbs.co.jp/megamisama/megami2/index-j.html",
     "begin": "2006-04-06T16:55:00.000Z",
     "end": "2014-08-11T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Rt6pJ4ic1ZaMGhOw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/dshcqhalk3nfoin",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -450,12 +305,7 @@
       {
         "site": "bilibili",
         "id": "1449",
-        "begin": "2006-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -474,27 +324,16 @@
     "officialSite": "http://www.ntv.co.jp/host/",
     "begin": "2006-04-04T16:10:00.000Z",
     "end": "2006-09-26T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KQ34dt5EtPJV0zs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "49316",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -503,52 +342,27 @@
       {
         "site": "nicovideo",
         "id": "hostbu",
-        "begin": "2014-04-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-15T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70205014",
-        "begin": "2017-04-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-01T07:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "t/tk0zxq4ahcvhzlx",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6jf75",
-        "begin": "2018-05-31T16:00:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:00:13.000Z"
       },
       {
         "site": "bilibili",
         "id": "1407",
-        "begin": "2006-04-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -564,17 +378,11 @@
     "officialSite": "http://www.starchild.co.jp/special/himawari/",
     "begin": "2006-04-08T15:30:00.000Z",
     "end": "2006-07-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KBnkYsowoN5Bvyc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -594,17 +402,11 @@
     "officialSite": "http://www.zegapain.net/tv/",
     "begin": "2006-04-06T09:00:00.000Z",
     "end": "2006-09-28T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "f7GLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -613,12 +415,7 @@
       {
         "site": "bilibili",
         "id": "1445",
-        "begin": "2006-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -635,47 +432,26 @@
     "officialSite": "http://www3.nhk.or.jp/anime/saiunkoku/",
     "begin": "2006-04-08T00:00:00.000Z",
     "end": "2007-02-24T00:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zmhT0TmfD02wLpY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0095",
-        "begin": "2014-11-06T09:32:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-06T09:32:13.000Z"
       },
       {
         "site": "letv",
         "id": "14691",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "109715",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -684,22 +460,12 @@
       {
         "site": "qq",
         "id": "7/7s5vctchzm87gd3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1299",
-        "begin": "2006-04-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -715,21 +481,10 @@
     "officialSite": "http://www.gonzo.co.jp/archives/witchblade/",
     "begin": "2006-04-05T16:45:00.000Z",
     "end": "2006-09-20T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "2939"
-      },
-      {
-        "site": "bilibili",
-        "id": "1447",
-        "begin": "2006-04-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -745,7 +500,6 @@
     "officialSite": "http://www.blacklagoon.jp/",
     "begin": "2006-04-08T17:35:00.000Z",
     "end": "2006-06-24T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -754,32 +508,17 @@
       {
         "site": "nicovideo",
         "id": "blacklagoon",
-        "begin": "2011-10-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-13T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1379",
-        "begin": "2006-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-07T16:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70308852",
-        "begin": "2017-11-29T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-29T15:00:00.000Z"
       }
     ]
   },
@@ -795,31 +534,15 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/get-chu/",
     "begin": "2006-04-04T16:30:00.000Z",
     "end": "2006-09-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wm9a2ECmFlS3NZ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "11728"
-      },
-      {
-        "site": "bilibili",
-        "id": "1479",
-        "begin": "2006-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -835,17 +558,11 @@
     "officialSite": "http://character.biglobe.ne.jp/special/magipoka/",
     "begin": "2006-04-04T16:30:00.000Z",
     "end": "2006-06-20T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3RTwbtY8rOpNyzM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -865,17 +582,11 @@
     "officialSite": "http://web.archive.org/web/*/www.gunghoworks.jp/visual/soullink/",
     "begin": "2006-04-01T16:35:00.000Z",
     "end": "2006-06-24T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KmVf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -884,12 +595,7 @@
       {
         "site": "bilibili",
         "id": "1474",
-        "begin": "2006-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -908,37 +614,21 @@
     "officialSite": "http://www.maql.co.jp/special/strawberrypanic/",
     "begin": "2006-04-03T17:45:00.000Z",
     "end": "2006-09-25T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pObiaYMguntwicvSU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "v/vdno40uxgrecfdh",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "23612",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -947,12 +637,7 @@
       {
         "site": "bilibili",
         "id": "1389",
-        "begin": "2006-04-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -968,31 +653,15 @@
     "officialSite": "http://www.imagicatv.jp/content/project-westwitch/index.html",
     "begin": "2006-04-07T16:45:00.000Z",
     "end": "2006-06-30T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4k45txibF9TOWFHw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3652"
-      },
-      {
-        "site": "bilibili",
-        "id": "3335",
-        "begin": "2006-04-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1008,31 +677,15 @@
     "officialSite": "http://www.shopro.co.jp/tv/kirarevo/",
     "begin": "2006-04-07T09:00:00.000Z",
     "end": "2008-03-28T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ya2XFX3jU5H0cto",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "49559"
-      },
-      {
-        "site": "bilibili",
-        "id": "1258",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
       }
     ]
   },
@@ -1049,27 +702,16 @@
     "officialSite": "http://www.maql.co.jp/special/school-rumble/index02.html",
     "begin": "2006-04-02T16:36:00.000Z",
     "end": "2006-09-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1HZRzzedDUuuLJQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/l6sbyahngnqf03u",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1078,22 +720,12 @@
       {
         "site": "letv",
         "id": "80318",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3750",
-        "begin": "2006-04-01T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-01T16:00:01.000Z"
       }
     ]
   },
@@ -1109,21 +741,10 @@
     "officialSite": "http://web.archive.org/web/*/www.yumetsukai.com/",
     "begin": "2006-04-08T17:30:00.000Z",
     "end": "2006-06-24T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "7621"
-      },
-      {
-        "site": "bilibili",
-        "id": "1475",
-        "begin": "2006-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1139,31 +760,15 @@
     "officialSite": "http://www.himehime.jp/",
     "begin": "2006-04-12T15:00:00.000Z",
     "end": "2006-07-19T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uoF8ibmLIOHbZV78",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3496"
-      },
-      {
-        "site": "bilibili",
-        "id": "1480",
-        "begin": "2006-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1179,17 +784,11 @@
     "officialSite": "http://www.ki-ba.com/",
     "begin": "2006-04-01T23:30:00.000Z",
     "end": "2007-03-25T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dMSicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1198,12 +797,7 @@
       {
         "site": "bilibili",
         "id": "1813",
-        "begin": "2006-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -1219,17 +813,11 @@
     "officialSite": "http://www.gonzo.co.jp/archives/garakan/",
     "begin": "2006-04-04T17:40:00.000Z",
     "end": "2006-09-21T18:16:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Y8q1M5sBca8SkPg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1238,12 +826,7 @@
       {
         "site": "bilibili",
         "id": "1469",
-        "begin": "2006-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -1259,41 +842,20 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/bakegyamon/",
     "begin": "2006-04-03T09:00:00.000Z",
     "end": "2007-03-26T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iczIOjPRayghr6VE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk4e56l",
-        "begin": "2012-11-30T16:00:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-30T16:00:37.000Z"
       },
       {
         "site": "bangumi",
         "id": "58916"
-      },
-      {
-        "site": "bilibili",
-        "id": "1452",
-        "begin": "2006-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1312,17 +874,11 @@
     "officialSite": "http://www.simoun.tv/",
     "begin": "2006-04-03T17:00:00.000Z",
     "end": "2006-09-25T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7SQgngZs3Bp9ib2M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1331,12 +887,7 @@
       {
         "site": "bilibili",
         "id": "1461",
-        "begin": "2006-04-03T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-03T17:00:00.000Z"
       }
     ]
   },
@@ -1352,17 +903,11 @@
     "officialSite": "http://jyu-oh-sei.com/",
     "begin": "2006-04-13T16:00:00.000Z",
     "end": "2006-06-22T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sJxn5U2zI2HEQqo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1371,12 +916,7 @@
       {
         "site": "bilibili",
         "id": "1460",
-        "begin": "2006-04-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-12T16:00:00.000Z"
       }
     ]
   },
@@ -1392,27 +932,16 @@
     "officialSite": "http://www.haruhi.tv/",
     "begin": "2006-04-02T15:00:00.000Z",
     "end": "2006-07-02T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "c/c5o6rkf5q2pc2f6",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "9986",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1433,17 +962,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/digimon_s/",
     "begin": "2006-04-02T00:00:00.000Z",
     "end": "2007-03-25T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1dad",
-        "begin": "2015-08-17T03:19:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-17T03:19:59.000Z"
       },
       {
         "site": "bangumi",
@@ -1463,7 +986,6 @@
     "officialSite": "http://www.wowow.co.jp/anime/tokko/",
     "begin": "2006-04-15T15:30:00.000Z",
     "end": "2006-07-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1483,27 +1005,11 @@
     "officialSite": "http://www.s-nana.com/",
     "begin": "2006-04-05T14:55:00.000Z",
     "end": "2007-03-28T15:47:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464301",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "1382",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1512,12 +1018,7 @@
       {
         "site": "nicovideo",
         "id": "nana01",
-        "begin": "2015-03-13T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-13T06:00:00.000Z"
       }
     ]
   },
@@ -1533,7 +1034,6 @@
     "officialSite": "http://www.j-gintama.com/",
     "begin": "2006-04-10T08:30:00.000Z",
     "end": "2010-03-25T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1542,12 +1042,7 @@
       {
         "site": "nicovideo",
         "id": "gintama01",
-        "begin": "2015-04-17T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-17T06:00:00.000Z"
       }
     ]
   },
@@ -1563,7 +1058,6 @@
     "officialSite": "http://www.hakusensha.co.jp/moe/book/com/shibawanko/index.html",
     "begin": "2006-04-05T14:00:00.000Z",
     "end": "2007-03-14T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1572,12 +1066,7 @@
       {
         "site": "bilibili",
         "id": "3255",
-        "begin": "2006-04-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-04T16:00:01.000Z"
       }
     ]
   },
@@ -1593,7 +1082,6 @@
     "officialSite": "http://futagohime.jp/",
     "begin": "2006-04-01T01:00:00.000Z",
     "end": "2007-03-31T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1613,17 +1101,11 @@
     "officialSite": "http://www.kadokawa.co.jp/thethird/",
     "begin": "2006-04-13T15:30:00.000Z",
     "end": "2006-10-26T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0XNOzDSaCkiarKZE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1632,12 +1114,7 @@
       {
         "site": "bilibili",
         "id": "1472",
-        "begin": "2006-04-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-12T16:00:00.000Z"
       }
     ]
   },
@@ -1653,7 +1130,6 @@
     "officialSite": "http://www.hack.channel.or.jp/roots/",
     "begin": "2006-04-05T16:30:00.000Z",
     "end": "2006-10-04T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1676,41 +1152,20 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/airgear/",
     "begin": "2006-04-04T16:00:00.000Z",
     "end": "2006-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CDALiafFXxwVo5k4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2469"
       },
       {
-        "site": "bilibili",
-        "id": "1467",
-        "begin": "2006-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "29089",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1726,17 +1181,11 @@
     "officialSite": "http://www.bem-tv.com/",
     "begin": "2006-04-01T10:00:00.000Z",
     "end": "2006-10-07T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yQP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1756,7 +1205,6 @@
     "officialSite": "http://www.tv-osaka.co.jp/mymelo_kurukuru/",
     "begin": "2006-04-02T00:30:00.000Z",
     "end": "2007-03-25T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1776,17 +1224,11 @@
     "officialSite": "http://web.archive.org/web/*/www.yoshimune-anime.com/index_content.html",
     "begin": "2006-04-05T16:30:00.000Z",
     "end": "2006-09-13T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8jcRjicddzQtu7FQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1806,7 +1248,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/wulong/",
     "begin": "2006-04-01T15:55:00.000Z",
     "end": "2006-09-30T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1826,31 +1267,15 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/spiderriders/",
     "begin": "2006-04-05T08:30:00.000Z",
     "end": "2006-09-27T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2RPta9M5qedKyDA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "100654"
-      },
-      {
-        "site": "bilibili",
-        "id": "4927",
-        "begin": "2006-04-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1866,27 +1291,16 @@
     "officialSite": "http://www.gungho.jp/cgame/visual/heaven/",
     "begin": "2006-04-01T00:00:00.000Z",
     "end": "2006-06-24T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VuLdW8Mpmdc6uCA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "g/gam3y5luf0yp8be",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1895,12 +1309,7 @@
       {
         "site": "bilibili",
         "id": "1466",
-        "begin": "2006-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -1916,27 +1325,16 @@
     "officialSite": "http://www3.nhk.or.jp/anime/tsubasa/",
     "begin": "2006-04-29T09:25:00.000Z",
     "end": "2006-11-04T09:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JQH8euJIuPZZ1z8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "k/k19h3z1ofm7wijx",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1945,22 +1343,12 @@
       {
         "site": "bilibili",
         "id": "1464",
-        "begin": "2006-04-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-28T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10386",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1976,17 +1364,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/rin-kake1_vsUSA/",
     "begin": "2006-04-06T17:40:00.000Z",
     "end": "2006-06-22T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IGpW1DyiaElCzMZk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1995,12 +1377,7 @@
       {
         "site": "bilibili",
         "id": "1881",
-        "begin": "2006-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -2016,7 +1393,6 @@
     "officialSite": "http://www.kaeruotoko.com/",
     "begin": "2006-04-05T17:40:00.000Z",
     "end": "2006-06-14T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2036,17 +1412,11 @@
     "officialSite": "http://www.ytv.co.jp/bj/index.html",
     "begin": "2006-04-10T10:00:00.000Z",
     "end": "2006-09-04T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjtgg1x",
-        "begin": "2017-10-10T09:17:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T09:17:09.000Z"
       },
       {
         "site": "bangumi",
@@ -2062,7 +1432,6 @@
     "officialSite": "http://www.akubigirl.com/",
     "begin": "2006-04-02T09:10:00.000Z",
     "end": "2006-09-10T22:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2082,7 +1451,6 @@
     "officialSite": "http://web.archive.org/web/*/www.bs-i.co.jp/main/entertainment/show.php?0050",
     "begin": "2006-04-09T00:30:00.000Z",
     "end": "2006-10-08T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2098,7 +1466,6 @@
     "officialSite": "http://www.vap.co.jp/mimika/index.html",
     "begin": "2006-04-03T09:00:00.000Z",
     "end": "2009-03-13T08:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2121,7 +1488,6 @@
     "officialSite": "",
     "begin": "2006-04-29T16:00:00.000Z",
     "end": "2006-04-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2130,12 +1496,7 @@
       {
         "site": "bilibili",
         "id": "4917",
-        "begin": "2006-04-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-28T16:00:01.000Z"
       }
     ]
   },
@@ -2151,7 +1512,6 @@
     "officialSite": "http://www.ariacompany.net/2nd/",
     "begin": "2006-04-02T16:00:00.000Z",
     "end": "2006-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2160,12 +1520,7 @@
       {
         "site": "nicovideo",
         "id": "arianatu01",
-        "begin": "2015-04-02T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-02T10:00:00.000Z"
       }
     ]
   },
@@ -2181,41 +1536,20 @@
     "officialSite": "",
     "begin": "2006-04-05T16:00:00.000Z",
     "end": "2006-06-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FDcSkPhezgxv7VU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "14275",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "9425"
-      },
-      {
-        "site": "bilibili",
-        "id": "1465",
-        "begin": "2006-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -2231,27 +1565,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2006-04-15T16:00:00.000Z",
     "end": "2006-04-15T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/v_19rrifwgai.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/v_19rrifwgai.html"
       },
       {
         "site": "bangumi",
@@ -2260,12 +1583,7 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2281,17 +1599,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2006-04-15T16:00:00.000Z",
     "end": "2006-04-15T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -2300,22 +1612,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2331,7 +1633,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2006-04-03T08:35:00.000Z",
     "end": "2006-06-09T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2351,17 +1652,11 @@
     "officialSite": "",
     "begin": "2006-04-26T16:00:00.000Z",
     "end": "2006-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iasWicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2381,7 +1676,6 @@
     "officialSite": "http://www.punie.jp/",
     "begin": "2006-04-05T16:00:00.000Z",
     "end": "2007-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2390,32 +1684,17 @@
       {
         "site": "pptv",
         "id": "ASwXlf1j0xF08lo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "95348",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4926",
-        "begin": "2006-04-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-04-04T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2006/05.json
+++ b/data/items/2006/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.demonbane.com/anime/",
     "begin": "2006-05-18T15:00:00.000Z",
     "end": "2006-08-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "t4J9ib2PJOXfaWMA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1473",
-        "begin": "2006-05-17T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-05-17T16:00:00.000Z"
       }
     ]
   },
@@ -51,31 +40,15 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/kamisama/",
     "begin": "2006-05-18T13:30:00.000Z",
     "end": "2006-08-10T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8jwIhu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "10246"
-      },
-      {
-        "site": "bilibili",
-        "id": "1454",
-        "begin": "2006-05-17T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2006/06.json
+++ b/data/items/2006/06.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.hachikuro.net/",
     "begin": "2006-06-29T16:00:00.000Z",
     "end": "2006-09-14T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zmNe3ESqGlia7OaE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "x/xumudvzjaautu6q",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "bilibili",
         "id": "3318",
-        "begin": "2006-06-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-06-28T16:00:01.000Z"
       }
     ]
   },
@@ -62,27 +46,16 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/binboushimai/",
     "begin": "2006-06-29T17:40:00.000Z",
     "end": "2006-09-14T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1XZRzzedDUuuLJQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/9y1p6nqbhm2fe7o",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -91,12 +64,7 @@
       {
         "site": "bilibili",
         "id": "1434",
-        "begin": "2006-06-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-06-28T16:00:00.000Z"
       }
     ]
   },
@@ -112,17 +80,11 @@
     "officialSite": "http://www.sonymusic.co.jp/Animation/ppgz/",
     "begin": "2006-06-30T22:00:00.000Z",
     "end": "2007-06-29T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eicfhX8ctndsibvCQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -145,17 +107,11 @@
     "officialSite": "http://www.flag20xx.net/",
     "begin": "2006-06-16T03:00:00.000Z",
     "end": "2007-03-02T03:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "f8iazMZnicb60QjvY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -164,22 +120,7 @@
       {
         "site": "nicovideo",
         "id": "flag",
-        "begin": "2012-03-28T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1328",
-        "begin": "2006-06-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-28T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/2006/07.json
+++ b/data/items/2006/07.json
@@ -7,7 +7,6 @@
     "officialSite": "http://web.archive.org/web/*/www.tokyokids.co.jp/monta/index.htm",
     "begin": "2006-07-31T23:30:00.000Z",
     "end": "2007-01-28T03:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -27,17 +26,11 @@
     "officialSite": "http://www.starchild.co.jp/special/tonagra/",
     "begin": "2006-07-08T16:00:00.000Z",
     "end": "2006-09-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "b6CcGoLoWJb5d98",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -57,17 +50,11 @@
     "officialSite": "http://www.mediafactory.co.jp/anime/chocosis/",
     "begin": "2006-07-11T15:00:00.000Z",
     "end": "2006-12-19T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lbiaDAWnPP33gXsY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -76,32 +63,12 @@
       {
         "site": "nicovideo",
         "id": "tyocosis",
-        "begin": "2012-09-05T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3309",
-        "begin": "2006-07-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-05T06:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "9424",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -120,17 +87,11 @@
     "officialSite": "http://www.ufotable.com/coyote/",
     "begin": "2006-07-03T16:30:00.000Z",
     "end": "2006-09-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "b7ibKCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -139,12 +100,7 @@
       {
         "site": "letv",
         "id": "22612",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -160,17 +116,11 @@
     "officialSite": "http://www.zero-tsukaima.com/zero/index.html",
     "begin": "2006-07-02T15:30:00.000Z",
     "end": "2006-09-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "q/q9sh9ergivpd3ou",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -179,22 +129,12 @@
       {
         "site": "nicovideo",
         "id": "zero-tsukaima",
-        "begin": "2011-12-14T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-12-14T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "818",
-        "begin": "2006-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -210,31 +150,15 @@
     "officialSite": "http://www.konami.jp/visual/akazukin/",
     "begin": "2006-07-01T00:00:00.000Z",
     "end": "2007-03-31T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "bZ9p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "49050"
-      },
-      {
-        "site": "bilibili",
-        "id": "1435",
-        "begin": "2006-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -250,7 +174,6 @@
     "officialSite": "http://www.gamecity.ne.jp/neoromance/tv/ange/",
     "begin": "2006-07-08T12:30:00.000Z",
     "end": "2006-09-30T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -259,22 +182,12 @@
       {
         "site": "bilibili",
         "id": "4823",
-        "begin": "2006-07-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-07T16:00:01.000Z"
       },
       {
         "site": "letv",
         "id": "42061",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -290,17 +203,11 @@
     "officialSite": "http://www.onimaru.net/",
     "begin": "2006-07-04T17:00:00.000Z",
     "end": "2006-09-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TPbRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -309,12 +216,7 @@
       {
         "site": "bilibili",
         "id": "3406",
-        "begin": "2006-07-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-03T16:00:01.000Z"
       }
     ]
   },
@@ -330,17 +232,11 @@
     "officialSite": "http://www.kadokawa.co.jp/hikky/",
     "begin": "2006-07-09T16:00:00.000Z",
     "end": "2006-12-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yQD8euJIuPZZ1z8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -360,21 +256,10 @@
     "officialSite": "http://web.archive.org/web/*/trinet.cata.jp/tsuyokiss/",
     "begin": "2006-07-01T17:05:00.000Z",
     "end": "2006-09-16T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "8008"
-      },
-      {
-        "site": "bilibili",
-        "id": "1441",
-        "begin": "2006-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -390,37 +275,21 @@
     "officialSite": "http://www.maql.co.jp/special/bokuragaita/www/index.html",
     "begin": "2006-07-03T17:00:00.000Z",
     "end": "2006-12-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8VItqxN56SeKCHA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/wr5uwohgi6mtjae",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "8420",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -429,12 +298,7 @@
       {
         "site": "bilibili",
         "id": "1383",
-        "begin": "2006-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -450,17 +314,11 @@
     "officialSite": "http://www.maql.co.jp/special/mamololli/www/index.html",
     "begin": "2006-07-01T17:00:00.000Z",
     "end": "2006-09-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "w3FMyjKYCEapJ48",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -469,12 +327,7 @@
       {
         "site": "bilibili",
         "id": "1442",
-        "begin": "2006-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -493,17 +346,11 @@
     "officialSite": "http://www.innocent-v.com/",
     "begin": "2006-07-26T15:00:00.000Z",
     "end": "2006-10-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "j8G7OaEHd7UYlv4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -512,12 +359,7 @@
       {
         "site": "bilibili",
         "id": "1437",
-        "begin": "2006-07-26T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-26T16:00:00.000Z"
       }
     ]
   },
@@ -533,31 +375,15 @@
     "officialSite": "http://web.archive.org/web/*/www.universalpictures.jp/sp/zaizen/",
     "begin": "2006-07-05T17:40:00.000Z",
     "end": "2006-09-20T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VibPeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "97170"
-      },
-      {
-        "site": "bilibili",
-        "id": "4914",
-        "begin": "2006-07-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -573,27 +399,16 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2006-07-15T16:00:00.000Z",
     "end": "2006-07-15T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -602,22 +417,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5751",
-        "begin": "2006-07-14T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-14T16:00:01.000Z"
       }
     ]
   },
@@ -633,17 +438,11 @@
     "officialSite": "http://www.projectblue.jp/",
     "begin": "2006-07-02T16:00:00.000Z",
     "end": "2006-12-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fKibZF3iclVZP2dNw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -652,12 +451,7 @@
       {
         "site": "bilibili",
         "id": "5223",
-        "begin": "2006-07-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-01T16:00:01.000Z"
       }
     ]
   },
@@ -674,17 +468,11 @@
     "officialSite": "",
     "begin": "2006-07-29T16:00:00.000Z",
     "end": "2006-12-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uJRv7VW7K2nMSrI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -693,12 +481,7 @@
       {
         "site": "bilibili",
         "id": "1470",
-        "begin": "2006-07-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-28T16:00:00.000Z"
       }
     ]
   },
@@ -714,17 +497,11 @@
     "officialSite": "http://www.seed-stargazer.net/",
     "begin": "2006-07-14T16:00:00.000Z",
     "end": "2006-09-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7T8KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -744,7 +521,6 @@
     "officialSite": "",
     "begin": "2006-07-10T16:00:00.000Z",
     "end": "2006-07-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -753,22 +529,12 @@
       {
         "site": "nicovideo",
         "id": "hoshizora",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3019",
-        "begin": "2006-07-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-07-09T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2006/08.json
+++ b/data/items/2006/08.json
@@ -11,21 +11,10 @@
     "officialSite": "http://kemonozume.net/",
     "begin": "2006-08-05T15:30:00.000Z",
     "end": "2006-11-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "4237"
-      },
-      {
-        "site": "bilibili",
-        "id": "1433",
-        "begin": "2006-08-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -42,57 +31,31 @@
     "officialSite": "http://www.kids-station.com/minisite/gyagumanga2/",
     "begin": "2006-08-05T13:30:00.000Z",
     "end": "2006-10-21T13:37:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OnRQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjb8bl",
-        "begin": "2014-09-12T06:42:56.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:42:56.000Z"
       },
       {
         "site": "qq",
         "id": "2/2w0n7vwp4l18dj4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15960",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "42752",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,12 +64,7 @@
       {
         "site": "bilibili",
         "id": "1594",
-        "begin": "2006-08-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-08-04T16:00:00.000Z"
       }
     ]
   },
@@ -122,7 +80,6 @@
     "officialSite": "http://web.archive.org/web/*/www.rams.jp/hanoka/",
     "begin": "2006-08-07T16:00:00.000Z",
     "end": "2006-10-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -142,7 +99,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2006-08-01T16:00:00.000Z",
     "end": "2006-08-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -162,7 +118,6 @@
     "officialSite": "",
     "begin": "2006-08-04T16:00:00.000Z",
     "end": "2006-11-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -182,7 +137,6 @@
     "officialSite": "http://www.wowow.co.jp/anime/chevalier/",
     "begin": "2006-08-19T09:55:00.000Z",
     "end": "2007-02-24T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -191,22 +145,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhgeb59",
-        "begin": "2017-11-16T07:24:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-16T07:24:26.000Z"
       },
       {
         "site": "bilibili",
         "id": "2776",
-        "begin": "2006-08-18T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-08-18T16:00:00.000Z"
       }
     ]
   },
@@ -225,7 +169,6 @@
     "officialSite": "https://web.archive.org/web/20081216021804/http://pierrot.jp/title/naruto/movie2006/index.html",
     "begin": "2006-08-04T16:00:00.000Z",
     "end": "2006-08-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -234,12 +177,7 @@
       {
         "site": "netflix",
         "id": "70108386",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2006/09.json
+++ b/data/items/2006/09.json
@@ -11,31 +11,15 @@
     "officialSite": "http://character.biglobe.ne.jp/BBB/",
     "begin": "2006-09-08T14:30:00.000Z",
     "end": "2006-11-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kryHBW3TQ4HkYso",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2090"
-      },
-      {
-        "site": "bilibili",
-        "id": "1436",
-        "begin": "2006-09-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -51,7 +35,6 @@
     "officialSite": "http://www.obanstarracers.com/",
     "begin": "2006-09-23T23:06:00.000Z",
     "end": "2007-09-28T23:31:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,7 +54,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2006-09-08T16:00:00.000Z",
     "end": "2006-09-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,22 +62,12 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3942",
-        "begin": "2006-09-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-09-07T16:00:01.000Z"
       }
     ]
   },
@@ -111,7 +83,6 @@
     "officialSite": "http://www.ayumayu.net/",
     "begin": "2006-09-29T16:00:00.000Z",
     "end": "2007-01-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -131,21 +102,10 @@
     "officialSite": "http://www.wowow.co.jp/anime/taiyo/",
     "begin": "2006-09-17T16:00:00.000Z",
     "end": "2006-09-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "182294"
-      },
-      {
-        "site": "bilibili",
-        "id": "1443",
-        "begin": "2006-09-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -162,57 +122,31 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_dp/",
     "begin": "2006-09-28T16:00:00.000Z",
     "end": "2010-09-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BSELiafFXxwVo5k4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb7brp",
-        "begin": "2015-09-15T09:37:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-15T09:37:01.000Z"
       },
       {
         "site": "qq",
         "id": "u/ulvcbmiwibeg2un",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10006441",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2017/jlbkm3",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -221,12 +155,7 @@
       {
         "site": "bilibili",
         "id": "6162",
-        "begin": "2006-09-27T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-09-27T16:00:01.000Z"
       }
     ]
   },
@@ -242,7 +171,6 @@
     "officialSite": "",
     "begin": "2006-09-22T16:00:00.000Z",
     "end": "2006-10-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2006/10.json
+++ b/data/items/2006/10.json
@@ -11,31 +11,15 @@
     "officialSite": "http://www.starchild.co.jp/special/otome/index.html",
     "begin": "2006-10-07T15:30:00.000Z",
     "end": "2012-09-10T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "14336",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3828"
-      },
-      {
-        "site": "bilibili",
-        "id": "1377",
-        "begin": "2006-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -51,7 +35,6 @@
     "officialSite": "http://www.vap.co.jp/sasami-club/",
     "begin": "2006-10-05T09:00:00.000Z",
     "end": "2007-01-11T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "4885",
-        "begin": "2006-10-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-02T16:00:01.000Z"
       }
     ]
   },
@@ -81,17 +59,11 @@
     "officialSite": "http://www.broccoli.co.jp/ga/game/ga2/index.html",
     "begin": "2006-10-01T17:00:00.000Z",
     "end": "2006-12-24T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EVompAxy4iaCDAWk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -111,27 +83,16 @@
     "officialSite": "http://www.konami.jp/visual/tokimemo-anime/",
     "begin": "2006-10-02T16:30:00.000Z",
     "end": "2007-03-26T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Akw4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/uqm4ypu0zrkwrzj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,12 +101,7 @@
       {
         "site": "bilibili",
         "id": "1410",
-        "begin": "2006-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -166,17 +122,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/kanon/",
     "begin": "2006-10-05T16:00:00.000Z",
     "end": "2007-03-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "8/8ozab44d94v8uod",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -185,22 +135,12 @@
       {
         "site": "bilibili",
         "id": "1374",
-        "begin": "2002-01-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2002-01-29T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kanon_anime",
-        "begin": "2018-12-27T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-27T15:00:00.000Z"
       }
     ]
   },
@@ -216,31 +156,15 @@
     "officialSite": "http://www.tbs.co.jp/yoakena/",
     "begin": "2006-10-04T17:30:00.000Z",
     "end": "2006-12-20T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JWdh30etHVuibPKQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2319"
-      },
-      {
-        "site": "bilibili",
-        "id": "1424",
-        "begin": "2006-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -256,27 +180,16 @@
     "officialSite": "http://www.corda-primopasso.com/",
     "begin": "2006-10-01T16:00:00.000Z",
     "end": "2007-03-25T16:36:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MhXwbtY8rOpNyzM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/9o0bf8t9sjllqlk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -285,12 +198,7 @@
       {
         "site": "nicovideo",
         "id": "cordapp",
-        "begin": "2014-05-30T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-30T06:00:00.000Z"
       }
     ]
   },
@@ -309,17 +217,11 @@
     "officialSite": "http://www.gonzo.co.jp/archives/pumpkin-scissors/",
     "begin": "2006-10-02T17:00:00.000Z",
     "end": "2007-03-17T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibkk0shqA8C6RD3c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -328,22 +230,12 @@
       {
         "site": "bilibili",
         "id": "1409",
-        "begin": "2006-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-01T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "pumpkin_scissors",
-        "begin": "2019-05-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-05-12T15:00:00.000Z"
       }
     ]
   },
@@ -359,7 +251,6 @@
     "officialSite": "http://www.ntv.co.jp/deathnote/",
     "begin": "2006-10-03T15:56:00.000Z",
     "end": "2007-06-26T16:26:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -368,22 +259,12 @@
       {
         "site": "nicovideo",
         "id": "deathnote",
-        "begin": "2014-11-11T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-11T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70204970",
-        "begin": "2016-10-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-15T07:00:00.000Z"
       }
     ]
   },
@@ -399,17 +280,11 @@
     "officialSite": "http://web.archive.org/web/*/www.kujian.info/",
     "begin": "2006-10-06T15:00:00.000Z",
     "end": "2006-12-22T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ycm0MpoAcK4Rjicc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -418,22 +293,7 @@
       {
         "site": "nicovideo",
         "id": "kujian",
-        "begin": "2013-08-22T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1425",
-        "begin": "2006-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-22T15:00:00.000Z"
       }
     ]
   },
@@ -449,17 +309,11 @@
     "officialSite": "http://web.archive.org/web/*/www.busourenkin.com/",
     "begin": "2006-10-04T16:00:00.000Z",
     "end": "2007-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IQz3dd1DsicFU0jo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -468,12 +322,7 @@
       {
         "site": "bilibili",
         "id": "1408",
-        "begin": "2006-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -489,7 +338,6 @@
     "officialSite": "http://web.archive.org/web/*/trinet.cata.jp/redgarden/",
     "begin": "2006-10-03T17:40:00.000Z",
     "end": "2007-03-13T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -509,17 +357,11 @@
     "officialSite": "http://www.tv-sumomo.com/",
     "begin": "2006-10-05T17:40:00.000Z",
     "end": "2007-03-15T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DzMOjPRayghr6VE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -528,12 +370,7 @@
       {
         "site": "bilibili",
         "id": "1811",
-        "begin": "2006-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -552,27 +389,16 @@
     "officialSite": "http://www.geass.jp/",
     "begin": "2006-10-05T16:25:00.000Z",
     "end": "2007-08-31T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9mi8h",
-        "begin": "2016-08-31T16:02:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:02:46.000Z"
       },
       {
         "site": "letv",
         "id": "42481",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -581,12 +407,7 @@
       {
         "site": "netflix",
         "id": "80065146",
-        "begin": "2017-12-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-13T15:00:00.000Z"
       }
     ]
   },
@@ -602,17 +423,11 @@
     "officialSite": "http://web.archive.org/web/*/www.megadere.com/",
     "begin": "2006-10-05T15:00:00.000Z",
     "end": "2007-03-29T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VOXgXsYsnNo9uyM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -621,22 +436,12 @@
       {
         "site": "letv",
         "id": "23107",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1416",
-        "begin": "2006-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -652,27 +457,16 @@
     "officialSite": "http://seimeinomago.net/web/index.html",
     "begin": "2006-10-03T17:17:00.000Z",
     "end": "2007-03-27T18:02:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sJNu7FS6KmjLSbE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hk3y7ix87i6m77g",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -692,27 +486,16 @@
     "officialSite": "http://mv.avex.jp/lovedol/",
     "begin": "2006-10-02T16:30:00.000Z",
     "end": "2006-12-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CjwHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/fm4gi2fu44vs2wk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -721,22 +504,12 @@
       {
         "site": "nicovideo",
         "id": "lovelyidol",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1429",
-        "begin": "2006-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -752,17 +525,11 @@
     "officialSite": "http://www.maql.co.jp/special/ghosthunt/www/index.html",
     "begin": "2006-10-03T16:00:00.000Z",
     "end": "2007-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "T4F7ibWHHN3XYVr4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -771,12 +538,7 @@
       {
         "site": "bilibili",
         "id": "1406",
-        "begin": "2006-10-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -792,17 +554,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/kenichi/",
     "begin": "2006-10-07T15:55:00.000Z",
     "end": "2007-09-29T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vplk4kqwIF7BP6c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -811,12 +567,7 @@
       {
         "site": "bilibili",
         "id": "1728",
-        "begin": "2006-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -832,17 +583,11 @@
     "officialSite": "http://www.negima.ne.jp/",
     "begin": "2006-10-04T08:30:00.000Z",
     "end": "2007-03-28T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yAH7eeFHticVY1j4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -851,32 +596,17 @@
       {
         "site": "nicovideo",
         "id": "negima02",
-        "begin": "2014-12-25T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-25T06:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "15636",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1421",
-        "begin": "2006-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -892,7 +622,6 @@
     "officialSite": "http://www.dgray-man.com/",
     "begin": "2006-10-03T09:00:00.000Z",
     "end": "2008-09-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -901,12 +630,7 @@
       {
         "site": "nicovideo",
         "id": "d-gray-man",
-        "begin": "2016-04-22T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-22T03:00:00.000Z"
       }
     ]
   },
@@ -922,17 +646,11 @@
     "officialSite": "http://www.hataraki-anime.com/",
     "begin": "2006-10-12T16:05:00.000Z",
     "end": "2006-12-21T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XPDLSbEXh8Uopg4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -941,12 +659,7 @@
       {
         "site": "bilibili",
         "id": "1412",
-        "begin": "2006-10-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-11T16:00:00.000Z"
       }
     ]
   },
@@ -962,17 +675,11 @@
     "officialSite": "http://www.tbs.co.jp/asatteno/",
     "begin": "2006-10-05T16:59:00.000Z",
     "end": "2006-12-21T17:33:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rIB7ibWHHN3XYVr4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -992,27 +699,16 @@
     "officialSite": "http://web.archive.org/web/*/www.mpri-a.jp/",
     "begin": "2006-10-01T17:29:00.000Z",
     "end": "2006-10-24T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "x3VQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "g/gxu6195iajn4bzt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1021,12 +717,7 @@
       {
         "site": "bilibili",
         "id": "1427",
-        "begin": "2006-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -1042,17 +733,11 @@
     "officialSite": "http://www.irohanihoheto.jp/",
     "begin": "2006-10-06T03:00:00.000Z",
     "end": "2007-04-06T03:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UvvGRKwSgsAjoQk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1072,17 +757,11 @@
     "officialSite": "http://www.ayakashiayashi.com/",
     "begin": "2006-10-07T09:00:00.000Z",
     "end": "2007-03-31T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jKCbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1091,12 +770,7 @@
       {
         "site": "bilibili",
         "id": "1417",
-        "begin": "2006-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -1112,17 +786,11 @@
     "officialSite": "http://www.imagicatv.jp/content/gift-er/index.html",
     "begin": "2006-10-05T18:00:00.000Z",
     "end": "2006-12-21T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "61Yxrxd97SuODHQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1131,12 +799,7 @@
       {
         "site": "bilibili",
         "id": "1423",
-        "begin": "2006-10-22T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-22T16:00:00.000Z"
       }
     ]
   },
@@ -1152,7 +815,6 @@
     "officialSite": "http://www.blacklagoon.jp/",
     "begin": "2006-10-03T16:10:00.000Z",
     "end": "2006-12-19T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1172,17 +834,11 @@
     "officialSite": "http://www.maql.co.jp/special/happiness-anime/",
     "begin": "2006-10-05T16:55:00.000Z",
     "end": "2006-12-21T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "l/l1qbtr8kn8t8f5l",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1191,32 +847,17 @@
       {
         "site": "nicovideo",
         "id": "happiness",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "9858",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1426",
-        "begin": "2006-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -1232,31 +873,15 @@
     "officialSite": "http://www.tbs.co.jp/anime/009-1/",
     "begin": "2006-10-05T16:29:00.000Z",
     "end": "2006-12-21T17:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gcu1M5sBca8SkPg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "12970"
-      },
-      {
-        "site": "bilibili",
-        "id": "4882",
-        "begin": "2006-10-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1272,17 +897,11 @@
     "officialSite": "http://www.jigokushoujo.com/",
     "begin": "2006-10-07T10:30:00.000Z",
     "end": "2007-04-07T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "43122",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1291,12 +910,7 @@
       {
         "site": "nicovideo",
         "id": "jigokushoujo02",
-        "begin": "2017-08-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-28T15:00:00.000Z"
       }
     ]
   },
@@ -1313,47 +927,21 @@
     "officialSite": "http://www.j-reborn.com/",
     "begin": "2006-10-07T01:30:00.000Z",
     "end": "2010-09-25T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjt45md",
-        "begin": "2015-11-16T07:54:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-16T07:54:55.000Z"
       },
       {
         "site": "letv",
         "id": "42673",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2012/jtjsry",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464686",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1362,12 +950,7 @@
       {
         "site": "nicovideo",
         "id": "reborn1",
-        "begin": "2016-02-24T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-24T06:00:00.000Z"
       }
     ]
   },
@@ -1386,27 +969,16 @@
     "officialSite": "http://web.archive.org/web/*/www.bartender-tv.com/",
     "begin": "2006-10-14T17:25:00.000Z",
     "end": "2006-12-30T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZNOuLJT6aqgLiafE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "n/nsw42914r9tbt6d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1415,12 +987,7 @@
       {
         "site": "bilibili",
         "id": "1422",
-        "begin": "2006-10-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-13T16:00:00.000Z"
       }
     ]
   },
@@ -1436,17 +1003,11 @@
     "officialSite": "http://www.souten.tv/",
     "begin": "2006-10-04T17:40:00.000Z",
     "end": "2007-03-14T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZMm0MpoAcK4Rjicc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1466,17 +1027,11 @@
     "officialSite": "http://www.gintetsu.com/",
     "begin": "2006-10-04T17:10:00.000Z",
     "end": "2007-03-28T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JgcCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1496,7 +1051,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/shizuku/",
     "begin": "2006-10-07T00:30:00.000Z",
     "end": "2007-09-29T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1516,17 +1070,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/olynssis/",
     "begin": "2006-10-05T16:30:00.000Z",
     "end": "2006-12-21T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WOjTUbkfj80wrhY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1535,12 +1083,7 @@
       {
         "site": "bilibili",
         "id": "1430",
-        "begin": "2006-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -1556,7 +1099,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yamanade/",
     "begin": "2006-10-03T16:30:00.000Z",
     "end": "2007-03-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1576,7 +1118,6 @@
     "officialSite": "http://www.bs-j.co.jp/kabuto/",
     "begin": "2006-10-05T09:30:00.000Z",
     "end": "2007-10-11T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1596,17 +1137,11 @@
     "officialSite": "http://www.suparobo-anime.jp/",
     "begin": "2006-10-04T16:30:00.000Z",
     "end": "2007-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "esib6OKAGdrQXlf0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1626,27 +1161,16 @@
     "officialSite": "http://www.sunrise-inc.co.jp/kekkaishi/",
     "begin": "2006-10-16T13:30:00.000Z",
     "end": "2008-02-11T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zHpFwyuRATibiaIIg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbvvqx",
-        "begin": "2014-08-12T07:17:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-12T07:17:43.000Z"
       },
       {
         "site": "bangumi",
@@ -1655,12 +1179,7 @@
       {
         "site": "bilibili",
         "id": "1405",
-        "begin": "2006-10-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-10-15T16:00:00.000Z"
       }
     ]
   },
@@ -1678,17 +1197,11 @@
     "officialSite": "http://www.mtvjapan.com/usavich/",
     "begin": "2006-10-09T16:00:00.000Z",
     "end": "2007-01-08T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhazvyt",
-        "begin": "2015-03-03T02:00:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-03T02:00:09.000Z"
       },
       {
         "site": "bangumi",
@@ -1697,22 +1210,12 @@
       {
         "site": "sohu",
         "id": "s2017/dhptwt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/db4pt2rnwc7cd5o",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1728,7 +1231,6 @@
     "officialSite": "",
     "begin": "2006-10-01T16:00:00.000Z",
     "end": "2006-10-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1737,22 +1239,12 @@
       {
         "site": "pptv",
         "id": "ccOtK5P5aacKiaPA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3827",
-        "begin": "2006-09-30T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-09-30T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2006/11.json
+++ b/data/items/2006/11.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tt2-anime.com/top.html",
     "begin": "2006-11-11T16:00:00.000Z",
     "end": "2007-02-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://web.archive.org/web/*/www.rgbadv.com/",
     "begin": "2006-11-19T00:30:00.000Z",
     "end": "2007-01-21T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,17 +49,11 @@
     "officialSite": "http://web.archive.org/web/*/www.s-strain.jp/",
     "begin": "2006-11-01T22:00:00.000Z",
     "end": "2007-02-14T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zficJR68VhcMmpAw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -82,27 +74,16 @@
     "officialSite": "http://www.sonypictures.jp/movies/paprika/",
     "begin": "2006-11-25T16:00:00.000Z",
     "end": "2006-11-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QCoGhOxSwgBj4Uk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10002033",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -122,7 +103,6 @@
     "officialSite": "http://www.gokigenyou.com/",
     "begin": "2006-11-29T16:00:00.000Z",
     "end": "2007-07-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -131,22 +111,7 @@
       {
         "site": "pptv",
         "id": "Mn1HxS2TA0GkIoo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2704",
-        "begin": "2006-11-28T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2006/12.json
+++ b/data/items/2006/12.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.tbs.co.jp/rozen-maiden/",
     "begin": "2006-12-22T18:30:00.000Z",
     "end": "2006-12-23T18:48:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "u/u29kivvpuvfowk8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,42 +27,22 @@
       {
         "site": "nicovideo",
         "id": "rozen-ova",
-        "begin": "2014-01-24T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-24T06:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "BjwHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "524",
-        "begin": "2006-12-21T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-12-21T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7l359",
-        "begin": "2019-01-24T09:06:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-24T09:06:23.000Z"
       }
     ]
   },
@@ -87,7 +61,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/wintergarden/",
     "begin": "2006-12-22T16:00:00.000Z",
     "end": "2006-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -96,12 +69,7 @@
       {
         "site": "bilibili",
         "id": "4863",
-        "begin": "2006-12-21T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-12-21T16:00:01.000Z"
       }
     ]
   },
@@ -118,17 +86,11 @@
     "officialSite": "http://www.toei-anim.co.jp/sp/seiya_koushou/",
     "begin": "2006-12-15T16:00:00.000Z",
     "end": "2007-02-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1eeh",
-        "begin": "2015-08-14T17:07:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:07:26.000Z"
       },
       {
         "site": "bangumi",
@@ -148,7 +110,6 @@
     "officialSite": "",
     "begin": "2006-12-09T16:00:00.000Z",
     "end": "2006-12-09T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -157,12 +118,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tgp",
-        "begin": "2015-08-06T12:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-06T12:03:19.000Z"
       }
     ]
   },
@@ -178,16 +134,10 @@
     "officialSite": "",
     "begin": "2006-12-08T16:00:00.000Z",
     "end": "2006-12-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": "",
         "url": "http://www.iqiyi.com/dongman/20120531/8041937e9c2f0d24.html"
       },
       {
@@ -197,12 +147,7 @@
       {
         "site": "bilibili",
         "id": "1607",
-        "begin": "2006-12-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2006-12-07T16:00:00.000Z"
       }
     ]
   },
@@ -218,7 +163,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2006_precureSS/",
     "begin": "2006-12-09T16:00:00.000Z",
     "end": "2006-12-09T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -227,22 +171,12 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   }

--- a/data/items/2007/01.json
+++ b/data/items/2007/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://gr-anime.com/",
     "begin": "2007-01-19T14:00:00.000Z",
     "end": "2007-07-06T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0xbycNgibruxPzTU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "4815",
-        "begin": "2007-01-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-18T16:00:01.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://www.starchild.co.jp/special/manabi/",
     "begin": "2007-01-07T16:30:00.000Z",
     "end": "2007-03-25T17:06:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sicbSULgejswvrRU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,22 +53,12 @@
       {
         "site": "nicovideo",
         "id": "manabi_straight",
-        "begin": "2017-10-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-01T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1315",
-        "begin": "2007-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -101,7 +74,6 @@
     "officialSite": "http://www.saintoctober.konami.jp/",
     "begin": "2007-01-04T16:55:00.000Z",
     "end": "2007-06-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,12 +82,7 @@
       {
         "site": "bilibili",
         "id": "1321",
-        "begin": "2007-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-03T16:00:00.000Z"
       }
     ]
   },
@@ -134,31 +101,15 @@
     "officialSite": "http://web.archive.org/web/*/www.deltoraquest.jp/",
     "begin": "2007-01-05T23:00:00.000Z",
     "end": "2008-03-28T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sfrGRKwSgsAjoQk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "38536"
-      },
-      {
-        "site": "bilibili",
-        "id": "4821",
-        "begin": "2007-01-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -175,27 +126,16 @@
     "officialSite": "http://www3.nhk.or.jp/anime/major/",
     "begin": "2007-01-06T09:00:00.000Z",
     "end": "2007-06-30T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MhrlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbziyh",
-        "begin": "2014-12-24T06:17:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-24T06:17:42.000Z"
       },
       {
         "site": "bangumi",
@@ -218,17 +158,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/hidamari/1st/",
     "begin": "2007-01-11T16:35:00.000Z",
     "end": "2008-07-11T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "N3lDwSmPicz2gHoY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -237,32 +171,17 @@
       {
         "site": "nicovideo",
         "id": "hidamari_01",
-        "begin": "2014-11-14T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-14T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "731",
-        "begin": "2007-01-11T16:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-11T16:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh2hh1h",
-        "begin": "2018-11-30T16:05:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-30T16:05:22.000Z"
       }
     ]
   },
@@ -278,17 +197,11 @@
     "officialSite": "http://web.archive.org/web/*/www.kyoshiro-sora.net/",
     "begin": "2007-01-05T04:30:00.000Z",
     "end": "2007-03-23T05:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LV4qqBB25iaSHBW0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -297,12 +210,7 @@
       {
         "site": "bilibili",
         "id": "2992",
-        "begin": "2007-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -318,27 +226,16 @@
     "officialSite": "http://www.starchild.co.jp/special/himawari2/",
     "begin": "2007-01-06T15:30:00.000Z",
     "end": "2007-03-31T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QPHMSrIYiaMYppw8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jzlxtdawrpcvsui",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -361,27 +258,16 @@
     "officialSite": "http://www.nodame-anime.com/season1/index.html",
     "begin": "2007-01-11T16:00:00.000Z",
     "end": "2007-06-28T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lLmEAmrQQH7hX8c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/jxqrm",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -390,12 +276,7 @@
       {
         "site": "bilibili",
         "id": "1039",
-        "begin": "2007-01-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-10T16:00:00.000Z"
       }
     ]
   },
@@ -414,17 +295,11 @@
     "officialSite": "http://www.shuffle-tv.com/",
     "begin": "2007-01-07T15:00:00.000Z",
     "end": "2007-03-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "r4l08lrAMG7RT7c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -444,17 +319,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/vvv/",
     "begin": "2007-01-11T17:05:00.000Z",
     "end": "2007-03-29T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2XtGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -474,7 +343,6 @@
     "officialSite": "http://www.mi-na.jp/",
     "begin": "2007-01-13T17:15:00.000Z",
     "end": "2007-03-24T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -483,12 +351,7 @@
       {
         "site": "bilibili",
         "id": "1322",
-        "begin": "2007-01-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-12T16:00:00.000Z"
       }
     ]
   },
@@ -505,27 +368,16 @@
     "officialSite": "http://www.nippon-animation.co.jp/lesmise/",
     "begin": "2007-01-07T10:30:00.000Z",
     "end": "2007-12-30T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eLSQDnbcTIrta9M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifu8mo",
-        "begin": "2014-09-12T06:32:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:32:44.000Z"
       },
       {
         "site": "bangumi",
@@ -534,12 +386,7 @@
       {
         "site": "bilibili",
         "id": "1314",
-        "begin": "2007-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -555,7 +402,6 @@
     "officialSite": "http://www.gamecity.ne.jp/neoromance/tv/ange/02/index.htm",
     "begin": "2007-01-05T16:30:00.000Z",
     "end": "2007-03-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -575,41 +421,20 @@
     "officialSite": "http://web.archive.org/web/*/www.majin.tv/",
     "begin": "2007-01-19T14:00:00.000Z",
     "end": "2007-04-20T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "a/am0nal8x8ak0ovf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4100"
       },
       {
-        "site": "bilibili",
-        "id": "1318",
-        "begin": "2007-01-18T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "46653",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -628,17 +453,11 @@
     "officialSite": "http://moepic.com/anime/",
     "begin": "2007-01-07T17:00:00.000Z",
     "end": "2007-03-25T17:36:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ecG8OqIIeLYZlic8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -647,12 +466,7 @@
       {
         "site": "bilibili",
         "id": "4817",
-        "begin": "2007-01-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-01-06T16:00:01.000Z"
       }
     ]
   },
@@ -668,17 +482,11 @@
     "officialSite": "",
     "begin": "2007-01-24T16:00:00.000Z",
     "end": "2007-04-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Roh08lrAMG7RT7c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2007/02.json
+++ b/data/items/2007/02.json
@@ -14,57 +14,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/naruto/index2.html",
     "begin": "2007-02-15T10:30:00.000Z",
     "end": "2017-03-23T10:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhabcll",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Lqfme5hSolM",
-        "begin": "2007-02-15T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3287",
-        "begin": "2016-01-14T11:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-14T11:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "cc001f06962411de83b1",
-        "begin": "2013-04-06T02:47:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "火影忍者",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2013-04-06T02:47:00.000Z"
       },
       {
         "site": "bangumi",
@@ -73,12 +37,7 @@
       {
         "site": "nicovideo",
         "id": "naruto_shippu",
-        "begin": "2015-07-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-15T06:00:00.000Z"
       }
     ]
   },
@@ -94,7 +53,6 @@
     "officialSite": "http://kyoryu-king.com/",
     "begin": "2007-02-03T22:00:00.000Z",
     "end": "2008-01-26T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -114,17 +72,11 @@
     "officialSite": "http://www.pro-reed.com/dancouganova/",
     "begin": "2007-02-15T13:30:00.000Z",
     "end": "2007-05-10T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "camTEXnfT43wbtY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -144,7 +96,6 @@
     "officialSite": "http://www.ikkitousen.com/",
     "begin": "2007-02-26T01:30:00.000Z",
     "end": "2007-05-14T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -164,17 +115,11 @@
     "officialSite": "http://asahi.co.jp/precure5/",
     "begin": "2007-02-03T23:30:00.000Z",
     "end": "2008-01-27T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb14x1",
-        "begin": "2015-08-18T04:13:41.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-18T04:13:41.000Z"
       },
       {
         "site": "bangumi",
@@ -197,7 +142,6 @@
     "officialSite": "http://web.archive.org/web/*/www.rocket-girl.jp/",
     "begin": "2007-02-21T15:00:00.000Z",
     "end": "2007-05-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -213,7 +157,6 @@
     "officialSite": "http://aquaplus.jp/th2v/product.html",
     "begin": "2007-02-28T16:00:00.000Z",
     "end": "2007-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -222,22 +165,12 @@
       {
         "site": "nicovideo",
         "id": "th2v",
-        "begin": "2012-03-03T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-03T13:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "iaMKibPKQKergbmQE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -253,7 +186,6 @@
     "officialSite": "",
     "begin": "2007-02-23T16:00:00.000Z",
     "end": "2007-02-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -262,12 +194,7 @@
       {
         "site": "nicovideo",
         "id": "hokuto-no-ken",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -283,7 +210,6 @@
     "officialSite": "",
     "begin": "2007-02-23T16:00:00.000Z",
     "end": "2007-06-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -292,12 +218,7 @@
       {
         "site": "pptv",
         "id": "ATkEgupQwP5h30c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -313,7 +234,6 @@
     "officialSite": "",
     "begin": "2007-02-23T16:00:00.000Z",
     "end": "2007-04-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -322,22 +242,12 @@
       {
         "site": "pptv",
         "id": "ORDradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "4828",
-        "begin": "2007-02-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "89132",
+        "begin": "2007-02-22T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2007/03.json
+++ b/data/items/2007/03.json
@@ -14,27 +14,16 @@
     "officialSite": "http://www.gurren-lagann.net/",
     "begin": "2007-03-31T23:30:00.000Z",
     "end": "2007-09-30T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "er6JB2icVRYPmZMw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "37026",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -43,22 +32,12 @@
       {
         "site": "nicovideo",
         "id": "gurren-lagann",
-        "begin": "2015-12-28T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-28T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70213196",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   },
@@ -74,17 +53,11 @@
     "officialSite": "http://www.reideen.jp/",
     "begin": "2007-03-03T10:00:00.000Z",
     "end": "2007-09-01T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fsq1M5sBca8SkPg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -93,12 +66,7 @@
       {
         "site": "bilibili",
         "id": "1323",
-        "begin": "2007-03-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-03-02T16:00:00.000Z"
       }
     ]
   },
@@ -114,17 +82,11 @@
     "officialSite": "http://www.hitohira.tv/",
     "begin": "2007-03-28T02:00:00.000Z",
     "end": "2007-06-13T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YqyYFn7kVJL1c9s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -133,22 +95,12 @@
       {
         "site": "bilibili",
         "id": "4810",
-        "begin": "2007-03-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-03-27T16:00:01.000Z"
       },
       {
         "site": "letv",
         "id": "9475",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -164,17 +116,11 @@
     "officialSite": "http://web.archive.org/web/*/www.moonlightmile.jp/",
     "begin": "2007-03-03T16:00:00.000Z",
     "end": "2007-05-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ruHbWcEnl9U4th4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -194,17 +140,11 @@
     "officialSite": "http://www.ktai-s.net/",
     "begin": "2007-03-20T03:00:00.000Z",
     "end": "2007-04-17T03:07:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5Schnwdt3RtibicGQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -224,27 +164,16 @@
     "officialSite": "http://5cm.yahoo.co.jp/",
     "begin": "2007-03-03T16:00:00.000Z",
     "end": "2007-03-03T17:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjze9o5",
-        "begin": "2014-04-09T23:31:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:31:04.000Z"
       },
       {
         "site": "letv",
         "id": "7264",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -253,22 +182,12 @@
       {
         "site": "nicovideo",
         "id": "5cm",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2688",
-        "begin": "2007-03-03T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-03-03T16:00:00.000Z"
       }
     ]
   },
@@ -284,17 +203,11 @@
     "officialSite": "http://doraeiga.com/2007/",
     "begin": "2007-03-10T16:00:00.000Z",
     "end": "2007-03-10T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "81024",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -303,32 +216,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6midd",
-        "begin": "2018-05-31T16:13:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:13:26.000Z"
       }
     ]
   },
@@ -344,7 +242,6 @@
     "officialSite": "",
     "begin": "2007-03-03T16:00:00.000Z",
     "end": "2007-03-03T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -364,7 +261,6 @@
     "officialSite": "http://www.onepiece-movie.com/",
     "begin": "2007-03-03T16:00:00.000Z",
     "end": "2007-03-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -380,7 +276,6 @@
     "officialSite": "",
     "begin": "2007-03-21T16:00:00.000Z",
     "end": "2007-03-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -389,12 +284,7 @@
       {
         "site": "nicovideo",
         "id": "mushiking-movie02",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -410,7 +300,6 @@
     "officialSite": "",
     "begin": "2007-03-28T16:00:00.000Z",
     "end": "2007-08-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -419,22 +308,12 @@
       {
         "site": "pptv",
         "id": "Z9umJIzyYqADgek",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1787",
-        "begin": "2007-03-27T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-03-27T16:00:00.000Z"
       }
     ]
   },
@@ -450,7 +329,6 @@
     "officialSite": "http://www.keroro-movie.net/",
     "begin": "2007-03-17T16:00:00.000Z",
     "end": "2007-03-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -459,22 +337,12 @@
       {
         "site": "pptv",
         "id": "9LQdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4820",
-        "begin": "2007-03-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-03-16T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2007/04.json
+++ b/data/items/2007/04.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.moribito.com/",
     "begin": "2007-04-06T23:06:00.000Z",
     "end": "2007-09-28T23:31:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EiaAbmQFn1xV49l4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh7nm05",
-        "begin": "2018-02-28T07:13:27.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-28T07:13:27.000Z"
       },
       {
         "site": "bilibili",
         "id": "1271",
-        "begin": "2007-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "http://www.nanoha.com/archive3/index.html",
     "begin": "2007-04-01T16:10:00.000Z",
     "end": "2007-09-23T16:52:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "v5Jt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,12 +58,7 @@
       {
         "site": "bilibili",
         "id": "1537",
-        "begin": "2007-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -102,27 +75,16 @@
     "officialSite": "http://www.emma-victorian.com/",
     "begin": "2007-04-16T16:30:00.000Z",
     "end": "2007-07-02T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tJhj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifuapp",
-        "begin": "2013-07-31T09:18:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-31T09:18:12.000Z"
       },
       {
         "site": "bangumi",
@@ -131,12 +93,7 @@
       {
         "site": "bilibili",
         "id": "2999",
-        "begin": "2007-04-19T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-19T16:00:00.000Z"
       }
     ]
   },
@@ -152,31 +109,15 @@
     "officialSite": "http://web.archive.org/web/*/www.ohedorocket.jp/",
     "begin": "2007-04-03T17:00:00.000Z",
     "end": "2007-09-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wgz4dt5EtPJV0zs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "7597"
-      },
-      {
-        "site": "bilibili",
-        "id": "1276",
-        "begin": "2007-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -192,31 +133,15 @@
     "officialSite": "http://mv.avex.jp/wellber/",
     "begin": "2007-04-03T17:43:00.000Z",
     "end": "2007-06-26T18:13:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5T4Jhib9VxQNm5Ew",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3420"
-      },
-      {
-        "site": "bilibili",
-        "id": "1267",
-        "begin": "2007-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -232,7 +157,6 @@
     "officialSite": "http://web.archive.org/web/*/www.romejuli.jp/",
     "begin": "2007-04-04T16:45:00.000Z",
     "end": "2007-09-25T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -252,17 +176,11 @@
     "officialSite": "http://www.starchild.co.jp/special/airantou/",
     "begin": "2007-04-04T16:20:00.000Z",
     "end": "2007-09-26T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "l/ltwi6ohyw2id66s",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -271,22 +189,7 @@
       {
         "site": "nicovideo",
         "id": "airantou",
-        "begin": "2012-09-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1304",
-        "begin": "2007-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-16T15:00:00.000Z"
       }
     ]
   },
@@ -302,31 +205,15 @@
     "officialSite": "http://www3.nhk.or.jp/anime/emily/",
     "begin": "2007-04-06T22:25:00.000Z",
     "end": "2007-09-28T22:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ut6pJ4ic1ZaMGhOw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "84583"
-      },
-      {
-        "site": "bilibili",
-        "id": "4793",
-        "begin": "2007-04-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -342,7 +229,6 @@
     "officialSite": "http://www.j-claymore.com/",
     "begin": "2007-04-03T16:41:00.000Z",
     "end": "2007-09-25T18:56:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -351,12 +237,7 @@
       {
         "site": "nicovideo",
         "id": "claymore_anime",
-        "begin": "2019-03-29T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-03-29T06:00:00.000Z"
       }
     ]
   },
@@ -372,7 +253,6 @@
     "officialSite": "http://www.gigantic-f.com/",
     "begin": "2007-04-04T16:50:00.000Z",
     "end": "2007-09-26T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -381,12 +261,7 @@
       {
         "site": "bilibili",
         "id": "1277",
-        "begin": "2007-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -402,7 +277,6 @@
     "officialSite": "http://www.d-black.net/1st/index.html",
     "begin": "2007-04-05T16:25:00.000Z",
     "end": "2009-10-03T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -411,22 +285,12 @@
       {
         "site": "nicovideo",
         "id": "dtb",
-        "begin": "2018-03-30T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-30T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1064",
-        "begin": "2007-04-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -442,17 +306,11 @@
     "officialSite": "http://www.gonzo.co.jp/archives/bokurano/",
     "begin": "2007-04-08T18:00:00.000Z",
     "end": "2007-09-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AiasWlPxia0hBz8Vk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -461,12 +319,7 @@
       {
         "site": "bilibili",
         "id": "1295",
-        "begin": "2007-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -482,27 +335,16 @@
     "officialSite": "http://www.lucky-ch.com/",
     "begin": "2007-04-08T11:00:00.000Z",
     "end": "2007-09-16T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EjINiaicNZyQdq6FA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "s/sgzt7sfc6mxfg48",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -511,32 +353,17 @@
       {
         "site": "nicovideo",
         "id": "ch329",
-        "begin": "2011-01-02T05:00:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-02T05:00:01.000Z"
       },
       {
         "site": "bilibili",
         "id": "1293",
-        "begin": "2007-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-07T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "52771",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -552,17 +379,11 @@
     "officialSite": "http://www.oofuri.com/1st/",
     "begin": "2007-04-12T16:40:00.000Z",
     "end": "2008-04-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "esiazMZnicb60QjvY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -571,22 +392,12 @@
       {
         "site": "nicovideo",
         "id": "oofuri",
-        "begin": "2017-09-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-26T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1015",
-        "begin": "2007-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -602,17 +413,11 @@
     "officialSite": "http://www.tbs.co.jp/lovecom/",
     "begin": "2007-04-07T08:30:00.000Z",
     "end": "2007-09-29T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XfbRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -621,12 +426,7 @@
       {
         "site": "bilibili",
         "id": "5221",
-        "begin": "2007-04-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-06T16:00:01.000Z"
       }
     ]
   },
@@ -642,7 +442,6 @@
     "officialSite": "http://web.archive.org/web/*/www.skullman.jp/",
     "begin": "2007-04-21T17:00:00.000Z",
     "end": "2007-07-21T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -663,27 +462,16 @@
     "officialSite": "http://web.archive.org/web/*/www.polyphonica.tv/",
     "begin": "2007-04-03T19:15:00.000Z",
     "end": "2007-06-19T19:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "s5Rv7VW7K2nMSrI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrg7sueh",
-        "begin": "2014-09-12T06:42:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:42:52.000Z"
       },
       {
         "site": "bangumi",
@@ -692,12 +480,7 @@
       {
         "site": "nicovideo",
         "id": "polyphonica",
-        "begin": "2013-07-29T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-29T06:00:00.000Z"
       }
     ]
   },
@@ -713,31 +496,15 @@
     "officialSite": "http://www.tbs.co.jp/anime/kaibutsu/",
     "begin": "2007-04-12T17:10:00.000Z",
     "end": "2008-04-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ASIdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4588"
-      },
-      {
-        "site": "bilibili",
-        "id": "1306",
-        "begin": "2007-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -756,37 +523,21 @@
     "officialSite": "http://www.broccoli.co.jp/sp/karin/",
     "begin": "2007-04-06T08:30:00.000Z",
     "end": "2007-09-28T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vZFs6lK4KGbJR68",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjpr6eh",
-        "begin": "2013-03-22T02:53:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-22T02:53:55.000Z"
       },
       {
         "site": "letv",
         "id": "6344",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -795,12 +546,7 @@
       {
         "site": "bilibili",
         "id": "1308",
-        "begin": "2007-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -816,31 +562,15 @@
     "officialSite": "http://mv.avex.jp/momotsuki/",
     "begin": "2007-04-02T16:30:00.000Z",
     "end": "2007-09-26T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "18129",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "809"
-      },
-      {
-        "site": "bilibili",
-        "id": "1310",
-        "begin": "2007-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -856,17 +586,11 @@
     "officialSite": "http://www.sunrise-inc.co.jp/idolmaster/",
     "begin": "2007-04-02T18:00:00.000Z",
     "end": "2007-09-25T18:13:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZtOuLJT6aqgLiafE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -875,12 +599,7 @@
       {
         "site": "bilibili",
         "id": "1278",
-        "begin": "2007-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -899,37 +618,21 @@
     "officialSite": "http://www.sola-project.com/",
     "begin": "2007-04-06T16:58:00.000Z",
     "end": "2015-07-29T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sJJt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9arel",
-        "begin": "2017-02-28T16:01:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-28T16:01:15.000Z"
       },
       {
         "site": "qq",
         "id": "j/je9n9cdxojhfsye",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -938,12 +641,7 @@
       {
         "site": "bilibili",
         "id": "1302",
-        "begin": "2007-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -959,17 +657,11 @@
     "officialSite": "http://www.gonzo.co.jp/works/0703.html",
     "begin": "2007-04-01T17:12:00.000Z",
     "end": "2007-09-30T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "a/apgvhkha7umincv",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -978,12 +670,7 @@
       {
         "site": "bilibili",
         "id": "1270",
-        "begin": "2007-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -999,41 +686,20 @@
     "officialSite": "http://web.archive.org/web/*/www.saintbeast.com/",
     "begin": "2007-04-03T17:00:00.000Z",
     "end": "2007-06-26T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wG5Z1ziblFVO2NJw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2091"
       },
       {
-        "site": "bilibili",
-        "id": "1977",
-        "begin": "2007-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "11871",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1053,37 +719,21 @@
     "officialSite": "http://hayatenogotoku.com/",
     "begin": "2007-04-01T01:00:00.000Z",
     "end": "2008-03-30T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sZ1o5k60JGLFQ6s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgibw29",
-        "begin": "2017-11-27T08:58:30.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-27T08:58:30.000Z"
       },
       {
         "site": "qq",
         "id": "0/0kgjaf3vg2iojl6",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1103,17 +753,11 @@
     "officialSite": "http://www.terra-e.com/",
     "begin": "2007-04-07T09:00:00.000Z",
     "end": "2007-09-22T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ntCsKpL4aKYJhib8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1122,12 +766,7 @@
       {
         "site": "bilibili",
         "id": "1272",
-        "begin": "2007-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1143,7 +782,6 @@
     "officialSite": "http://jeeg.tv/",
     "begin": "2007-04-05T14:30:00.000Z",
     "end": "2007-07-12T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1152,12 +790,7 @@
       {
         "site": "bilibili",
         "id": "1289",
-        "begin": "2007-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -1173,17 +806,11 @@
     "officialSite": "http://web.archive.org/web/*/pc.webnt.jp/stigma/",
     "begin": "2007-04-12T16:30:00.000Z",
     "end": "2007-09-20T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibVsmpAxy4iaCDAWk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1203,41 +830,20 @@
     "officialSite": "http://www.elcazador.tv/",
     "begin": "2007-04-02T16:30:00.000Z",
     "end": "2007-09-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9DYSkPhezgxv7VU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/74uy5tdrj5g2k55",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3489"
-      },
-      {
-        "site": "bilibili",
-        "id": "1275",
-        "begin": "2007-04-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1254,47 +860,26 @@
     "officialSite": "http://www3.nhk.or.jp/anime/saiunkoku/",
     "begin": "2007-04-07T00:00:00.000Z",
     "end": "2008-03-08T00:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "z2lU0jqgEE6xL5c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbzy7h",
-        "begin": "2014-11-07T06:20:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-07T06:20:45.000Z"
       },
       {
         "site": "letv",
         "id": "14692",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "109717",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1303,12 +888,7 @@
       {
         "site": "bilibili",
         "id": "1300",
-        "begin": "2007-04-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1327,17 +907,11 @@
     "officialSite": "http://www.starchild.co.jp/special/heroicage/index.html",
     "begin": "2007-04-01T16:42:00.000Z",
     "end": "2007-09-30T17:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YNCrKZH3Z6UIhu4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1346,22 +920,12 @@
       {
         "site": "nicovideo",
         "id": "heroicage",
-        "begin": "2015-04-16T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-16T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1274",
-        "begin": "2007-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -1377,47 +941,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/bluedragon/",
     "begin": "2007-04-07T00:00:00.000Z",
     "end": "2008-03-29T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TunUUrogkM4xrxc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjcrux",
-        "begin": "2014-01-27T07:11:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-27T07:11:12.000Z"
       },
       {
         "site": "qq",
         "id": "u/u5oo06fzr9p8btb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464700",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1426,22 +964,12 @@
       {
         "site": "letv",
         "id": "10003723",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1281",
-        "begin": "2007-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1457,21 +985,10 @@
     "officialSite": "http://www.beetrain.co.jp/contents/works2/spiderriders/",
     "begin": "2007-04-14T08:00:00.000Z",
     "end": "2007-10-13T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "106290"
-      },
-      {
-        "site": "bilibili",
-        "id": "4803",
-        "begin": "2007-04-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1487,17 +1004,11 @@
     "officialSite": "http://www.maql.co.jp/special/konnyaku/",
     "begin": "2007-04-03T17:15:00.000Z",
     "end": "2007-06-26T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DD0Ihu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1506,22 +1017,7 @@
       {
         "site": "nicovideo",
         "id": "konnyaku",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1279",
-        "begin": "2007-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1537,17 +1033,11 @@
     "officialSite": "http://www.nasinc.co.jp/jp/koutetsu-sangokushi/",
     "begin": "2007-04-05T17:15:00.000Z",
     "end": "2007-12-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ys65N58FdbMWlPw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1556,12 +1046,7 @@
       {
         "site": "bilibili",
         "id": "1309",
-        "begin": "2007-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -1577,17 +1062,11 @@
     "officialSite": "http://www.kissdum.com/",
     "begin": "2007-04-03T16:30:00.000Z",
     "end": "2007-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LmFb2UGnF1W4Np4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1596,12 +1075,7 @@
       {
         "site": "bilibili",
         "id": "1287",
-        "begin": "2007-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -1617,7 +1091,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/overdrive/",
     "begin": "2007-04-03T17:00:00.000Z",
     "end": "2007-09-25T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1640,41 +1113,20 @@
     "officialSite": "http://web.archive.org/web/*/shining-world.jp/tv_tearsXwind/",
     "begin": "2007-04-06T16:30:00.000Z",
     "end": "2007-06-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PW9Z1ziblFVO2NJw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "t/tmq0xxb06lt3mhk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "7941"
-      },
-      {
-        "site": "bilibili",
-        "id": "1307",
-        "begin": "2007-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1691,17 +1143,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/kitaro/",
     "begin": "2007-04-01T00:00:00.000Z",
     "end": "2009-03-22T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb159p",
-        "begin": "2015-08-14T17:08:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:08:46.000Z"
       },
       {
         "site": "bangumi",
@@ -1721,7 +1167,6 @@
     "officialSite": "http://www.bakugan.com/",
     "begin": "2007-04-05T08:30:00.000Z",
     "end": "2008-03-27T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1741,27 +1186,16 @@
     "officialSite": "http://www.shakugan.com/movie/index.html",
     "begin": "2007-04-21T16:00:00.000Z",
     "end": "2007-04-21T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20120815/bfcbebb2d01f1719.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20120815/bfcbebb2d01f1719.html"
       },
       {
         "site": "qq",
         "id": "o/ozxonwisw8kmtke",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1770,32 +1204,17 @@
       {
         "site": "nicovideo",
         "id": "shakugan-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1609",
-        "begin": "2007-04-20T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-20T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "45257",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1811,17 +1230,11 @@
     "officialSite": "",
     "begin": "2007-04-28T16:00:00.000Z",
     "end": "2007-04-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "4/4tohd6zvnip5odc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1830,22 +1243,12 @@
       {
         "site": "nicovideo",
         "id": "hokuto-no-ken",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4018",
-        "begin": "2007-04-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-27T16:00:01.000Z"
       }
     ]
   },
@@ -1861,27 +1264,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2007-04-21T16:00:00.000Z",
     "end": "2007-04-21T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/8d67b66bcbc2c11f.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/8d67b66bcbc2c11f.html"
       },
       {
         "site": "bangumi",
@@ -1890,22 +1282,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3888",
-        "begin": "2007-04-20T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "48472",
+        "begin": "2007-04-20T16:00:01.000Z"
       }
     ]
   },
@@ -1921,17 +1303,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2007-04-21T16:00:00.000Z",
     "end": "2007-04-21T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -1940,22 +1316,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1971,7 +1337,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2007-04-02T08:35:00.000Z",
     "end": "2007-06-12T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1991,7 +1356,6 @@
     "officialSite": "http://www.tv-osaka.co.jp/animelobby/story_chara_m.html",
     "begin": "2007-04-01T16:00:00.000Z",
     "end": "2008-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2011,7 +1375,6 @@
     "officialSite": "http://saiyuki-ova.net/web/top.htm",
     "begin": "2007-04-27T16:00:00.000Z",
     "end": "2008-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2020,22 +1383,12 @@
       {
         "site": "nicovideo",
         "id": "saiyukireload",
-        "begin": "2014-03-24T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-24T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2148",
-        "begin": "2007-04-26T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-26T16:00:00.000Z"
       }
     ]
   },
@@ -2051,7 +1404,6 @@
     "officialSite": "",
     "begin": "2007-04-04T16:00:00.000Z",
     "end": "2007-08-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2060,22 +1412,12 @@
       {
         "site": "pptv",
         "id": "0hfxb9c9retOzDQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3410",
-        "begin": "2007-04-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-04-03T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2007/05.json
+++ b/data/items/2007/05.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www3.nhk.or.jp/anime/coil/",
     "begin": "2007-05-12T09:30:00.000Z",
     "end": "2007-12-01T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "1294",
-        "begin": "2007-05-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-05-11T16:00:00.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "http://www.aquarion.info/",
     "begin": "2007-05-23T16:00:00.000Z",
     "end": "2007-11-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "g/g327ynn2eboikof",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "nicovideo",
         "id": "aquarion-betrayal",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -81,17 +64,11 @@
     "officialSite": "",
     "begin": "2007-05-25T16:00:00.000Z",
     "end": "2007-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AUs1sxuB8SibSEHg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -111,17 +88,11 @@
     "officialSite": "http://www.nhk.or.jp/ani-kuri",
     "begin": "2007-05-07T16:00:00.000Z",
     "end": "2007-12-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pUwopg505CKFA2s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2007/06.json
+++ b/data/items/2007/06.json
@@ -11,7 +11,6 @@
     "officialSite": "http://dmc-tv.com/",
     "begin": "2007-06-14T14:00:00.000Z",
     "end": "2007-09-06T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://tetsuko.jp/",
     "begin": "2007-06-24T01:00:00.000Z",
     "end": "2007-09-23T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,12 +38,7 @@
       {
         "site": "bilibili",
         "id": "1358",
-        "begin": "2007-06-23T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-06-23T16:00:00.000Z"
       }
     ]
   },
@@ -61,17 +54,11 @@
     "officialSite": "http://web.archive.org/web/*/www.universalpictures.jp/sp/wangan/",
     "begin": "2007-06-09T12:00:00.000Z",
     "end": "2012-06-06T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IBjjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,22 +67,12 @@
       {
         "site": "bilibili",
         "id": "3262",
-        "begin": "2007-06-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-06-14T16:00:01.000Z"
       },
       {
         "site": "letv",
         "id": "47475",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -111,17 +88,11 @@
     "officialSite": "http://www.neko-rahmen.com/",
     "begin": "2007-06-22T16:00:00.000Z",
     "end": "2007-07-13T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "X8yoJo70ZKIFgibs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -141,7 +112,6 @@
     "officialSite": "",
     "begin": "2007-06-01T16:00:00.000Z",
     "end": "2007-09-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -161,7 +131,6 @@
     "officialSite": "http://ova-tos.com/sylvarant/",
     "begin": "2007-06-08T16:00:00.000Z",
     "end": "2007-12-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,12 +139,7 @@
       {
         "site": "nicovideo",
         "id": "TOS-anime01",
-        "begin": "2016-07-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/2007/07.json
+++ b/data/items/2007/07.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.baccano.jp/",
     "begin": "2007-07-26T15:30:00.000Z",
     "end": "2007-11-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tuLeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "baccano-anime",
-        "begin": "2017-07-29T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-29T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1359",
-        "begin": "2007-07-25T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-25T16:00:00.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/nanatsuiro/",
     "begin": "2007-07-02T16:40:00.000Z",
     "end": "2007-09-17T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,22 +53,12 @@
       {
         "site": "nicovideo",
         "id": "nanatsuiro-drops",
-        "begin": "2018-08-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-10T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4763",
-        "begin": "2007-07-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-01T16:00:01.000Z"
       }
     ]
   },
@@ -101,27 +74,16 @@
     "officialSite": "http://www.potemayo.com/",
     "begin": "2007-07-06T16:30:00.000Z",
     "end": "2007-09-21T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1GNe3ESqGlia7OaE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/zcvyxzaq7fksa3y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -130,12 +92,7 @@
       {
         "site": "bilibili",
         "id": "3233",
-        "begin": "2007-07-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-05T16:00:01.000Z"
       }
     ]
   },
@@ -151,7 +108,6 @@
     "officialSite": "http://www.zero-tsukaima.com/zero2/",
     "begin": "2007-07-08T15:30:00.000Z",
     "end": "2007-09-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -160,22 +116,12 @@
       {
         "site": "nicovideo",
         "id": "zero-tsukaima2",
-        "begin": "2011-12-14T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-12-14T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "819",
-        "begin": "2007-07-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-07T16:00:00.000Z"
       }
     ]
   },
@@ -191,27 +137,16 @@
     "officialSite": "http://www.nasinc.co.jp/jp/zombieloan/index.html",
     "begin": "2007-07-03T17:40:00.000Z",
     "end": "2009-03-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1hvlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/90p2tgfoljepnsy",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -220,12 +155,7 @@
       {
         "site": "bilibili",
         "id": "1371",
-        "begin": "2007-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-02T16:00:00.000Z"
       }
     ]
   },
@@ -241,17 +171,11 @@
     "officialSite": "http://www.maql.co.jp/special/umisho/index2.htm",
     "begin": "2007-07-03T17:00:00.000Z",
     "end": "2007-09-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0h3nZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -271,17 +195,11 @@
     "officialSite": "http://www.oyashirosama.com/web/kai/index.htm",
     "begin": "2007-07-05T18:50:00.000Z",
     "end": "2007-12-17T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/oc9be21zz9l9zun",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -290,22 +208,7 @@
       {
         "site": "nicovideo",
         "id": "oyashirosama02",
-        "begin": "2017-06-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1773",
-        "begin": "2007-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T15:00:00.000Z"
       }
     ]
   },
@@ -321,17 +224,11 @@
     "officialSite": "http://www.ink-chan.com/",
     "begin": "2007-07-08T16:30:00.000Z",
     "end": "2007-09-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "naeiaIIjuXpzicfeU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -340,12 +237,7 @@
       {
         "site": "bilibili",
         "id": "1356",
-        "begin": "2007-07-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-07T16:00:00.000Z"
       }
     ]
   },
@@ -362,37 +254,21 @@
     "officialSite": "http://mononoke-anime.com/",
     "begin": "2007-07-12T18:25:00.000Z",
     "end": "2007-09-27T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sIRicicWXLO3ncWsI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "r/rdszf4nxhhkdfyp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "38538",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -401,12 +277,7 @@
       {
         "site": "bilibili",
         "id": "2654",
-        "begin": "2007-07-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-11T16:00:00.000Z"
       }
     ]
   },
@@ -423,17 +294,11 @@
     "officialSite": "http://mv.avex.jp/code-e/",
     "begin": "2007-07-03T17:43:00.000Z",
     "end": "2007-09-18T18:13:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "b8K9O6MJebcamAA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -442,12 +307,7 @@
       {
         "site": "bilibili",
         "id": "1236",
-        "begin": "2007-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-02T16:00:00.000Z"
       }
     ]
   },
@@ -463,17 +323,11 @@
     "officialSite": "http://www.wowow.co.jp/anime/mushi-uta/",
     "begin": "2007-07-05T15:00:00.000Z",
     "end": "2007-10-04T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "13FMyjKYCEapJ48",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -482,12 +336,7 @@
       {
         "site": "bilibili",
         "id": "3346",
-        "begin": "2007-07-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-04T16:00:01.000Z"
       }
     ]
   },
@@ -503,17 +352,11 @@
     "officialSite": "http://www.doujin.tv/",
     "begin": "2007-07-03T16:30:00.000Z",
     "end": "2007-09-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ERicqaNA2puRHxS0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -522,12 +365,7 @@
       {
         "site": "bilibili",
         "id": "3353",
-        "begin": "2007-07-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-02T16:00:01.000Z"
       }
     ]
   },
@@ -544,27 +382,16 @@
     "officialSite": "http://www.ntv.co.jp/buzzer/",
     "begin": "2007-07-03T16:16:00.000Z",
     "end": "2007-09-25T18:26:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0Qnzcdkicrib1QzjY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgi9s5d",
-        "begin": "2014-09-12T06:34:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:34:38.000Z"
       },
       {
         "site": "bangumi",
@@ -573,12 +400,7 @@
       {
         "site": "bilibili",
         "id": "3966",
-        "begin": "2007-07-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-02T16:00:01.000Z"
       }
     ]
   },
@@ -594,7 +416,6 @@
     "officialSite": "http://www.maql.co.jp/special/schooldays-anime/index.html",
     "begin": "2007-07-03T17:15:00.000Z",
     "end": "2007-09-18T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -603,12 +424,7 @@
       {
         "site": "nicovideo",
         "id": "schooldays",
-        "begin": "2009-09-21T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-09-21T15:00:00.000Z"
       }
     ]
   },
@@ -624,41 +440,20 @@
     "officialSite": "http://web.archive.org/web/*/www.majin2.com/",
     "begin": "2007-07-27T14:00:00.000Z",
     "end": "2007-10-12T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZaaiaIIjuXpzicfeU",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4101"
       },
       {
-        "site": "bilibili",
-        "id": "1319",
-        "begin": "2007-07-26T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "46654",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -674,7 +469,6 @@
     "officialSite": "http://web.archive.org/web/*/www.hapiclo.tv/",
     "begin": "2007-07-06T02:30:00.000Z",
     "end": "2007-09-28T03:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -694,7 +488,6 @@
     "officialSite": "http://www.konami.jp/visual/skygirls/",
     "begin": "2007-07-05T16:28:00.000Z",
     "end": "2007-12-27T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -703,12 +496,7 @@
       {
         "site": "bilibili",
         "id": "1366",
-        "begin": "2007-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -724,27 +512,16 @@
     "officialSite": "http://www.starchild.co.jp/special/zetsubou/",
     "begin": "2007-07-07T15:30:00.000Z",
     "end": "2007-09-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yALibfORKuvhb2UE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/89xh503efusv1xq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -753,22 +530,12 @@
       {
         "site": "nicovideo",
         "id": "zetsubou1",
-        "begin": "2016-10-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-31T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1792",
-        "begin": "2007-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-06T16:00:00.000Z"
       }
     ]
   },
@@ -784,7 +551,6 @@
     "officialSite": "http://www.wowow.co.jp/anime/shigurui/",
     "begin": "2007-07-19T14:30:00.000Z",
     "end": "2007-10-11T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -804,7 +570,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2007-07-27T16:00:00.000Z",
     "end": "2007-07-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -813,22 +578,12 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3944",
-        "begin": "2007-07-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-26T16:00:01.000Z"
       }
     ]
   },
@@ -845,17 +600,11 @@
     "officialSite": "http://www.piano-movie.jp/",
     "begin": "2007-07-21T16:00:00.000Z",
     "end": "2007-07-21T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10005124",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -864,22 +613,12 @@
       {
         "site": "bilibili",
         "id": "4769",
-        "begin": "2007-07-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-20T16:00:01.000Z"
       },
       {
         "site": "netflix",
         "id": "80986797",
-        "begin": "2018-09-28T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-09-28T07:00:00.000Z"
       }
     ]
   },
@@ -895,37 +634,21 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2007-07-14T16:00:00.000Z",
     "end": "2007-07-14T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "71821",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -934,22 +657,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5750",
-        "begin": "2007-07-13T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-13T16:00:01.000Z"
       }
     ]
   },
@@ -965,17 +678,11 @@
     "officialSite": "http://www.kappa-coo.com/",
     "begin": "2007-07-28T16:00:00.000Z",
     "end": "2007-07-28T18:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20110816/0c6a020636e4d3dd.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20110816/0c6a020636e4d3dd.html"
       },
       {
         "site": "bangumi",
@@ -984,12 +691,7 @@
       {
         "site": "bilibili",
         "id": "4760",
-        "begin": "2007-07-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-07-27T16:00:01.000Z"
       }
     ]
   },
@@ -1005,17 +707,11 @@
     "officialSite": "http://www.genius-party.jp/",
     "begin": "2007-07-07T16:00:00.000Z",
     "end": "2007-07-07T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TPTPTbUbia8ksqhI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2007/08.json
+++ b/data/items/2007/08.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.starchild.co.jp/special/kujira/",
     "begin": "2007-08-25T14:30:00.000Z",
     "end": "2007-11-10T14:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VJZy8FiaibLmzPTbU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -37,7 +31,6 @@
     "officialSite": "http://www.shin-ei-animation.jp/sensoudouwa/index.html",
     "begin": "2007-08-15T16:00:00.000Z",
     "end": "2007-08-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -57,21 +50,10 @@
     "officialSite": "http://wwwz.fujitv.co.jp/miyori/index.html",
     "begin": "2007-08-25T16:00:00.000Z",
     "end": "2007-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "13761"
-      },
-      {
-        "site": "bilibili",
-        "id": "4775",
-        "begin": "2007-08-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -87,7 +69,6 @@
     "officialSite": "",
     "begin": "2007-08-18T16:00:00.000Z",
     "end": "2007-08-18T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -96,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "5432",
-        "begin": "2007-08-17T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-08-17T16:00:01.000Z"
       }
     ]
   },
@@ -117,7 +93,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2007-08-01T17:10:00.000Z",
     "end": "2007-08-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,7 +115,6 @@
     "officialSite": "http://www.naruto-movie.com/",
     "begin": "2007-08-03T16:00:00.000Z",
     "end": "2007-08-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -149,12 +123,7 @@
       {
         "site": "netflix",
         "id": "70124999",
-        "begin": "2016-10-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-15T07:00:00.000Z"
       }
     ]
   },
@@ -170,7 +139,6 @@
     "officialSite": "http://www.bin-kan.com/",
     "begin": "2007-08-24T16:00:00.000Z",
     "end": "2007-11-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -179,12 +147,7 @@
       {
         "site": "letv",
         "id": "86281",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2007/09.json
+++ b/data/items/2007/09.json
@@ -11,17 +11,11 @@
     "officialSite": "http://web.archive.org/web/*/www.moonlightmile.jp/",
     "begin": "2007-09-13T14:00:00.000Z",
     "end": "2007-12-13T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zgH7eeFHticVY1j4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,31 +35,15 @@
     "officialSite": "",
     "begin": "2007-09-15T16:00:00.000Z",
     "end": "2007-09-15T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "4/4huihrcxu6nvc1x",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3686"
-      },
-      {
-        "site": "bilibili",
-        "id": "1179",
-        "begin": "2007-09-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -81,7 +59,6 @@
     "officialSite": "http://www.evangelion.co.jp/",
     "begin": "2007-09-01T16:00:00.000Z",
     "end": "2007-09-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -90,22 +67,12 @@
       {
         "site": "qq",
         "id": "t/tr5q6ohz06g4tzx",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "evangelion_new_movie_jo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -121,7 +88,6 @@
     "officialSite": "http://www.stranja.jp/",
     "begin": "2007-09-29T16:00:00.000Z",
     "end": "2007-09-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,22 +96,12 @@
       {
         "site": "qq",
         "id": "n/n845812mqzji6l1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3151",
-        "begin": "2007-09-29T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-09-29T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2007/10.json
+++ b/data/items/2007/10.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.kamosuzo.tv/",
     "begin": "2007-10-11T15:35:00.000Z",
     "end": "2007-12-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "btqlI4vxYZ8CgOg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "3405",
-        "begin": "2007-10-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-10T16:00:01.000Z"
       }
     ]
   },
@@ -51,27 +40,16 @@
     "officialSite": "http://www.kojika-anime.com/",
     "begin": "2007-10-11T16:30:00.000Z",
     "end": "2007-12-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Y8SicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "n/ncr12ncygwzy1tj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -92,27 +70,16 @@
     "officialSite": "http://www.gundam00.net/tv/index.html",
     "begin": "2007-10-06T09:00:00.000Z",
     "end": "2008-03-29T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg4a2c5",
-        "begin": "2017-03-02T09:22:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-02T09:22:31.000Z"
       },
       {
         "site": "qq",
         "id": "t/tt1wl97fhnn5a4s",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -121,12 +88,7 @@
       {
         "site": "bilibili",
         "id": "1192",
-        "begin": "2007-10-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -145,7 +107,6 @@
     "officialSite": "http://www.p-ark.tv/",
     "begin": "2007-10-07T15:30:00.000Z",
     "end": "2007-12-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -154,12 +115,7 @@
       {
         "site": "letv",
         "id": "29175",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -175,17 +131,11 @@
     "officialSite": "http://web.archive.org/web/*/www.genshiken.info/",
     "begin": "2007-10-09T16:30:00.000Z",
     "end": "2007-12-25T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "a/a24mcr96k48aeu9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -194,22 +144,12 @@
       {
         "site": "nicovideo",
         "id": "genshiken2",
-        "begin": "2013-08-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-15T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "518",
-        "begin": "2007-10-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-08T16:00:00.000Z"
       }
     ]
   },
@@ -229,47 +169,26 @@
     "officialSite": "http://www.shakugan.com/",
     "begin": "2007-10-04T16:25:00.000Z",
     "end": "2008-03-27T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QeXgXsYsnNo9uyM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk04woh",
-        "begin": "2012-06-01T01:22:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-01T01:22:02.000Z"
       },
       {
         "site": "qq",
         "id": "p/ph4m28ufdwsha2e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "45735",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -278,12 +197,7 @@
       {
         "site": "nicovideo",
         "id": "ch60006",
-        "begin": "2011-04-26T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-26T17:30:00.000Z"
       }
     ]
   },
@@ -302,17 +216,11 @@
     "officialSite": "http://www.dragonaut.com/",
     "begin": "2007-10-03T17:20:00.000Z",
     "end": "2011-10-20T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NwUAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -321,12 +229,7 @@
       {
         "site": "bilibili",
         "id": "1333",
-        "begin": "2007-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -342,37 +245,21 @@
     "officialSite": "http://www.tbs.co.jp/clannad/clannad1/",
     "begin": "2007-10-04T17:25:00.000Z",
     "end": "2008-03-20T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qIp181vBMWicSULg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1177",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/dgls5z543q3viyq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -381,22 +268,12 @@
       {
         "site": "nicovideo",
         "id": "clannad",
-        "begin": "2017-12-24T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-24T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7qyzp",
-        "begin": "2018-03-01T03:24:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-01T03:24:11.000Z"
       }
     ]
   },
@@ -412,27 +289,16 @@
     "officialSite": "http://www.tbs.co.jp/anime/taiho/",
     "begin": "2007-10-04T16:55:00.000Z",
     "end": "2015-04-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HCQfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/fe8m2ck4utqem0k",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -441,12 +307,7 @@
       {
         "site": "bilibili",
         "id": "1342",
-        "begin": "2007-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -462,7 +323,6 @@
     "officialSite": "http://www.jyushin.jp/",
     "begin": "2007-10-07T17:00:00.000Z",
     "end": "2008-03-30T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -482,17 +342,11 @@
     "officialSite": "http://www.ef-memo.com/index_top.html",
     "begin": "2007-10-06T16:35:00.000Z",
     "end": "2007-12-22T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ngr1c9tBse9S0Dg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -501,12 +355,7 @@
       {
         "site": "bilibili",
         "id": "1181",
-        "begin": "2007-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -522,17 +371,11 @@
     "officialSite": "http://www.mag-garden.co.jp/sketchbook/",
     "begin": "2007-10-01T17:00:00.000Z",
     "end": "2007-12-24T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "n/nua16x3bsqtsmyt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -541,12 +384,7 @@
       {
         "site": "bilibili",
         "id": "1344",
-        "begin": "2007-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -562,7 +400,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/labyrins/",
     "begin": "2007-10-02T16:30:00.000Z",
     "end": "2008-03-25T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -582,7 +419,6 @@
     "officialSite": "http://shugo-chara.com/",
     "begin": "2007-10-06T00:30:00.000Z",
     "end": "2008-09-27T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -602,17 +438,11 @@
     "officialSite": "http://www.hatsunejima.com/dc2/",
     "begin": "2007-10-01T15:00:00.000Z",
     "end": "2007-12-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "w/w2kmu8dgn83qups",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -621,22 +451,12 @@
       {
         "site": "nicovideo",
         "id": "dc2",
-        "begin": "2012-08-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-01T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "658",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -652,7 +472,6 @@
     "officialSite": "http://anime.goo.ne.jp/special/ghosthound/",
     "begin": "2007-10-18T14:30:00.000Z",
     "end": "2008-04-03T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -661,12 +480,7 @@
       {
         "site": "bilibili",
         "id": "1329",
-        "begin": "2007-10-17T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-17T16:00:00.000Z"
       }
     ]
   },
@@ -682,17 +496,11 @@
     "officialSite": "http://web.archive.org/web/*/www.shion-oh.com/",
     "begin": "2007-10-13T16:45:00.000Z",
     "end": "2008-03-22T19:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Eh7pZ881peNGxCw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -701,12 +509,7 @@
       {
         "site": "bilibili",
         "id": "1330",
-        "begin": "2007-10-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-12T16:00:00.000Z"
       }
     ]
   },
@@ -722,17 +525,11 @@
     "officialSite": "http://mv.avex.jp/mokke/",
     "begin": "2007-10-02T17:45:00.000Z",
     "end": "2008-11-30T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8D4Jhib9VxQNm5Ew",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -753,27 +550,16 @@
     "officialSite": "http://www.kimikiss-pure-rouge.jp/",
     "begin": "2007-10-06T17:55:00.000Z",
     "end": "2008-03-22T18:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Oh3oZs40pOJFwys",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "49104",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -782,12 +568,7 @@
       {
         "site": "bilibili",
         "id": "2996",
-        "begin": "2007-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -806,27 +587,16 @@
     "officialSite": "http://web.archive.org/web/*/www.nightwizard.jp/",
     "begin": "2007-10-02T17:00:00.000Z",
     "end": "2007-12-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9Es2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/8pe1m0a93icvltc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -835,12 +605,7 @@
       {
         "site": "bilibili",
         "id": "1346",
-        "begin": "2007-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -859,41 +624,20 @@
     "officialSite": "http://www.bambooblade.jp/",
     "begin": "2007-10-01T16:30:00.000Z",
     "end": "2008-03-31T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "a8XAPqYMfLodmwM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "i/i547kshtw285pnz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1272"
-      },
-      {
-        "site": "bilibili",
-        "id": "1336",
-        "begin": "2007-09-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -909,17 +653,11 @@
     "officialSite": "http://www.maql.co.jp/special/anime-myyour/",
     "begin": "2007-10-02T17:15:00.000Z",
     "end": "2007-12-25T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GxicqaNA2puRHxS0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -928,22 +666,12 @@
       {
         "site": "nicovideo",
         "id": "myselfyourself",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1338",
-        "begin": "2007-10-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -959,17 +687,11 @@
     "officialSite": "http://www.starchild.co.jp/special/minami-ke/1/index.html",
     "begin": "2007-10-07T16:30:00.000Z",
     "end": "2007-12-30T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ftmkIorwYJ4Bfibc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -978,32 +700,17 @@
       {
         "site": "nicovideo",
         "id": "minami-ke01",
-        "begin": "2017-08-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-08T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "620",
-        "begin": "2007-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-06T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "50471",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1019,17 +726,11 @@
     "officialSite": "http://www.ntv.co.jp/neuro/",
     "begin": "2007-10-02T17:24:00.000Z",
     "end": "2008-03-25T17:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dtGsKpL4aKYJhib8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1038,22 +739,12 @@
       {
         "site": "nicovideo",
         "id": "majintantei-nougami-neuro",
-        "begin": "2018-07-02T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-02T09:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1331",
-        "begin": "2007-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -1069,7 +760,6 @@
     "officialSite": "http://www.bestack.co.jp/bluedrop/",
     "begin": "2007-10-02T17:00:00.000Z",
     "end": "2007-12-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1078,12 +768,7 @@
       {
         "site": "bilibili",
         "id": "1335",
-        "begin": "2007-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -1101,27 +786,16 @@
     "officialSite": "http://www.kadokawa.co.jp/sneaker/magica/animation/",
     "begin": "2007-10-07T15:00:00.000Z",
     "end": "2008-03-23T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mtSwLpb8bKoNiaicM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk78019",
-        "begin": "2012-09-01T10:01:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-01T10:01:59.000Z"
       },
       {
         "site": "bangumi",
@@ -1130,22 +804,12 @@
       {
         "site": "bilibili",
         "id": "1332",
-        "begin": "2007-10-07T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-07T15:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "11259",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1161,17 +825,11 @@
     "officialSite": "http://www.ntv.co.jp/kaiji/",
     "begin": "2007-10-02T16:54:00.000Z",
     "end": "2008-04-01T16:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Pgr1c9tBse9S0Dg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1180,12 +838,7 @@
       {
         "site": "nicovideo",
         "id": "kaiji_anime",
-        "begin": "2014-04-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-01T06:00:00.000Z"
       }
     ]
   },
@@ -1202,41 +855,20 @@
     "officialSite": "http://web.archive.org/web/*/pc.webnt.jp/ninomiya/",
     "begin": "2007-10-04T16:30:00.000Z",
     "end": "2007-12-20T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xwnzcdkicrib1QzjY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "11014",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3013"
-      },
-      {
-        "site": "bilibili",
-        "id": "1345",
-        "begin": "2007-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1254,17 +886,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/maplestory/",
     "begin": "2007-10-06T23:30:00.000Z",
     "end": "2008-03-30T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SYJibicGTKOnjbWcE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1280,7 +906,6 @@
     "officialSite": "http://web.archive.org/web/*/www.anime-yattokame.com/",
     "begin": "2007-10-06T22:00:00.000Z",
     "end": "2007-12-30T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1300,7 +925,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/shizuku/",
     "begin": "2007-10-07T00:00:00.000Z",
     "end": "2008-09-28T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1320,27 +944,16 @@
     "officialSite": "http://www.maruma-ova.jp/",
     "begin": "2007-10-26T16:00:00.000Z",
     "end": "2008-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rH9KyDCWBkSnJY0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/wxs44c83knpaneq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1349,22 +962,12 @@
       {
         "site": "letv",
         "id": "84222",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3767",
-        "begin": "2007-10-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-10-25T16:00:01.000Z"
       }
     ]
   },
@@ -1380,31 +983,15 @@
     "officialSite": "http://www.exmachina.jp/",
     "begin": "2007-10-20T16:00:00.000Z",
     "end": "2007-10-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "c/c54ev1zwn5p2eb1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "6235"
-      },
-      {
-        "site": "bilibili",
-        "id": "4736",
-        "begin": "2007-10-19T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1421,27 +1008,16 @@
     "officialSite": "http://www.mtvjapan.com/usavich/",
     "begin": "2007-10-08T16:00:00.000Z",
     "end": "2008-01-15T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GhH7eeFHticVY1j4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhazu4l",
-        "begin": "2017-01-25T03:26:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-25T03:26:06.000Z"
       },
       {
         "site": "bangumi",
@@ -1450,22 +1026,12 @@
       {
         "site": "sohu",
         "id": "s2017/dhptwt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/u0m729agauuf7qg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1481,17 +1047,11 @@
     "officialSite": "",
     "begin": "2007-10-26T16:00:00.000Z",
     "end": "2008-08-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CDgDgelPvic1g3kY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2007/11.json
+++ b/data/items/2007/11.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.gyao.jp/bkids/tamago/index.php",
     "begin": "2007-11-29T03:00:00.000Z",
     "end": "2008-02-14T03:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "http://www.shonenmagazine.com/tsubasa_tokyo/",
     "begin": "2007-11-16T16:00:00.000Z",
     "end": "2008-03-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "k8G7OaEHd7UYlv4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,22 +43,12 @@
       {
         "site": "bilibili",
         "id": "2854",
-        "begin": "2007-11-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-11-15T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10387",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -77,7 +60,6 @@
     "officialSite": "",
     "begin": "2007-11-22T16:00:00.000Z",
     "end": "2007-11-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -86,12 +68,7 @@
       {
         "site": "nicovideo",
         "id": "ch157",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -107,7 +84,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2007_precure5/",
     "begin": "2007-11-10T16:00:00.000Z",
     "end": "2007-11-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -116,22 +92,12 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   }

--- a/data/items/2007/12.json
+++ b/data/items/2007/12.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.gungho.jp/cgame/visual/ayakashi/",
     "begin": "2007-12-12T02:00:00.000Z",
     "end": "2008-02-27T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZqiaUEnrgUI7xb9c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1347",
-        "begin": "2007-12-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-12-05T16:00:00.000Z"
       }
     ]
   },
@@ -51,31 +40,15 @@
     "officialSite": "http://www.gamecity.ne.jp/neoromance/tv/haruka/kurenai/",
     "begin": "2007-12-28T16:00:00.000Z",
     "end": "2007-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iclItqxN56SeKCHA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "72915"
-      },
-      {
-        "site": "bilibili",
-        "id": "3416",
-        "begin": "2007-12-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -91,27 +64,16 @@
     "officialSite": "http://www.tbs.co.jp/megamisama/",
     "begin": "2007-12-08T16:00:00.000Z",
     "end": "2007-12-08T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "k/kjdoip1hshpdcbk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "Ihbxb9c9retOzDQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -120,12 +82,7 @@
       {
         "site": "bilibili",
         "id": "5742",
-        "begin": "2007-12-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-12-07T16:00:01.000Z"
       }
     ]
   },
@@ -141,7 +98,6 @@
     "officialSite": "",
     "begin": "2007-12-26T16:00:00.000Z",
     "end": "2008-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -150,22 +106,7 @@
       {
         "site": "pptv",
         "id": "Qox49l7ENHLVU7s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1786",
-        "begin": "2007-12-25T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -181,7 +122,6 @@
     "officialSite": "http://www.tokyomarble.com/",
     "begin": "2007-12-19T16:00:00.000Z",
     "end": "2007-12-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -190,22 +130,12 @@
       {
         "site": "pptv",
         "id": "FS0Ylv5k1BJ181s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3254",
-        "begin": "2007-12-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-12-18T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2008/01.json
+++ b/data/items/2008/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.zenryoku-usagi.com/",
     "begin": "2008-01-15T03:30:00.000Z",
     "end": "2008-12-27T04:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oINibicGTKOnjbWcE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1269",
-        "begin": "2008-01-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-15T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://mv.avex.jp/wellber/",
     "begin": "2008-01-01T17:30:00.000Z",
     "end": "2008-03-25T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5kE8uiaKIibDaZF38",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "3977",
-        "begin": "2007-12-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2007-12-31T16:00:01.000Z"
       }
     ]
   },
@@ -91,27 +69,16 @@
     "officialSite": "http://www.shigofumi.com/",
     "begin": "2008-01-05T16:35:00.000Z",
     "end": "2008-03-22T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yWpV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "4/4p10d7cilzonxbc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -120,12 +87,7 @@
       {
         "site": "bilibili",
         "id": "1262",
-        "begin": "2008-01-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -141,47 +103,26 @@
     "officialSite": "http://www.truetears.jp/",
     "begin": "2008-01-05T16:00:00.000Z",
     "end": "2008-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OBznZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhabes5",
-        "begin": "2016-01-08T06:57:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T06:57:14.000Z"
       },
       {
         "site": "letv",
         "id": "15990",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "167652",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -190,12 +131,7 @@
       {
         "site": "bilibili",
         "id": "2910",
-        "begin": "2008-01-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-04T16:00:01.000Z"
       }
     ]
   },
@@ -211,7 +147,6 @@
     "officialSite": "http://www.rosa-vam.com/first/",
     "begin": "2008-01-03T14:30:00.000Z",
     "end": "2008-03-27T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -231,37 +166,21 @@
     "officialSite": "http://www.starchild.co.jp/special/zetsubou2/",
     "begin": "2008-01-05T15:30:00.000Z",
     "end": "2008-03-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kNulI4vxYZ8CgOg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/djg5wh5izb8td8g",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1793",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -270,12 +189,7 @@
       {
         "site": "nicovideo",
         "id": "zetsubou2",
-        "begin": "2016-10-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-31T15:00:00.000Z"
       }
     ]
   },
@@ -291,27 +205,16 @@
     "officialSite": "http://www.maql.co.jp/special/gs/gunslingergirl/www/",
     "begin": "2008-01-07T18:00:00.000Z",
     "end": "2008-03-26T18:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OXNNyzOZCUeqKJA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bb7jounypjm8dwd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -320,22 +223,12 @@
       {
         "site": "netflix",
         "id": "80092436",
-        "begin": "2018-01-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-01T08:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1265",
-        "begin": "2008-01-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -351,7 +244,6 @@
     "officialSite": "http://www.ariacompany.net/",
     "begin": "2008-01-07T17:30:00.000Z",
     "end": "2008-03-31T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -360,12 +252,7 @@
       {
         "site": "nicovideo",
         "id": "ariaorigin",
-        "begin": "2015-07-10T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-10T06:00:00.000Z"
       }
     ]
   },
@@ -381,17 +268,11 @@
     "officialSite": "http://yatterman.jp/",
     "begin": "2008-01-14T10:00:00.000Z",
     "end": "2009-09-26T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk4cvuh",
-        "begin": "2012-12-11T12:01:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-11T12:01:00.000Z"
       },
       {
         "site": "bangumi",
@@ -411,17 +292,11 @@
     "officialSite": "http://www.persona-ts.net/",
     "begin": "2008-01-05T13:30:00.000Z",
     "end": "2008-06-28T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "q/q9rnef1akt3hnr4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -430,22 +305,12 @@
       {
         "site": "nicovideo",
         "id": "persona-ts",
-        "begin": "2012-02-22T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-02-22T06:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "4697",
-        "begin": "2008-01-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10552",
+        "begin": "2008-01-04T16:00:01.000Z"
       }
     ]
   },
@@ -462,27 +327,16 @@
     "officialSite": "http://www3.nhk.or.jp/anime/major/main.html",
     "begin": "2008-01-05T09:00:00.000Z",
     "end": "2008-06-28T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UicvGRKwSgsAjoQk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc3itt",
-        "begin": "2014-12-24T06:18:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-24T06:18:24.000Z"
       },
       {
         "site": "bangumi",
@@ -505,17 +359,11 @@
     "officialSite": "http://www.nippon-animation.co.jp/porphy/",
     "begin": "2008-01-06T10:30:00.000Z",
     "end": "2008-12-28T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tfzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -535,21 +383,10 @@
     "officialSite": "http://kimiaru.jp/",
     "begin": "2008-01-05T17:00:00.000Z",
     "end": "2008-03-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "487"
-      },
-      {
-        "site": "bilibili",
-        "id": "1263",
-        "begin": "2008-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -566,37 +403,21 @@
     "officialSite": "http://www.spicy-wolf.com/1st/top.html",
     "begin": "2008-01-08T16:30:00.000Z",
     "end": "2008-03-25T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QfHMSrIYiaMYppw8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9moox",
-        "begin": "2016-08-31T16:02:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:02:21.000Z"
       },
       {
         "site": "qq",
         "id": "c/cr7os3gcvszvaqe",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -605,22 +426,12 @@
       {
         "site": "nicovideo",
         "id": "spicy-wolf",
-        "begin": "2011-10-29T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-29T10:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1071",
-        "begin": "2008-01-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -636,17 +447,11 @@
     "officialSite": "http://www.starchild.co.jp/special/minami-ke/2/index.html",
     "begin": "2008-01-06T17:12:00.000Z",
     "end": "2008-03-30T17:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "f9iajIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -655,22 +460,12 @@
       {
         "site": "nicovideo",
         "id": "minami-ke2",
-        "begin": "2017-09-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-07T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "621",
-        "begin": "2008-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -686,17 +481,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/hakaba/",
     "begin": "2008-01-10T15:45:00.000Z",
     "end": "2008-03-20T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb14ah",
-        "begin": "2015-08-14T17:05:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:05:52.000Z"
       },
       {
         "site": "bangumi",
@@ -716,7 +505,6 @@
     "officialSite": "http://tv.moegaku.jp/",
     "begin": "2008-01-14T08:00:00.000Z",
     "end": "2008-03-09T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -736,27 +524,16 @@
     "officialSite": "http://anime.webnt.jp/h2o/",
     "begin": "2008-01-03T16:30:00.000Z",
     "end": "2008-03-20T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "g823NZ0Dc7EUkvo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "g/gsacm22dh6vak2m",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -765,12 +542,7 @@
       {
         "site": "bilibili",
         "id": "1204",
-        "begin": "2008-01-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-02T16:00:00.000Z"
       }
     ]
   },
@@ -786,27 +558,16 @@
     "officialSite": "http://hatenkouyugi.com/",
     "begin": "2008-01-04T17:30:00.000Z",
     "end": "2008-03-07T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ak03tR2D8zGUEno",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/fr3iyjjgnk32euk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -815,12 +576,7 @@
       {
         "site": "bilibili",
         "id": "1266",
-        "begin": "2008-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-03T16:00:00.000Z"
       }
     ]
   },
@@ -836,27 +592,16 @@
     "officialSite": "http://www.ikki-para.com/comix/noramimi.html",
     "begin": "2008-01-09T16:00:00.000Z",
     "end": "2008-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1hjkYsowoN5Bvyc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "a/abcvl4ekck8ov03",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -865,12 +610,7 @@
       {
         "site": "bilibili",
         "id": "2698",
-        "begin": "2008-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-01-08T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2008/02.json
+++ b/data/items/2008/02.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.rin-asougi.com/",
     "begin": "2008-02-03T15:00:00.000Z",
     "end": "2008-07-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "http://asahi.co.jp/precure5gogo/",
     "begin": "2008-02-02T23:30:00.000Z",
     "end": "2009-01-25T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb151d",
-        "begin": "2015-09-18T08:08:54.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-18T08:08:54.000Z"
       },
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://www.nagoyatv.com/kyoryu/",
     "begin": "2008-02-02T22:00:00.000Z",
     "end": "2008-08-30T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,17 +73,11 @@
     "officialSite": "",
     "begin": "2008-02-29T16:00:00.000Z",
     "end": "2008-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Tn5KyDCWBkSnJY0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,12 +86,7 @@
       {
         "site": "bilibili",
         "id": "2906",
-        "begin": "2008-02-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-02-28T16:00:00.000Z"
       }
     ]
   },
@@ -121,7 +102,6 @@
     "officialSite": "",
     "begin": "2008-02-22T16:00:00.000Z",
     "end": "2008-02-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2008/03.json
+++ b/data/items/2008/03.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.fwinc.co.jp/busgamer/",
     "begin": "2008-03-14T17:30:00.000Z",
     "end": "2008-03-28T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NgTicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,7 @@
       {
         "site": "nicovideo",
         "id": "busgamer",
-        "begin": "2017-04-07T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1268",
-        "begin": "2008-03-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T06:00:00.000Z"
       }
     ]
   },
@@ -62,57 +41,31 @@
     "officialSite": "http://www.kids-station.com/minisite/gag3/",
     "begin": "2008-03-17T14:00:00.000Z",
     "end": "2008-06-02T14:06:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LhfycNgibruxPzTU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjb89p",
-        "begin": "2014-04-09T23:30:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:30:25.000Z"
       },
       {
         "site": "qq",
         "id": "7/77mnuidmyfuyr5d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15967",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "42753",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -121,12 +74,7 @@
       {
         "site": "bilibili",
         "id": "1595",
-        "begin": "2008-03-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-03-16T16:00:00.000Z"
       }
     ]
   },
@@ -145,7 +93,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/chissweet/",
     "begin": "2008-03-30T21:40:00.000Z",
     "end": "2008-09-24T21:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -165,17 +112,11 @@
     "officialSite": "http://doraeiga.com/2008/",
     "begin": "2008-03-08T16:00:00.000Z",
     "end": "2008-03-08T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "81025",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -184,32 +125,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mks9",
-        "begin": "2018-05-31T16:00:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:00:23.000Z"
       }
     ]
   },
@@ -225,17 +151,11 @@
     "officialSite": "",
     "begin": "2008-03-26T16:00:00.000Z",
     "end": "2008-03-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "u/uxczmobn4fzsi0m",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -244,12 +164,7 @@
       {
         "site": "nicovideo",
         "id": "hokuto-no-ken",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -266,17 +181,11 @@
     "officialSite": "http://www.toei-anim.co.jp/sp/seiya/index.html",
     "begin": "2008-03-28T16:00:00.000Z",
     "end": "2008-08-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1e8x",
-        "begin": "2015-08-14T17:06:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:06:44.000Z"
       },
       {
         "site": "bangumi",
@@ -296,7 +205,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2008_onepiece/",
     "begin": "2008-03-01T16:00:00.000Z",
     "end": "2008-03-01T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -316,7 +224,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2008-03-31T08:35:00.000Z",
     "end": "2008-08-29T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -332,7 +239,6 @@
     "officialSite": "http://aquaplus.jp/th2ad/product.html",
     "begin": "2008-03-26T16:00:00.000Z",
     "end": "2008-08-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -341,12 +247,7 @@
       {
         "site": "nicovideo",
         "id": "th2ad",
-        "begin": "2012-03-03T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-03T13:30:00.000Z"
       }
     ]
   },
@@ -362,7 +263,6 @@
     "officialSite": "http://www.keroro-movie.net/",
     "begin": "2008-03-01T16:00:00.000Z",
     "end": "2008-03-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -371,12 +271,7 @@
       {
         "site": "pptv",
         "id": "9LQdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2008/04.json
+++ b/data/items/2008/04.json
@@ -11,17 +11,11 @@
     "officialSite": "http://druaga-anime.com/",
     "begin": "2008-04-04T16:15:00.000Z",
     "end": "2008-06-20T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YMOibPKQKergbmQE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1100",
-        "begin": "2008-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -54,31 +43,15 @@
     "officialSite": "http://allison-web.net/",
     "begin": "2008-04-03T14:32:00.000Z",
     "end": "2008-10-02T15:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ia8WicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4252"
-      },
-      {
-        "site": "bilibili",
-        "id": "1240",
-        "begin": "2008-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -94,27 +67,16 @@
     "officialSite": "http://www.nabari.tv/",
     "begin": "2008-04-06T16:30:00.000Z",
     "end": "2008-09-28T17:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "z2Fc2kKoGFa5N58",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15660",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -123,12 +85,7 @@
       {
         "site": "bilibili",
         "id": "3220",
-        "begin": "2008-04-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-05T16:00:01.000Z"
       }
     ]
   },
@@ -144,17 +101,11 @@
     "officialSite": "http://web.archive.org/web/*/www.maidguy.com/",
     "begin": "2008-04-05T16:35:00.000Z",
     "end": "2008-06-21T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jr6KCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -177,7 +128,6 @@
     "officialSite": "http://www.souleater.tv/",
     "begin": "2008-04-07T09:00:00.000Z",
     "end": "2009-03-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -186,22 +136,12 @@
       {
         "site": "nicovideo",
         "id": "souleater",
-        "begin": "2012-04-18T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-18T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70205024",
-        "begin": "2017-12-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-01T08:00:00.000Z"
       }
     ]
   },
@@ -220,17 +160,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/golgo/",
     "begin": "2008-04-11T16:23:00.000Z",
     "end": "2009-03-27T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "610opg505CKFA2s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -239,12 +173,7 @@
       {
         "site": "bilibili",
         "id": "1251",
-        "begin": "2008-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -260,27 +189,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yugioh/",
     "begin": "2008-04-02T09:00:00.000Z",
     "end": "2015-01-30T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ltexL5f9basOjPQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "5895",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -289,12 +207,7 @@
       {
         "site": "nicovideo",
         "id": "yugioh-5ds",
-        "begin": "2018-09-30T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-09-30T15:00:00.000Z"
       }
     ]
   },
@@ -314,27 +227,16 @@
     "officialSite": "http://www.geass.jp/",
     "begin": "2008-04-06T08:00:00.000Z",
     "end": "2008-09-28T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9mhxp",
-        "begin": "2016-08-31T16:03:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:03:06.000Z"
       },
       {
         "site": "letv",
         "id": "36712",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -343,12 +245,7 @@
       {
         "site": "netflix",
         "id": "80065146",
-        "begin": "2017-12-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-13T15:00:00.000Z"
       }
     ]
   },
@@ -367,17 +264,11 @@
     "officialSite": "http://www.toshokan-sensou.com/",
     "begin": "2008-04-10T16:00:00.000Z",
     "end": "2008-06-26T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mrSPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -386,12 +277,7 @@
       {
         "site": "bilibili",
         "id": "1196",
-        "begin": "2008-04-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-10T16:00:00.000Z"
       }
     ]
   },
@@ -407,7 +293,6 @@
     "officialSite": "http://www.kyouran.jp/",
     "begin": "2008-04-12T16:00:00.000Z",
     "end": "2008-10-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -427,31 +312,15 @@
     "officialSite": "http://www.samidareso.com/",
     "begin": "2008-04-03T17:00:00.000Z",
     "end": "2008-06-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gMu1M5sBca8SkPg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "494"
-      },
-      {
-        "site": "bilibili",
-        "id": "1197",
-        "begin": "2008-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -467,27 +336,16 @@
     "officialSite": "http://www.tbs.co.jp/holic/",
     "begin": "2008-04-03T16:59:00.000Z",
     "end": "2008-06-26T16:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "s5Vw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/udlxd7gdzg5m83v",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -496,22 +354,12 @@
       {
         "site": "bilibili",
         "id": "3389",
-        "begin": "2008-04-02T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-02T16:00:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7ljmt",
-        "begin": "2019-01-25T01:54:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-25T01:54:00.000Z"
       }
     ]
   },
@@ -528,27 +376,16 @@
     "officialSite": "http://www.chico-tv.com/",
     "begin": "2008-04-12T18:05:00.000Z",
     "end": "2008-09-27T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qYWAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifuaps",
-        "begin": "2013-08-01T06:09:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-01T06:09:47.000Z"
       },
       {
         "site": "bangumi",
@@ -557,12 +394,7 @@
       {
         "site": "bilibili",
         "id": "1246",
-        "begin": "2008-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -578,7 +410,6 @@
     "officialSite": "http://www.kanokon.com/",
     "begin": "2008-04-05T01:30:00.000Z",
     "end": "2008-06-21T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -598,27 +429,16 @@
     "officialSite": "http://anime.webnt.jp/oinarisama/",
     "begin": "2008-04-06T15:00:00.000Z",
     "end": "2008-09-14T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8FMurBR66iaiaLCXE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/d4v2t8ykhk43k82",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -627,12 +447,7 @@
       {
         "site": "bilibili",
         "id": "1247",
-        "begin": "2008-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -648,7 +463,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/to-love-ru/",
     "begin": "2008-04-03T17:29:00.000Z",
     "end": "2008-09-25T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -657,12 +471,7 @@
       {
         "site": "nicovideo",
         "id": "to-love-ru",
-        "begin": "2012-10-17T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-17T06:00:00.000Z"
       }
     ]
   },
@@ -678,27 +487,16 @@
     "officialSite": "http://amatsuki.com/",
     "begin": "2008-04-04T17:30:00.000Z",
     "end": "2008-06-27T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "edWwLpb8bKoNiaicM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5u8wk4o4dfeja4z",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -707,12 +505,7 @@
       {
         "site": "bilibili",
         "id": "1249",
-        "begin": "2008-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -731,37 +524,21 @@
     "officialSite": "http://www.monochro.tv/",
     "begin": "2008-04-07T17:00:00.000Z",
     "end": "2008-09-29T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FS4Zlic9l1RN29Fw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/j034ol3oyjdwt80",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15437",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -770,12 +547,7 @@
       {
         "site": "bilibili",
         "id": "1255",
-        "begin": "2008-04-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -791,41 +563,20 @@
     "officialSite": "http://anime.biglobe.ne.jp/crystal-blaze/",
     "begin": "2008-04-08T16:15:00.000Z",
     "end": "2008-06-24T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1WJd20OpGVe6OKA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifuar2",
-        "begin": "2013-08-01T06:06:53.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-01T06:06:53.000Z"
       },
       {
         "site": "bangumi",
         "id": "1306"
-      },
-      {
-        "site": "bilibili",
-        "id": "1257",
-        "begin": "2008-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -841,7 +592,6 @@
     "officialSite": "http://www.hatsunejima.com/dc2ss/",
     "begin": "2008-04-05T15:30:00.000Z",
     "end": "2008-06-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -850,22 +600,12 @@
       {
         "site": "nicovideo",
         "id": "dc2ss",
-        "begin": "2012-08-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-01T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3745",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -885,27 +625,16 @@
     "officialSite": "http://www.macrossf.com/",
     "begin": "2008-04-03T15:55:00.000Z",
     "end": "2008-09-25T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "03VQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5ao8fwnu2qpl5xf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -914,12 +643,7 @@
       {
         "site": "bilibili",
         "id": "1189",
-        "begin": "2008-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -938,37 +662,21 @@
     "officialSite": "http://web.archive.org/web/*/www.vampire-knight.jp/",
     "begin": "2008-04-07T16:00:00.000Z",
     "end": "2008-06-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ic1gjoQlv3x2AicmY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "2/2ffojof65qn9grr",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "15272",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -977,32 +685,17 @@
       {
         "site": "nicovideo",
         "id": "vampire-knight",
-        "begin": "2014-10-08T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-08T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70309457",
-        "begin": "2016-10-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-15T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1211",
-        "begin": "2008-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1018,7 +711,6 @@
     "officialSite": "http://www.z-child.com/",
     "begin": "2008-04-06T01:00:00.000Z",
     "end": "2009-03-29T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1038,7 +730,6 @@
     "officialSite": "http://www.gamecity.ne.jp/neoromance/tv/neo/index.htm",
     "begin": "2008-04-06T17:00:00.000Z",
     "end": "2008-06-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1061,37 +752,21 @@
     "officialSite": "http://special-a.jp/",
     "begin": "2008-04-06T16:30:00.000Z",
     "end": "2008-09-14T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rYeCAGjOPnzfXcU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzly39",
-        "begin": "2014-09-12T06:22:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:22:33.000Z"
       },
       {
         "site": "qq",
         "id": "s/shaqr883fvr6qqw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1100,12 +775,7 @@
       {
         "site": "bilibili",
         "id": "1245",
-        "begin": "2008-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -1124,17 +794,11 @@
     "officialSite": "http://www.blassreiter.jp/",
     "begin": "2008-04-05T17:00:00.000Z",
     "end": "2008-09-27T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZKehH4ftXZvibfOQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1143,12 +807,7 @@
       {
         "site": "bilibili",
         "id": "1250",
-        "begin": "2008-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -1164,77 +823,36 @@
     "officialSite": "http://itakiss-anime.jp/index.htm",
     "begin": "2008-04-04T17:29:00.000Z",
     "end": "2008-09-26T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7lkkogpw4B6Bic2c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrg3nb7h",
-        "begin": "2013-07-10T07:50:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-10T07:50:02.000Z"
       },
       {
         "site": "qq",
         "id": "e/ebl0msiamhqaiso",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "40240",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/kiss",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464259",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "291270",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1255,37 +873,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/bluedragon/",
     "begin": "2008-04-05T00:00:00.000Z",
     "end": "2009-03-28T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NnhEwiaqQAD6hH4c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgiigu1",
-        "begin": "2014-07-17T05:56:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-17T05:56:28.000Z"
       },
       {
         "site": "qq",
         "id": "8/83su0xjk0pr5h14",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1305,7 +907,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pipopa/",
     "begin": "2008-04-05T23:30:00.000Z",
     "end": "2009-03-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1325,17 +926,11 @@
     "officialSite": "http://suzukisan.info/romantica/",
     "begin": "2008-04-10T16:30:00.000Z",
     "end": "2008-06-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "l/lxlxuxe65uevo4h",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1355,17 +950,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/3shimai/",
     "begin": "2008-04-08T08:30:00.000Z",
     "end": "2010-12-28T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FysWlPxia0hBz8Vk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1374,12 +963,7 @@
       {
         "site": "bilibili",
         "id": "4778",
-        "begin": "2008-04-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-07T16:00:01.000Z"
       }
     ]
   },
@@ -1395,17 +979,11 @@
     "officialSite": "http://www.ntv.co.jp/RD/",
     "begin": "2008-04-08T16:29:00.000Z",
     "end": "2008-09-30T16:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "adGsKpL4aKYJhib8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1414,12 +992,7 @@
       {
         "site": "bilibili",
         "id": "1248",
-        "begin": "2008-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -1438,7 +1011,6 @@
     "officialSite": "http://www.ntv.co.jp/secret/",
     "begin": "2008-04-08T16:59:00.000Z",
     "end": "2008-09-30T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1447,12 +1019,7 @@
       {
         "site": "bilibili",
         "id": "3158",
-        "begin": "2008-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -1468,17 +1035,11 @@
     "officialSite": "http://pen-musu.jp/",
     "begin": "2008-04-19T03:00:00.000Z",
     "end": "2008-11-15T03:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fcbBP6cNfbsenAQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1498,17 +1059,11 @@
     "officialSite": "http://www.tv-osaka.co.jp/mymelo_kirara/",
     "begin": "2008-04-06T00:30:00.000Z",
     "end": "2009-03-29T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HyMenARq2hh7ibWE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1528,27 +1083,16 @@
     "officialSite": "http://www3.nhk.or.jp/anime/mao/main.html",
     "begin": "2008-04-03T14:02:00.000Z",
     "end": "2009-02-19T14:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Sphk4kqwIF7BP6c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/77supmdwa2u31t3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1557,12 +1101,7 @@
       {
         "site": "bilibili",
         "id": "3766",
-        "begin": "2008-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-02T16:00:01.000Z"
       }
     ]
   },
@@ -1578,17 +1117,11 @@
     "officialSite": "http://www.wowow.co.jp/anime/kaiba/",
     "begin": "2008-04-10T15:00:00.000Z",
     "end": "2008-07-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BEZCwCiaOicjyfHYU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1597,12 +1130,7 @@
       {
         "site": "bilibili",
         "id": "1238",
-        "begin": "2008-04-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-09T16:00:00.000Z"
       }
     ]
   },
@@ -1618,7 +1146,6 @@
     "officialSite": "http://www.kirarevo.com/",
     "begin": "2008-04-04T09:00:00.000Z",
     "end": "2009-03-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1638,17 +1165,11 @@
     "officialSite": "http://www.disneychannel.jp/dc/program/anime/fireball/",
     "begin": "2008-04-07T16:00:00.000Z",
     "end": "2008-06-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0hzoZs40pOJFwys",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1657,12 +1178,7 @@
       {
         "site": "bilibili",
         "id": "3232",
-        "begin": "2008-04-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-04-06T16:00:01.000Z"
       }
     ]
   },
@@ -1678,27 +1194,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2008-04-19T16:00:00.000Z",
     "end": "2008-04-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/afc810555211733d.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/afc810555211733d.html"
       },
       {
         "site": "bangumi",
@@ -1707,12 +1212,7 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1728,17 +1228,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2008-04-19T16:00:00.000Z",
     "end": "2008-04-19T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -1747,22 +1241,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1778,17 +1262,11 @@
     "officialSite": "",
     "begin": "2008-04-07T16:00:00.000Z",
     "end": "2010-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lrqWFHziaUpDzcdk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1808,7 +1286,6 @@
     "officialSite": "",
     "begin": "2008-04-02T16:00:00.000Z",
     "end": "2008-04-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1817,12 +1294,7 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2008/05.json
+++ b/data/items/2008/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://candyboy.jp/",
     "begin": "2008-05-02T03:00:00.000Z",
     "end": "2009-05-15T10:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XpFr6VG3J2XIRq4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "ch157",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1789",
-        "begin": "2008-05-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-05-01T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2008/06.json
+++ b/data/items/2008/06.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www3.nhk.or.jp/anime/ran/",
     "begin": "2008-06-21T09:25:00.000Z",
     "end": "2008-12-20T09:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GCgTkflfzw1w7lY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -31,12 +25,7 @@
       {
         "site": "bilibili",
         "id": "4799",
-        "begin": "2008-06-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-06-20T16:00:01.000Z"
       }
     ]
   },
@@ -52,7 +41,6 @@
     "officialSite": "http://www.ikkitousen.com/",
     "begin": "2008-06-11T00:30:00.000Z",
     "end": "2008-08-27T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -75,17 +63,11 @@
     "officialSite": "http://www.choco-bar.jp/",
     "begin": "2008-06-12T03:00:00.000Z",
     "end": "2008-06-12T03:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ESkUkvpg0A5x71c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -105,7 +87,6 @@
     "officialSite": "",
     "begin": "2008-06-08T16:00:00.000Z",
     "end": "2008-10-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2008/07.json
+++ b/data/items/2008/07.json
@@ -11,17 +11,11 @@
     "officialSite": "http://timeofeve.com/",
     "begin": "2008-07-31T15:00:00.000Z",
     "end": "2009-09-17T15:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VuDbWcEnl9U4th4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "3339",
-        "begin": "2008-07-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-31T16:00:01.000Z"
       }
     ]
   },
@@ -54,17 +43,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/hidamari/2nd/",
     "begin": "2008-07-03T16:25:00.000Z",
     "end": "2008-09-25T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LnZS0DiaeDkyvLZU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -73,32 +56,17 @@
       {
         "site": "nicovideo",
         "id": "hidamari_02",
-        "begin": "2014-12-18T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-18T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "732",
-        "begin": "2008-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-02T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhg5atp",
-        "begin": "2018-12-13T07:30:54.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-13T07:30:54.000Z"
       }
     ]
   },
@@ -114,7 +82,6 @@
     "officialSite": "http://mv.avex.jp/mission-e/",
     "begin": "2008-07-07T17:40:00.000Z",
     "end": "2008-09-22T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -134,7 +101,6 @@
     "officialSite": "http://www.birdy-tv.com/season01/",
     "begin": "2008-07-04T16:00:00.000Z",
     "end": "2008-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -142,13 +108,8 @@
       },
       {
         "site": "bilibili",
-        "id": "22958",
-        "begin": "2008-07-03T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "44832",
+        "begin": "2008-07-03T16:00:01.000Z"
       }
     ]
   },
@@ -167,27 +128,16 @@
     "officialSite": "http://www.starchild.co.jp/special/slayers_revolution/",
     "begin": "2008-07-02T16:20:00.000Z",
     "end": "2008-09-24T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibFItqxN56SeKCHA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/boamxckisncwexs",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -210,17 +160,11 @@
     "officialSite": "http://mugen.kc.kodansha.co.jp/",
     "begin": "2008-07-13T15:00:00.000Z",
     "end": "2008-12-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lr2IBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -229,22 +173,12 @@
       {
         "site": "nicovideo",
         "id": "mugen_anime",
-        "begin": "2017-06-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-06T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1230",
-        "begin": "2008-07-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-12T16:00:00.000Z"
       }
     ]
   },
@@ -260,67 +194,36 @@
     "officialSite": "http://www.natsume-anime.jp/",
     "begin": "2008-07-07T16:00:00.000Z",
     "end": "2008-09-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AiaIdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk05utd",
-        "begin": "2012-05-24T07:15:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-05-24T07:15:26.000Z"
       },
       {
         "site": "qq",
         "id": "7/7c9fn2twcli73uz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "49393",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/xmyrz1",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "44660",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -329,22 +232,12 @@
       {
         "site": "nicovideo",
         "id": "natsume-anime",
-        "begin": "2015-10-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-01T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1660",
-        "begin": "2008-07-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-06T16:00:00.000Z"
       }
     ]
   },
@@ -360,17 +253,11 @@
     "officialSite": "http://www.zero-tsukaima.com/zero3/",
     "begin": "2008-07-06T15:30:00.000Z",
     "end": "2011-01-20T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "x/xpp70x2j76gpb31",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -379,22 +266,7 @@
       {
         "site": "nicovideo",
         "id": "zero-tsukaima3",
-        "begin": "2011-12-14T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "820",
-        "begin": "2008-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-12-14T06:00:00.000Z"
       }
     ]
   },
@@ -413,17 +285,11 @@
     "officialSite": "http://www.starchild.co.jp/special/yakushijiryouko/",
     "begin": "2008-07-05T15:30:00.000Z",
     "end": "2008-09-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dNeyMJjibbqwPjfU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -432,12 +298,7 @@
       {
         "site": "bilibili",
         "id": "1231",
-        "begin": "2008-07-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -456,31 +317,15 @@
     "officialSite": "http://bd-dvd.sonypictures.jp/uvcode044/",
     "begin": "2008-07-01T13:00:00.000Z",
     "end": "2008-09-16T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "F1gkogpw4B6Bic2c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "15184"
-      },
-      {
-        "site": "bilibili",
-        "id": "24779",
-        "begin": "2008-06-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -499,37 +344,21 @@
     "officialSite": "http://wd.sega.jp/anime/",
     "begin": "2008-07-07T16:30:00.000Z",
     "end": "2008-09-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VibDbWcEnl9U4th4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaai6x",
-        "begin": "2016-01-06T16:00:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-06T16:00:18.000Z"
       },
       {
         "site": "mgtv",
         "id": "109775",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -538,22 +367,12 @@
       {
         "site": "bilibili",
         "id": "1233",
-        "begin": "2008-07-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-06T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "15387",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -569,7 +388,6 @@
     "officialSite": "http://www.nogizaka-haruka.com/",
     "begin": "2008-07-10T17:00:00.000Z",
     "end": "2008-09-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -578,22 +396,12 @@
       {
         "site": "nicovideo",
         "id": "nogizaka-haruka",
-        "begin": "2011-10-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-26T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1062",
-        "begin": "2008-07-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-09T16:00:00.000Z"
       }
     ]
   },
@@ -612,17 +420,11 @@
     "officialSite": "http://s-witch.cute.or.jp/first/index.html",
     "begin": "2008-07-03T16:30:00.000Z",
     "end": "2008-09-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "6540",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -631,12 +433,7 @@
       {
         "site": "nicovideo",
         "id": "ch324",
-        "begin": "2010-06-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-06-28T15:00:00.000Z"
       }
     ]
   },
@@ -656,17 +453,11 @@
     "officialSite": "http://www.sekirei-tv.com/1st/",
     "begin": "2008-07-02T14:30:00.000Z",
     "end": "2008-09-17T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "e/ekrump5mdasvecx",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -675,12 +466,7 @@
       {
         "site": "nicovideo",
         "id": "ch325",
-        "begin": "2010-06-26T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-06-26T15:00:00.000Z"
       }
     ]
   },
@@ -699,17 +485,11 @@
     "officialSite": "http://www.vap.co.jp/scarecrowman/",
     "begin": "2008-07-03T14:00:00.000Z",
     "end": "2008-12-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QYp29FzCMnDTUbk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -729,17 +509,11 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/sora-mahou/",
     "begin": "2008-07-02T17:40:00.000Z",
     "end": "2008-09-24T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "q5lk4kqwIF7BP6c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -748,12 +522,7 @@
       {
         "site": "bilibili",
         "id": "1235",
-        "begin": "2008-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -769,7 +538,6 @@
     "officialSite": "http://www.maql.co.jp/special/koihime/",
     "begin": "2008-07-08T17:00:00.000Z",
     "end": "2008-09-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -778,12 +546,7 @@
       {
         "site": "nicovideo",
         "id": "koihime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -802,7 +565,6 @@
     "officialSite": "http://www.gamecity.ne.jp/neoromance/tv/neo/index.htm",
     "begin": "2008-07-06T17:00:00.000Z",
     "end": "2008-09-28T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -822,17 +584,11 @@
     "officialSite": "http://www.antique-anime.com/",
     "begin": "2008-07-03T16:00:00.000Z",
     "end": "2008-09-18T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjp2gfp",
-        "begin": "2014-09-12T06:34:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:34:37.000Z"
       },
       {
         "site": "bangumi",
@@ -841,12 +597,7 @@
       {
         "site": "bilibili",
         "id": "1232",
-        "begin": "2008-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-02T16:00:00.000Z"
       }
     ]
   },
@@ -862,7 +613,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_ova.html",
     "begin": "2008-07-25T16:00:00.000Z",
     "end": "2008-07-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -871,12 +621,7 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -892,7 +637,6 @@
     "officialSite": "http://www.animax.co.jp/feature/index.php?program=NN10000680",
     "begin": "2008-07-05T16:00:00.000Z",
     "end": "2008-07-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -912,17 +656,11 @@
     "officialSite": "http://www.ghibli.jp/ponyo/",
     "begin": "2008-07-19T16:00:00.000Z",
     "end": "2008-07-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10010645",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -942,37 +680,21 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2008-07-19T16:00:00.000Z",
     "end": "2008-07-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "71822",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -981,22 +703,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5749",
-        "begin": "2008-07-18T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-07-18T16:00:01.000Z"
       }
     ]
   },
@@ -1012,7 +724,6 @@
     "officialSite": "",
     "begin": "2008-07-12T16:00:00.000Z",
     "end": "2008-07-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1021,12 +732,7 @@
       {
         "site": "letv",
         "id": "71773",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2008/08.json
+++ b/data/items/2008/08.json
@@ -7,7 +7,6 @@
     "officialSite": "http://www.shin-ei-animation.jp/sensoudouwa08/",
     "begin": "2008-08-13T16:00:00.000Z",
     "end": "2008-08-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -27,7 +26,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2008-08-01T17:10:00.000Z",
     "end": "2008-08-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -47,17 +45,11 @@
     "officialSite": "http://negima.kc.kodansha.co.jp/alaalba/",
     "begin": "2008-08-12T16:00:00.000Z",
     "end": "2009-02-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ImpW1DyiaElCzMZk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -66,22 +58,12 @@
       {
         "site": "nicovideo",
         "id": "negima-oad",
-        "begin": "2017-08-30T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-30T06:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "9195",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -100,7 +82,6 @@
     "officialSite": "http://www.naruto-movie.com/",
     "begin": "2008-08-01T16:00:00.000Z",
     "end": "2008-08-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -109,12 +90,7 @@
       {
         "site": "netflix",
         "id": "70105699",
-        "begin": "2016-10-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-15T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2008/09.json
+++ b/data/items/2008/09.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.nagoyatv.com/battlespirits/",
     "begin": "2008-09-06T22:00:00.000Z",
     "end": "2009-09-05T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VZZy8FiaibLmzPTbU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,27 +35,16 @@
     "officialSite": "http://web.archive.org/web/*/www.myfairy.tv/index.html",
     "begin": "2008-09-28T15:00:00.000Z",
     "end": "2008-12-23T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yGpV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "p/pk87sfhwvxamsxd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "1220",
-        "begin": "2008-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -91,17 +69,11 @@
     "officialSite": "http://www.xamd.jp/",
     "begin": "2008-09-24T16:00:00.000Z",
     "end": "2009-02-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "E0RAviaaMicDqdG4M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,12 +82,7 @@
       {
         "site": "bilibili",
         "id": "1206",
-        "begin": "2008-09-23T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-09-23T16:00:00.000Z"
       }
     ]
   },
@@ -131,17 +98,11 @@
     "officialSite": "http://www.movic.jp/info/rakisutaova/",
     "begin": "2008-09-26T16:00:00.000Z",
     "end": "2008-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XYSAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,12 +111,7 @@
       {
         "site": "bilibili",
         "id": "3548",
-        "begin": "2008-09-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-09-25T16:00:01.000Z"
       }
     ]
   },
@@ -171,7 +127,6 @@
     "officialSite": "http://twin-angel.com/media.html",
     "begin": "2008-09-18T16:00:00.000Z",
     "end": "2008-10-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -180,12 +135,7 @@
       {
         "site": "pptv",
         "id": "WpJu7FS6KmjLSbE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -201,7 +151,6 @@
     "officialSite": "",
     "begin": "2008-09-21T16:00:00.000Z",
     "end": "2008-09-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -210,12 +159,7 @@
       {
         "site": "nicovideo",
         "id": "jump-ani-gintama",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -231,7 +175,6 @@
     "officialSite": "http://www.konami.jp/products/qma_ova/",
     "begin": "2008-09-12T16:00:00.000Z",
     "end": "2010-02-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -240,32 +183,17 @@
       {
         "site": "pptv",
         "id": "KQUAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "18248",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5460",
-        "begin": "2008-09-11T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-09-11T16:00:01.000Z"
       }
     ]
   },
@@ -281,7 +209,6 @@
     "officialSite": "http://www.gurren-lagann-movie.net/",
     "begin": "2008-09-06T16:00:00.000Z",
     "end": "2008-09-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -290,12 +217,7 @@
       {
         "site": "nicovideo",
         "id": "gurren-lagann-movie-gurren",
-        "begin": "2018-05-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2008/10.json
+++ b/data/items/2008/10.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.starchild.co.jp/special/gononi/",
     "begin": "2008-10-05T16:30:00.000Z",
     "end": "2008-12-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Lgn0ctpAsO5Rzzc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "0/0zfvm8f4o1isbg1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,17 +40,11 @@
     "officialSite": "http://www.jigokushoujo.com/",
     "begin": "2008-10-04T08:00:00.000Z",
     "end": "2009-04-04T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "43123",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "nicovideo",
         "id": "jigokushoujo03",
-        "begin": "2017-08-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-31T15:00:00.000Z"
       }
     ]
   },
@@ -91,17 +69,11 @@
     "officialSite": "http://bd-dvd.sonypictures.jp/kurozuka/",
     "begin": "2008-10-07T13:00:00.000Z",
     "end": "2008-12-23T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XI56ibGDGNnTXVb0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,12 +82,7 @@
       {
         "site": "bilibili",
         "id": "1228",
-        "begin": "2008-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -131,17 +98,11 @@
     "officialSite": "http://www.tbs.co.jp/clannad/",
     "begin": "2008-10-02T16:59:00.000Z",
     "end": "2009-03-26T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ERH7eeFHticVY1j4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,32 +111,17 @@
       {
         "site": "nicovideo",
         "id": "clannad_after",
-        "begin": "2017-12-29T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-29T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7iwet",
-        "begin": "2018-03-01T04:03:54.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-01T04:03:54.000Z"
       },
       {
         "site": "bilibili",
         "id": "1178",
-        "begin": "2008-10-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -194,27 +140,16 @@
     "officialSite": "http://www.tbs.co.jp/anime/yozakura/",
     "begin": "2008-10-02T16:29:00.000Z",
     "end": "2008-12-18T17:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IATicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "y/yjt1xncfw0wukln",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -223,12 +158,7 @@
       {
         "site": "bilibili",
         "id": "472",
-        "begin": "2008-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -245,27 +175,16 @@
     "officialSite": "http://www.gundam00.net/tv/index.html",
     "begin": "2008-10-05T08:00:00.000Z",
     "end": "2009-03-29T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AiawXlf1j0xF08lo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rriftre6",
-        "begin": "2017-03-02T09:23:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-02T09:23:08.000Z"
       },
       {
         "site": "bangumi",
@@ -274,12 +193,7 @@
       {
         "site": "bilibili",
         "id": "1193",
-        "begin": "2008-10-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-04T16:00:01.000Z"
       }
     ]
   },
@@ -295,27 +209,16 @@
     "officialSite": "http://www.chaoshead.jp/",
     "begin": "2008-10-09T14:00:00.000Z",
     "end": "2008-12-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WJNt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/unct2s8n0sosuof",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -324,12 +227,7 @@
       {
         "site": "nicovideo",
         "id": "anime-chaoshead",
-        "begin": "2012-11-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-03T15:00:00.000Z"
       }
     ]
   },
@@ -348,17 +246,11 @@
     "officialSite": "http://www.tv-toa.jp/",
     "begin": "2008-10-03T12:00:00.000Z",
     "end": "2009-03-27T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sZJt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -367,22 +259,12 @@
       {
         "site": "bilibili",
         "id": "1210",
-        "begin": "2008-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-02T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "15388",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -401,67 +283,36 @@
     "officialSite": "http://www.starchild.co.jp/special/toradora/",
     "begin": "2008-10-01T16:20:00.000Z",
     "end": "2009-03-25T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SPrWVLwiaktAzsRk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9n6ul",
-        "begin": "2016-08-31T16:02:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:02:01.000Z"
       },
       {
         "site": "qq",
         "id": "0/01c2icrv59gbkkt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "16045",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "303213",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1672",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -470,22 +321,12 @@
       {
         "site": "nicovideo",
         "id": "toradora",
-        "begin": "2011-11-27T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-27T16:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80049275",
-        "begin": "2018-12-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-12T16:00:00.000Z"
       }
     ]
   },
@@ -501,37 +342,21 @@
     "officialSite": "http://web.archive.org/web/*/www.vampire-knight.jp/",
     "begin": "2008-10-06T16:00:00.000Z",
     "end": "2008-12-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ACQfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "v/vagq5bv9jy3avyv",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "7907",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -540,22 +365,12 @@
       {
         "site": "nicovideo",
         "id": "vampire-knight2",
-        "begin": "2014-11-12T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-12T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5118",
-        "begin": "2008-10-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -571,27 +386,16 @@
     "officialSite": "http://www.kemeko.jp/",
     "begin": "2008-10-04T17:00:00.000Z",
     "end": "2008-12-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IhLta9M5qedKyDA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "2/2cxoeduk8id9hlf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -600,32 +404,12 @@
       {
         "site": "nicovideo",
         "id": "kemeko",
-        "begin": "2011-11-09T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1222",
-        "begin": "2008-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-09T06:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "17524",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -645,37 +429,21 @@
     "officialSite": "http://www.ga-rei.jp/top.html",
     "begin": "2008-10-05T15:00:00.000Z",
     "end": "2008-12-21T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aKKeHITqWpj7eeE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/uagxf65tyk7amgm",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "44254",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -684,12 +452,7 @@
       {
         "site": "bilibili",
         "id": "1201",
-        "begin": "2008-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -705,17 +468,11 @@
     "officialSite": "http://web.archive.org/web/*/www.macademi.tv/index.html",
     "begin": "2008-10-05T15:30:00.000Z",
     "end": "2008-12-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "80E8uiaKIibDaZF38",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -724,22 +481,12 @@
       {
         "site": "nicovideo",
         "id": "makademi",
-        "begin": "2011-11-30T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-30T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3294",
-        "begin": "2008-10-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-04T16:00:01.000Z"
       }
     ]
   },
@@ -755,17 +502,11 @@
     "officialSite": "http://www.kuroshitsuji.tv/",
     "begin": "2008-10-02T16:25:00.000Z",
     "end": "2009-03-26T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "50049",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -774,22 +515,12 @@
       {
         "site": "nicovideo",
         "id": "ch322",
-        "begin": "2010-06-27T15:00:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-06-27T15:00:01.000Z"
       },
       {
         "site": "bilibili",
-        "id": "75",
-        "begin": "2008-10-01T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "67712",
+        "begin": "2008-10-01T16:00:01.000Z"
       }
     ]
   },
@@ -808,7 +539,6 @@
     "officialSite": "http://web.archive.org/web/*/www.tytania.jp/",
     "begin": "2008-10-09T14:32:00.000Z",
     "end": "2009-09-24T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -817,12 +547,7 @@
       {
         "site": "bilibili",
         "id": "3358",
-        "begin": "2008-10-08T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-08T16:00:01.000Z"
       }
     ]
   },
@@ -841,7 +566,6 @@
     "officialSite": "http://www.rosa-vam.com/",
     "begin": "2008-10-01T17:55:00.000Z",
     "end": "2008-12-24T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -861,17 +585,11 @@
     "officialSite": "http://suzukisan.info/romantica/",
     "begin": "2008-10-11T16:00:00.000Z",
     "end": "2008-12-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "j/jjbz7gsnjn8o9yd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -891,17 +609,11 @@
     "officialSite": "http://www.linebarrels.jp/",
     "begin": "2008-10-03T17:25:00.000Z",
     "end": "2010-05-03T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg3lj4x",
-        "begin": "2014-09-12T06:39:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:39:10.000Z"
       },
       {
         "site": "bangumi",
@@ -910,22 +622,12 @@
       {
         "site": "nicovideo",
         "id": "linebarrels",
-        "begin": "2013-06-07T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-07T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1221",
-        "begin": "2008-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -941,7 +643,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/s-beat/",
     "begin": "2008-10-05T17:00:00.000Z",
     "end": "2009-03-29T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -964,27 +665,16 @@
     "officialSite": "http://www.nodame-anime.com/index_pari.html",
     "begin": "2008-10-09T15:50:00.000Z",
     "end": "2008-12-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eNWwLpb8bKoNiaicM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "4/450jwb67l1hzktf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -993,12 +683,7 @@
       {
         "site": "bilibili",
         "id": "1040",
-        "begin": "2008-10-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-08T16:00:00.000Z"
       }
     ]
   },
@@ -1014,7 +699,6 @@
     "officialSite": "http://www.nagisama-fc.com/anime/",
     "begin": "2008-10-04T13:30:00.000Z",
     "end": "2009-01-03T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1023,22 +707,12 @@
       {
         "site": "nicovideo",
         "id": "ch60004",
-        "begin": "2011-04-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-02T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1185",
-        "begin": "2008-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -1055,37 +729,21 @@
     "officialSite": "http://www.project-index.net/tv/",
     "begin": "2008-10-04T16:35:00.000Z",
     "end": "2009-03-19T04:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9ogep",
-        "begin": "2016-08-15T06:27:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-15T06:27:07.000Z"
       },
       {
         "site": "letv",
         "id": "48909",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2011/mfjsml",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1094,22 +752,12 @@
       {
         "site": "nicovideo",
         "id": "ch641",
-        "begin": "2010-09-17T03:00:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-09-17T03:00:01.000Z"
       },
       {
         "site": "bilibili",
         "id": "963",
-        "begin": "2008-10-04T16:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-04T16:35:00.000Z"
       }
     ]
   },
@@ -1125,17 +773,11 @@
     "officialSite": "http://www.starchild.co.jp/special/shikabanehime/",
     "begin": "2008-10-02T01:30:00.000Z",
     "end": "2008-12-25T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "n/nlj14v0svsox2pj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1155,17 +797,11 @@
     "officialSite": "http://www.ef-melo.com/",
     "begin": "2008-10-06T17:15:00.000Z",
     "end": "2008-12-22T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LgYBfibdNvfte3EQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1174,12 +810,7 @@
       {
         "site": "bilibili",
         "id": "1182",
-        "begin": "2008-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -1195,7 +826,6 @@
     "officialSite": "http://casshern-sins.jp/",
     "begin": "2008-10-01T16:30:00.000Z",
     "end": "2009-03-15T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1204,12 +834,7 @@
       {
         "site": "bilibili",
         "id": "1219",
-        "begin": "2008-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -1225,17 +850,11 @@
     "officialSite": "http://www.sunred.jp/",
     "begin": "2008-10-03T15:45:00.000Z",
     "end": "2009-03-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nKqVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1244,22 +863,12 @@
       {
         "site": "nicovideo",
         "id": "ch243",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1159",
-        "begin": "2008-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -1275,27 +884,16 @@
     "officialSite": "http://www.maql.co.jp/special/akasaka/",
     "begin": "2008-10-01T13:00:00.000Z",
     "end": "2008-12-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aNCrKZH3Z6UIhu4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "d/ddqwqkeedkbh94g",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1304,22 +902,12 @@
       {
         "site": "nicovideo",
         "id": "akane-iro",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "17615",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1336,27 +924,16 @@
     "officialSite": "http://web.archive.org/web/*/hyakko.jp/",
     "begin": "2008-10-01T17:35:00.000Z",
     "end": "2009-02-26T05:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UtibqKJD2ZqQHhe0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "c/c3y3kinjq2hc3th",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1365,12 +942,7 @@
       {
         "site": "bilibili",
         "id": "1223",
-        "begin": "2008-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -1386,17 +958,11 @@
     "officialSite": "http://www.ntv.co.jp/mouryou/",
     "begin": "2008-10-07T16:29:00.000Z",
     "end": "2008-12-30T17:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5D8KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1405,12 +971,7 @@
       {
         "site": "bilibili",
         "id": "3374",
-        "begin": "2008-10-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-06T16:00:01.000Z"
       }
     ]
   },
@@ -1429,17 +990,11 @@
     "officialSite": "http://www.ntv.co.jp/oneouts/",
     "begin": "2008-10-07T15:59:00.000Z",
     "end": "2009-03-31T16:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1G5Z1ziblFVO2NJw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1448,12 +1003,7 @@
       {
         "site": "bilibili",
         "id": "1205",
-        "begin": "2008-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -1469,17 +1019,11 @@
     "officialSite": "http://www.michikotohatchin.com/",
     "begin": "2008-10-15T17:08:00.000Z",
     "end": "2009-03-18T17:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EyciaoAhu3hxicicWU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1488,12 +1032,7 @@
       {
         "site": "bilibili",
         "id": "3360",
-        "begin": "2008-10-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-14T16:00:01.000Z"
       }
     ]
   },
@@ -1510,27 +1049,16 @@
     "officialSite": "http://www.haoh.tv/",
     "begin": "2008-10-02T16:28:00.000Z",
     "end": "2008-12-25T16:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "K2Rg3kasHFq9O6M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk77r2x",
-        "begin": "2012-09-01T10:04:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-01T10:04:57.000Z"
       },
       {
         "site": "bangumi",
@@ -1539,12 +1067,7 @@
       {
         "site": "bilibili",
         "id": "1226",
-        "begin": "2008-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -1560,57 +1083,31 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/inazuma/",
     "begin": "2008-10-05T00:00:00.000Z",
     "end": "2011-04-27T10:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rol08lrAMG7RT7c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjwuwj1",
-        "begin": "2017-01-18T08:03:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-18T08:03:10.000Z"
       },
       {
         "site": "qq",
         "id": "i/irdhfa8q4fzs1ud",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "5770",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/sdsyr",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1619,12 +1116,7 @@
       {
         "site": "bilibili",
         "id": "5466",
-        "begin": "2008-10-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-04T16:00:01.000Z"
       }
     ]
   },
@@ -1640,7 +1132,6 @@
     "officialSite": "http://shugo-chara.com/",
     "begin": "2008-10-04T00:30:00.000Z",
     "end": "2009-09-26T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1660,7 +1151,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/negibozu/",
     "begin": "2008-10-11T21:30:00.000Z",
     "end": "2009-09-26T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1680,7 +1170,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cardliver/",
     "begin": "2008-10-05T01:30:00.000Z",
     "end": "2009-09-27T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1700,7 +1189,6 @@
     "officialSite": "http://www.disney.co.jp/character/stitch/okinawa/index.html",
     "begin": "2008-10-08T06:30:00.000Z",
     "end": "2009-03-25T03:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1720,17 +1208,11 @@
     "officialSite": "",
     "begin": "2008-10-04T16:00:00.000Z",
     "end": "2008-10-04T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "e/e2ou7uh8vxr19ld",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1739,12 +1221,7 @@
       {
         "site": "nicovideo",
         "id": "hokuto-no-ken",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1761,27 +1238,16 @@
     "officialSite": "http://www.mtvjapan.com/usavich/",
     "begin": "2008-10-13T16:00:00.000Z",
     "end": "2009-05-25T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HRLibfORKuvhb2UE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhazwjh",
-        "begin": "2017-01-25T03:25:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-25T03:25:44.000Z"
       },
       {
         "site": "bangumi",
@@ -1790,22 +1256,12 @@
       {
         "site": "sohu",
         "id": "s2017/dhptwt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5870",
-        "begin": "2008-10-12T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-12T16:00:01.000Z"
       }
     ]
   },
@@ -1821,17 +1277,11 @@
     "officialSite": "",
     "begin": "2008-10-24T16:00:00.000Z",
     "end": "2009-04-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "J2Zia4EiauHlyicPaU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1851,17 +1301,11 @@
     "officialSite": "",
     "begin": "2008-10-06T16:00:00.000Z",
     "end": "2008-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "e7SQDnbcTIrta9M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1881,17 +1325,11 @@
     "officialSite": "http://www.ikki-para.com/comix/noramimi.html",
     "begin": "2008-10-01T16:00:00.000Z",
     "end": "2008-12-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KWJe3ESqGlia7OaE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1911,7 +1349,6 @@
     "officialSite": "",
     "begin": "2008-10-24T16:00:00.000Z",
     "end": "2008-10-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1920,22 +1357,12 @@
       {
         "site": "pptv",
         "id": "j8C8OqIIeLYZlic8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3058",
-        "begin": "2008-10-23T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2008-10-23T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2008/11.json
+++ b/data/items/2008/11.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.neko-rahmen.com/",
     "begin": "2008-11-04T16:00:00.000Z",
     "end": "2008-11-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YOicJR68VhcMmpAw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2008_precure5gogo/",
     "begin": "2008-11-08T16:00:00.000Z",
     "end": "2008-11-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,22 +43,12 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   }

--- a/data/items/2008/12.json
+++ b/data/items/2008/12.json
@@ -11,27 +11,16 @@
     "officialSite": "http://maikaze.com/",
     "begin": "2008-12-30T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VYVicicWXLO3ncWsI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "23613",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "2008-12-20T16:00:00.000Z",
     "end": "2008-12-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4kld",
-        "begin": "2015-08-11T08:03:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-11T08:03:32.000Z"
       }
     ]
   },
@@ -84,7 +67,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/bleach/",
     "begin": "2008-12-12T16:00:00.000Z",
     "end": "2008-12-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -93,12 +75,7 @@
       {
         "site": "netflix",
         "id": "70208801",
-        "begin": "2016-10-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-15T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2009/01.json
+++ b/data/items/2009/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.mariaholic.com/01/index.html",
     "begin": "2009-01-04T15:30:00.000Z",
     "end": "2009-03-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "nicovideo",
         "id": "mariaholic",
-        "begin": "2012-07-04T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-04T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "920",
-        "begin": "2009-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-03T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://www.melomelomelon.com/",
     "begin": "2009-01-03T15:00:00.000Z",
     "end": "2009-03-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QuXgXsYsnNo9uyM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "1097",
-        "begin": "2009-01-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-02T16:00:00.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "http://asahi.co.jp/fresh_precure/",
     "begin": "2009-01-31T23:30:00.000Z",
     "end": "2010-01-31T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb14pl",
-        "begin": "2015-09-24T06:16:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-24T06:16:43.000Z"
       }
     ]
   },
@@ -121,7 +93,6 @@
     "officialSite": "http://www3.nhk.or.jp/anime/erin/index.html",
     "begin": "2009-01-10T09:25:00.000Z",
     "end": "2009-12-26T09:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,12 +101,7 @@
       {
         "site": "bilibili",
         "id": "3434",
-        "begin": "2009-01-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-10T16:00:01.000Z"
       }
     ]
   },
@@ -152,67 +118,36 @@
     "officialSite": "http://www.natsume-anime.jp/",
     "begin": "2009-01-05T16:30:00.000Z",
     "end": "2009-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AyMenARq2hh7ibWE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk05u75",
-        "begin": "2016-12-12T15:38:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-12T15:38:17.000Z"
       },
       {
         "site": "qq",
         "id": "x/xiijm0os2zcnel2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "50088",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/xmyrz2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "44661",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -221,22 +156,12 @@
       {
         "site": "nicovideo",
         "id": "zokunatsume",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1661",
-        "begin": "2009-01-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -252,37 +177,21 @@
     "officialSite": "http://hetalia.com/index.htm",
     "begin": "2009-01-26T07:00:00.000Z",
     "end": "2009-07-20T07:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iaLeSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaaub5",
-        "begin": "2016-01-06T16:01:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-06T16:01:34.000Z"
       },
       {
         "site": "letv",
         "id": "10018939",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -291,12 +200,7 @@
       {
         "site": "nicovideo",
         "id": "hetaria-axis-powers",
-        "begin": "2012-12-28T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-28T07:00:00.000Z"
       }
     ]
   },
@@ -312,17 +216,11 @@
     "officialSite": "http://web.archive.org/web/*/slayers-tv.net/",
     "begin": "2009-01-12T00:30:00.000Z",
     "end": "2009-04-06T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ftWwLpb8bKoNiaicM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -345,27 +243,16 @@
     "officialSite": "http://anime.webnt.jp/regios/",
     "begin": "2009-01-10T16:00:00.000Z",
     "end": "2009-06-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ic1kkogpw4B6Bic2c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzm3qd",
-        "begin": "2012-07-01T06:24:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:24:55.000Z"
       },
       {
         "site": "bangumi",
@@ -374,12 +261,7 @@
       {
         "site": "bilibili",
         "id": "1092",
-        "begin": "2009-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -395,17 +277,11 @@
     "officialSite": "http://www.starchild.co.jp/special/minami-ke/3/",
     "begin": "2009-01-04T16:30:00.000Z",
     "end": "2009-03-29T17:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gKOeHITqWpj7eeE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -414,22 +290,12 @@
       {
         "site": "nicovideo",
         "id": "minami-ke3",
-        "begin": "2017-09-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-09T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "622",
-        "begin": "2009-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-03T16:00:00.000Z"
       }
     ]
   },
@@ -445,17 +311,11 @@
     "officialSite": "http://web.archive.org/web/*/viperscreed.jp/",
     "begin": "2009-01-06T13:00:00.000Z",
     "end": "2009-03-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BjoFgibtRwf9ia4Eg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -464,12 +324,7 @@
       {
         "site": "bilibili",
         "id": "1099",
-        "begin": "2009-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -485,17 +340,11 @@
     "officialSite": "http://www.rideback-anime.jp/",
     "begin": "2009-01-11T15:00:00.000Z",
     "end": "2009-03-29T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ufPNS7MZiaccqqBA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -504,12 +353,7 @@
       {
         "site": "bilibili",
         "id": "3278",
-        "begin": "2009-01-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-10T16:00:01.000Z"
       }
     ]
   },
@@ -525,17 +369,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/yoichi/index-j.html",
     "begin": "2009-01-08T16:29:00.000Z",
     "end": "2009-03-26T16:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "b8iazMZnicb60QjvY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -544,12 +382,7 @@
       {
         "site": "bilibili",
         "id": "1093",
-        "begin": "2009-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -565,7 +398,6 @@
     "officialSite": "http://www.birdy-tv.com/",
     "begin": "2009-01-09T17:10:00.000Z",
     "end": "2009-03-27T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -573,13 +405,8 @@
       },
       {
         "site": "bilibili",
-        "id": "4738",
-        "begin": "2009-01-08T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "44812",
+        "begin": "2009-01-08T16:00:01.000Z"
       }
     ]
   },
@@ -595,17 +422,11 @@
     "officialSite": "http://www.munto.com/",
     "begin": "2009-01-13T16:45:00.000Z",
     "end": "2009-03-10T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tP3HRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -614,12 +435,7 @@
       {
         "site": "bilibili",
         "id": "1117",
-        "begin": "2009-01-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-12T16:00:00.000Z"
       }
     ]
   },
@@ -635,7 +451,6 @@
     "officialSite": "http://www.starchild.co.jp/special/shikabanehime/",
     "begin": "2009-01-01T01:30:00.000Z",
     "end": "2009-03-26T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -655,17 +470,11 @@
     "officialSite": "http://www.gokigenyou.com/index2.htm",
     "begin": "2009-01-03T01:30:00.000Z",
     "end": "2009-03-28T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LBvmZMwyouBDwSk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -674,22 +483,7 @@
       {
         "site": "letv",
         "id": "15322",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2705",
-        "begin": "2009-01-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -705,17 +499,11 @@
     "officialSite": "http://www.druaga-anime.com/",
     "begin": "2009-01-08T16:30:00.000Z",
     "end": "2009-03-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YcK9O6MJebcamAA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -724,12 +512,7 @@
       {
         "site": "bilibili",
         "id": "1101",
-        "begin": "2009-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -745,17 +528,11 @@
     "officialSite": "http://www.sorakake.net/",
     "begin": "2009-01-05T17:00:00.000Z",
     "end": "2009-06-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icC8Zlic9l1RN29Fw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -775,7 +552,6 @@
     "officialSite": "http://www.kurokami-anime.net/",
     "begin": "2009-01-08T17:40:00.000Z",
     "end": "2009-06-18T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -784,12 +560,7 @@
       {
         "site": "bilibili",
         "id": "1102",
-        "begin": "2009-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -806,27 +577,16 @@
     "officialSite": "http://www9.nhk.or.jp/anime/major/",
     "begin": "2009-01-10T09:00:00.000Z",
     "end": "2009-06-27T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hKiaTEXnfT43wbtY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc3iwl",
-        "begin": "2014-12-24T06:19:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-24T06:19:18.000Z"
       },
       {
         "site": "bangumi",
@@ -846,7 +606,6 @@
     "officialSite": "http://www.ntv.co.jp/ippo/",
     "begin": "2009-01-06T16:59:00.000Z",
     "end": "2009-06-30T17:09:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -866,17 +625,11 @@
     "officialSite": "http://www.whitealbum-tv.com/",
     "begin": "2009-01-03T17:00:00.000Z",
     "end": "2009-03-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "a/ahsfol4rlzypt3e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -885,12 +638,7 @@
       {
         "site": "bilibili",
         "id": "1078",
-        "begin": "2009-01-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-02T16:00:00.000Z"
       }
     ]
   },
@@ -906,27 +654,16 @@
     "officialSite": "http://genji-anime.com/",
     "begin": "2009-01-15T15:45:00.000Z",
     "end": "2009-03-26T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "T96pJ4ic1ZaMGhOw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "43418",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -935,12 +672,7 @@
       {
         "site": "bilibili",
         "id": "1118",
-        "begin": "2009-01-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-01-14T16:00:00.000Z"
       }
     ]
   },
@@ -956,7 +688,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/yumezou/",
     "begin": "2009-01-13T16:00:00.000Z",
     "end": "2009-12-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -976,17 +707,11 @@
     "officialSite": "http://blog.san-x.co.jp/mamegoma/",
     "begin": "2009-01-10T16:00:00.000Z",
     "end": "2009-12-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fMSicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2009/02.json
+++ b/data/items/2009/02.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.haruhi.tv/haruchuru/",
     "begin": "2009-02-14T07:00:00.000Z",
     "end": "2009-05-08T13:04:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7CUfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "letv",
         "id": "43941",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://www.haruhi.tv/haruchuru/",
     "begin": "2009-02-14T07:00:00.000Z",
     "end": "2009-05-08T13:02:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fdKtK5P5aacKiaPA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "4734",
-        "begin": "2009-02-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-02-13T16:00:01.000Z"
       }
     ]
   },
@@ -91,17 +69,11 @@
     "officialSite": "http://kc.kodansha.co.jp/tsubaholi/",
     "begin": "2009-02-17T16:00:00.000Z",
     "end": "2009-06-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tI5591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -110,12 +82,7 @@
       {
         "site": "bilibili",
         "id": "3390",
-        "begin": "2009-02-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-02-16T16:00:01.000Z"
       }
     ]
   },
@@ -131,7 +98,6 @@
     "officialSite": "http://oyashirosama.com/web/rei/index.htm",
     "begin": "2009-02-25T16:00:00.000Z",
     "end": "2009-08-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,22 +106,7 @@
       {
         "site": "nicovideo",
         "id": "oyashirosama03",
-        "begin": "2017-06-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1774",
-        "begin": "2009-02-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-16T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2009/03.json
+++ b/data/items/2009/03.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.corda-primopasso.com/",
     "begin": "2009-03-26T15:00:00.000Z",
     "end": "2009-06-05T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0x3nZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "corda-secondo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "168",
-        "begin": "2009-03-25T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-03-25T16:00:00.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/chissweet2009/",
     "begin": "2009-03-29T21:40:00.000Z",
     "end": "2009-09-23T21:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -81,17 +64,11 @@
     "officialSite": "http://www.nhk.or.jp/kids/program/main.html",
     "begin": "2009-03-30T08:40:00.000Z",
     "end": "2013-03-21T21:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icjAMiavJYyAZp508",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -111,31 +88,15 @@
     "officialSite": "http://www.joke-charady-365.com/charady_top.html",
     "begin": "2009-03-31T15:40:00.000Z",
     "end": "2010-03-30T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RIeBic2fNPXveXMQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1546"
-      },
-      {
-        "site": "bilibili",
-        "id": "1121",
-        "begin": "2009-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -151,7 +112,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/marie_gali01/",
     "begin": "2009-03-31T10:25:00.000Z",
     "end": "2010-03-23T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -171,7 +131,6 @@
     "officialSite": "http://www.ntv.co.jp/lupin-conan/",
     "begin": "2009-03-27T16:00:00.000Z",
     "end": "2009-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -191,17 +150,11 @@
     "officialSite": "http://doraeiga.com/2009/",
     "begin": "2009-03-07T16:00:00.000Z",
     "end": "2009-03-07T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "81026",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -210,32 +163,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mkdh",
-        "begin": "2018-05-31T16:11:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:11:26.000Z"
       }
     ]
   },
@@ -251,7 +189,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2009_precure_allstars/",
     "begin": "2009-03-20T16:00:00.000Z",
     "end": "2009-03-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -260,12 +197,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   },
@@ -281,7 +213,6 @@
     "officialSite": "",
     "begin": "2009-03-06T16:00:00.000Z",
     "end": "2009-03-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -301,7 +232,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2009-03-30T08:35:00.000Z",
     "end": "2009-07-31T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -321,17 +251,11 @@
     "officialSite": "http://www.shonenmagazine.com/tsubasa_tokyo/",
     "begin": "2009-03-17T16:00:00.000Z",
     "end": "2009-05-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "R5Vv7VW7K2nMSrI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -340,22 +264,12 @@
       {
         "site": "bilibili",
         "id": "2855",
-        "begin": "2009-03-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-03-16T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10388",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -371,17 +285,11 @@
     "officialSite": "",
     "begin": "2009-03-27T16:00:00.000Z",
     "end": "2009-05-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "t5dy8FiaibLmzPTbU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -401,7 +309,6 @@
     "officialSite": "http://www.keroro-movie.net/",
     "begin": "2009-03-07T16:00:00.000Z",
     "end": "2009-03-07T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -410,12 +317,7 @@
       {
         "site": "pptv",
         "id": "9LQdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2009/04.json
+++ b/data/items/2009/04.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.guinsaga.net/",
     "begin": "2009-04-05T14:29:00.000Z",
     "end": "2009-09-27T14:54:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xV8qqBB25iaSHBW0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,12 +27,7 @@
       {
         "site": "bilibili",
         "id": "1131",
-        "begin": "2009-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -54,27 +43,16 @@
     "officialSite": "http://www3.nhk.or.jp/anime/hana/",
     "begin": "2009-04-05T14:01:00.000Z",
     "end": "2010-02-14T14:26:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0nVQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "5341",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -83,22 +61,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhbp039",
-        "begin": "2017-10-31T16:01:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-31T16:01:40.000Z"
       },
       {
         "site": "bilibili",
         "id": "1133",
-        "begin": "2009-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -114,17 +82,11 @@
     "officialSite": "http://www.phantom-r.jp/",
     "begin": "2009-04-02T16:30:00.000Z",
     "end": "2009-09-24T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yG9a2ECmFlS3NZ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -133,12 +95,7 @@
       {
         "site": "nicovideo",
         "id": "phantom-r",
-        "begin": "2012-06-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-20T06:00:00.000Z"
       }
     ]
   },
@@ -157,27 +114,16 @@
     "officialSite": "http://www.hagaren.jp/",
     "begin": "2009-04-05T08:00:00.000Z",
     "end": "2010-07-04T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Jwr1c9tBse9S0Dg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "45402",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -186,32 +132,17 @@
       {
         "site": "nicovideo",
         "id": "hagaren-fa",
-        "begin": "2015-04-10T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70204981",
-        "begin": "2018-01-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-01T08:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1089",
-        "begin": "2009-04-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-04T16:00:01.000Z"
       }
     ]
   },
@@ -227,17 +158,11 @@
     "officialSite": "http://www.nippon-animation.co.jp/before_GG/index.html",
     "begin": "2009-04-05T10:30:00.000Z",
     "end": "2009-12-27T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gqWgHobsXJr9eibM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -246,12 +171,7 @@
       {
         "site": "letv",
         "id": "6172",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -267,27 +187,16 @@
     "officialSite": "http://ponican.jp/ttt/",
     "begin": "2009-04-03T11:00:00.000Z",
     "end": "2009-09-27T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ynpFwyuRATibiaIIg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzen3l",
-        "begin": "2012-07-01T06:25:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:25:22.000Z"
       },
       {
         "site": "bangumi",
@@ -307,17 +216,11 @@
     "officialSite": "http://www.j-hatsukoi.com/",
     "begin": "2009-04-11T15:00:00.000Z",
     "end": "2009-06-27T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vop181vBMWicSULg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -326,12 +229,7 @@
       {
         "site": "letv",
         "id": "7433",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -347,17 +245,11 @@
     "officialSite": "http://www.starchild.co.jp/special/natsunoarashi/",
     "begin": "2009-04-05T16:30:00.000Z",
     "end": "2009-06-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BCAbmQFn1xV49l4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -366,12 +258,7 @@
       {
         "site": "bilibili",
         "id": "1135",
-        "begin": "2009-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -387,7 +274,6 @@
     "officialSite": "http://queensblade.tv/",
     "begin": "2009-04-01T23:00:00.000Z",
     "end": "2009-06-17T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -396,12 +282,7 @@
       {
         "site": "nicovideo",
         "id": "queensblade01",
-        "begin": "2012-04-11T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-11T06:00:00.000Z"
       }
     ]
   },
@@ -417,31 +298,15 @@
     "officialSite": "http://www.tayutama.com/",
     "begin": "2009-04-05T15:30:00.000Z",
     "end": "2009-06-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mtWvLZX7a6kMiavI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "1605"
-      },
-      {
-        "site": "bilibili",
-        "id": "1130",
-        "begin": "2009-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -458,27 +323,16 @@
     "officialSite": "http://07-ghost.net/",
     "begin": "2009-04-06T16:40:00.000Z",
     "end": "2009-09-21T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "spVw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzmccx",
-        "begin": "2012-07-01T06:24:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:24:21.000Z"
       },
       {
         "site": "bangumi",
@@ -487,22 +341,7 @@
       {
         "site": "mgtv",
         "id": "319823",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1139",
-        "begin": "2009-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -521,17 +360,11 @@
     "officialSite": "http://www.valkyria-anime.com/",
     "begin": "2009-04-04T16:35:00.000Z",
     "end": "2009-09-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "m9WvLZX7a6kMiavI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -540,12 +373,7 @@
       {
         "site": "qq",
         "id": "d/dzrw32cutvxpp5n",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -561,31 +389,15 @@
     "officialSite": "http://mechamote.tv/",
     "begin": "2009-04-04T00:00:00.000Z",
     "end": "2010-03-27T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IQL9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "3640"
-      },
-      {
-        "site": "bilibili",
-        "id": "1034",
-        "begin": "2009-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -605,17 +417,11 @@
     "officialSite": "http://hayatenogotoku.com/index.html",
     "begin": "2009-04-03T16:23:00.000Z",
     "end": "2009-09-18T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgift5l",
-        "begin": "2014-09-12T06:31:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:31:25.000Z"
       },
       {
         "site": "bangumi",
@@ -635,18 +441,7 @@
     "officialSite": "http://www.saki-anime.com/1st/",
     "begin": "2009-04-05T17:00:00.000Z",
     "end": "2009-09-27T17:48:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1463253",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "1444"
@@ -665,37 +460,21 @@
     "officialSite": "http://www.tbs.co.jp/anime/ph/",
     "begin": "2009-04-02T16:39:00.000Z",
     "end": "2009-09-24T17:09:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iaKuWFHziaUpDzcdk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrg85ny5",
-        "begin": "2013-06-06T06:26:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-06T06:26:35.000Z"
       },
       {
         "site": "qq",
         "id": "b/b1v5iy053dtf3k8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -704,12 +483,7 @@
       {
         "site": "bilibili",
         "id": "1073",
-        "begin": "2009-04-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -726,47 +500,21 @@
     "officialSite": "http://web.archive.org/web/*/www.sengokubasara.tv/basara1/index2.html",
     "begin": "2009-04-01T16:34:00.000Z",
     "end": "2009-06-17T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Gjchnwdt3RtibicGQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk44cp1",
-        "begin": "2014-09-12T06:44:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:44:11.000Z"
       },
       {
         "site": "qq",
         "id": "5/5xvc2gtn2s9mf43",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1463236",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -775,22 +523,12 @@
       {
         "site": "nicovideo",
         "id": "ch327",
-        "begin": "2010-07-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-07-31T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1590",
-        "begin": "2009-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -806,7 +544,6 @@
     "officialSite": "http://www.starchild.co.jp/special/asura/",
     "begin": "2009-04-02T00:30:00.000Z",
     "end": "2009-06-25T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -815,12 +552,7 @@
       {
         "site": "bilibili",
         "id": "1765",
-        "begin": "2009-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -839,7 +571,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/k-on/k-on_tv/index-j.html",
     "begin": "2009-04-02T17:09:00.000Z",
     "end": "2013-06-22T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -848,12 +579,7 @@
       {
         "site": "nicovideo",
         "id": "k-on_anime",
-        "begin": "2018-12-27T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-27T15:00:00.000Z"
       }
     ]
   },
@@ -872,7 +598,6 @@
     "officialSite": "http://web.archive.org/web/*/www.anime-shangri-la.jp/index.html",
     "begin": "2009-04-05T15:00:00.000Z",
     "end": "2009-09-13T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -893,27 +618,16 @@
     "officialSite": "http://web.archive.org/web/*/www.polyphonica.tv/",
     "begin": "2009-04-04T16:30:00.000Z",
     "end": "2009-06-20T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lriaDAWnPP33gXsY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrg7wqah",
-        "begin": "2014-09-12T06:28:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:28:24.000Z"
       },
       {
         "site": "bangumi",
@@ -922,22 +636,12 @@
       {
         "site": "nicovideo",
         "id": "polyphonica_cs",
-        "begin": "2013-07-30T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-30T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1129",
-        "begin": "2009-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -956,17 +660,11 @@
     "officialSite": "http://basquash.com/",
     "begin": "2009-04-02T16:30:00.000Z",
     "end": "2009-10-01T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YauVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -975,12 +673,7 @@
       {
         "site": "bilibili",
         "id": "1124",
-        "begin": "2009-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -999,27 +692,16 @@
     "officialSite": "http://www.juiz.jp/",
     "begin": "2009-04-09T15:45:00.000Z",
     "end": "2009-06-18T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8VMurBR66iaiaLCXE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrg7wn7t",
-        "begin": "2014-09-12T06:35:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:35:48.000Z"
       },
       {
         "site": "bangumi",
@@ -1028,12 +710,7 @@
       {
         "site": "bilibili",
         "id": "2674",
-        "begin": "2009-04-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-08T16:00:00.000Z"
       }
     ]
   },
@@ -1049,17 +726,11 @@
     "officialSite": "http://web.archive.org/web/*/www.rispara.tv/",
     "begin": "2009-04-08T17:08:00.000Z",
     "end": "2009-06-24T17:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1G9a2ECmFlS3NZ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1068,12 +739,7 @@
       {
         "site": "bilibili",
         "id": "1141",
-        "begin": "2009-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -1089,17 +755,11 @@
     "officialSite": "http://www.ntv.co.jp/souten/",
     "begin": "2009-04-07T16:14:00.000Z",
     "end": "2009-09-29T16:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0HJNyzOZCUeqKJA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1108,22 +768,12 @@
       {
         "site": "nicovideo",
         "id": "souten_anime",
-        "begin": "2016-06-22T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-22T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1140",
-        "begin": "2009-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1142,17 +792,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/dragon_kai/",
     "begin": "2009-04-05T00:00:00.000Z",
     "end": "2011-03-27T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1cvx",
-        "begin": "2015-08-14T17:02:27.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:02:27.000Z"
       },
       {
         "site": "bangumi",
@@ -1173,37 +817,21 @@
     "officialSite": "http://web.archive.org/web/*/www.sup-arad.jp/",
     "begin": "2009-04-03T17:45:00.000Z",
     "end": "2009-09-25T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pZRv7VW7K2nMSrI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "y/ye76z23ahqk7ro4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "5334",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1212,12 +840,7 @@
       {
         "site": "bilibili",
         "id": "1123",
-        "begin": "2009-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -1236,17 +859,11 @@
     "officialSite": "http://www.jewelpet.jp/",
     "begin": "2009-04-05T00:30:00.000Z",
     "end": "2010-03-28T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xF4ppw915SOGBGw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1255,12 +872,7 @@
       {
         "site": "letv",
         "id": "6171",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1277,27 +889,16 @@
     "officialSite": "http://www.shin-mazinger.com/",
     "begin": "2009-04-04T14:20:00.000Z",
     "end": "2009-09-26T14:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "e7WPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbvpa9",
-        "begin": "2014-08-19T01:23:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-19T01:23:12.000Z"
       },
       {
         "site": "bangumi",
@@ -1306,22 +907,12 @@
       {
         "site": "letv",
         "id": "10018941",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1126",
-        "begin": "2009-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -1340,27 +931,16 @@
     "officialSite": "http://www.shopro.co.jp/tv/crossgame/",
     "begin": "2009-04-05T01:00:00.000Z",
     "end": "2010-03-28T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "y2xX1T2jE1G0Mpo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/7d8pewhl60n7jbd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1380,17 +960,11 @@
     "officialSite": "http://www.kaasan.jp/",
     "begin": "2009-04-01T10:00:00.000Z",
     "end": "2012-03-25T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjz44hh",
-        "begin": "2012-06-07T09:16:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-07T09:16:44.000Z"
       },
       {
         "site": "bangumi",
@@ -1413,7 +987,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mf-beyblade/",
     "begin": "2009-04-04T23:30:00.000Z",
     "end": "2010-03-28T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1433,27 +1006,16 @@
     "officialSite": "http://www.haruhi.tv/",
     "begin": "2009-04-02T15:40:00.000Z",
     "end": "2009-10-08T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "R8GrKZH3Z6UIhu4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "40473",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1462,12 +1024,7 @@
       {
         "site": "nicovideo",
         "id": "haruhi_2009",
-        "begin": "2016-07-11T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-11T01:00:00.000Z"
       }
     ]
   },
@@ -1483,17 +1040,11 @@
     "officialSite": "http://www.higepiyo-tv.com/",
     "begin": "2009-04-03T09:20:00.000Z",
     "end": "2010-02-19T09:54:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RIaCAGjOPnzfXcU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1502,12 +1053,7 @@
       {
         "site": "bilibili",
         "id": "1122",
-        "begin": "2009-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -1523,27 +1069,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2009-04-18T16:00:00.000Z",
     "end": "2009-04-18T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/dea630dffb9ba638.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/dea630dffb9ba638.html"
       },
       {
         "site": "bangumi",
@@ -1552,22 +1087,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3890",
-        "begin": "2009-04-17T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10532",
+        "begin": "2009-04-17T16:00:01.000Z"
       }
     ]
   },
@@ -1583,17 +1108,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2009-04-18T16:00:00.000Z",
     "end": "2009-04-18T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -1602,22 +1121,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1633,17 +1142,11 @@
     "officialSite": "",
     "begin": "2009-04-24T16:00:00.000Z",
     "end": "2009-04-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DUE7uSGH9zWYFn4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1659,7 +1162,6 @@
     "officialSite": "http://aquaplus.jp/th2adplus/",
     "begin": "2009-04-24T16:00:00.000Z",
     "end": "2009-10-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1668,12 +1170,7 @@
       {
         "site": "nicovideo",
         "id": "th2adplus",
-        "begin": "2012-03-03T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-03T13:30:00.000Z"
       }
     ]
   },
@@ -1689,7 +1186,6 @@
     "officialSite": "",
     "begin": "2009-04-18T16:00:00.000Z",
     "end": "2009-04-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1709,7 +1205,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/bakugan2/",
     "begin": "2009-04-12T16:00:00.000Z",
     "end": "2010-05-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1718,12 +1213,7 @@
       {
         "site": "letv",
         "id": "17789",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1739,7 +1229,6 @@
     "officialSite": "http://www.gurren-lagann-movie.net/",
     "begin": "2009-04-25T16:00:00.000Z",
     "end": "2009-04-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1748,12 +1237,7 @@
       {
         "site": "nicovideo",
         "id": "gurren-lagann-movie-lagann",
-        "begin": "2018-05-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2009/05.json
+++ b/data/items/2009/05.json
@@ -11,27 +11,16 @@
     "officialSite": "http://seikishi.com/",
     "begin": "2009-05-01T16:00:00.000Z",
     "end": "2009-05-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vOzYVr4klNI1sxs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "6376",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,7 +40,6 @@
     "officialSite": "http://www.first-squad.com/",
     "begin": "2009-05-13T16:00:00.000Z",
     "end": "2009-05-13T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -72,27 +60,16 @@
     "officialSite": "http://www.tenipuri.jp/dvd05/01.html",
     "begin": "2009-05-26T16:00:00.000Z",
     "end": "2009-09-25T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MRXicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjrjyhp",
-        "begin": "2013-01-29T07:31:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-29T07:31:47.000Z"
       },
       {
         "site": "bangumi",
@@ -101,22 +78,12 @@
       {
         "site": "mgtv",
         "id": "103523",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "23775",
-        "begin": "2009-05-26T12:09:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "73412",
+        "begin": "2009-05-26T12:09:00.000Z"
       }
     ]
   },
@@ -132,31 +99,15 @@
     "officialSite": "http://annex.s-manga.net/dogs/",
     "begin": "2009-05-19T16:00:00.000Z",
     "end": "2009-07-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7VYxrxd97SuODHQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "2430"
-      },
-      {
-        "site": "bilibili",
-        "id": "4705",
-        "begin": "2009-05-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -172,7 +123,6 @@
     "officialSite": "",
     "begin": "2009-05-01T16:00:00.000Z",
     "end": "2009-12-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -181,12 +131,7 @@
       {
         "site": "letv",
         "id": "12878",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2009/06.json
+++ b/data/items/2009/06.json
@@ -11,17 +11,11 @@
     "officialSite": "http://mv.avex.jp/juden-chan/",
     "begin": "2009-06-24T23:00:00.000Z",
     "end": "2009-09-09T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "c9SvLZX7a6kMiavI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,27 +35,16 @@
     "officialSite": "http://www.sea-story.tv/",
     "begin": "2009-06-24T16:29:00.000Z",
     "end": "2010-06-13T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9FYxrxd97SuODHQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "y/y8qu9f8n19viijw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "1144",
-        "begin": "2009-06-23T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-06-23T16:00:00.000Z"
       }
     ]
   },
@@ -91,7 +69,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/kawanohikari/",
     "begin": "2009-06-20T16:00:00.000Z",
     "end": "2009-06-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "1143",
-        "begin": "2009-06-19T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-06-19T16:00:00.000Z"
       }
     ]
   },
@@ -122,47 +94,26 @@
     "officialSite": "",
     "begin": "2009-06-24T16:00:00.000Z",
     "end": "2009-06-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SOzXVb0jk9E0sho",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaait5",
-        "begin": "2016-01-06T16:00:27.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-06T16:00:27.000Z"
       },
       {
         "site": "qq",
         "id": "5/58x2m31mujwn2ds",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "37223",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -171,12 +122,7 @@
       {
         "site": "bilibili",
         "id": "800",
-        "begin": "2009-06-23T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-06-23T16:00:00.000Z"
       }
     ]
   },
@@ -192,17 +138,11 @@
     "officialSite": "http://www.barnumlaboratory.com/",
     "begin": "2009-06-01T16:00:00.000Z",
     "end": "2009-06-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CvLeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -222,7 +162,6 @@
     "officialSite": "",
     "begin": "2009-06-14T16:00:00.000Z",
     "end": "2009-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -238,7 +177,6 @@
     "officialSite": "",
     "begin": "2009-06-18T16:00:00.000Z",
     "end": "2009-06-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -247,12 +185,7 @@
       {
         "site": "nicovideo",
         "id": "peeping",
-        "begin": "2011-12-26T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-12-26T03:00:00.000Z"
       }
     ]
   },
@@ -268,7 +201,6 @@
     "officialSite": "http://aquaplus.jp/ova_uta/",
     "begin": "2009-06-24T16:00:00.000Z",
     "end": "2010-06-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -277,12 +209,7 @@
       {
         "site": "pptv",
         "id": "231Ixia6UBEKlI4s",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -298,7 +225,6 @@
     "officialSite": "",
     "begin": "2009-06-23T16:00:00.000Z",
     "end": "2009-06-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -307,12 +233,7 @@
       {
         "site": "pptv",
         "id": "F2tV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -328,7 +249,6 @@
     "officialSite": "http://www.evangelion.co.jp/",
     "begin": "2009-06-27T16:00:00.000Z",
     "end": "2009-06-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -337,22 +257,12 @@
       {
         "site": "qq",
         "id": "t/tj88awp3feyr538",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "evangelion_new_movie_ha",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2009/07.json
+++ b/data/items/2009/07.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.starchild.co.jp/special/kanamemo/",
     "begin": "2009-07-05T16:30:00.000Z",
     "end": "2009-09-27T17:18:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4SgUkvpg0A5x71c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1091",
-        "begin": "2009-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://www.maql.co.jp/special/soramani/",
     "begin": "2009-07-07T01:30:00.000Z",
     "end": "2009-09-22T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "haGcGoLoWJb5d98",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "bilibili",
         "id": "2849",
-        "begin": "2009-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-06T16:00:00.000Z"
       }
     ]
   },
@@ -91,27 +69,16 @@
     "officialSite": "http://umineko.tv/web/index.html",
     "begin": "2009-07-01T16:30:00.000Z",
     "end": "2009-12-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TubhX8ctndsibvCQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "1/12hb2es8l3qi2ov",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -120,12 +87,7 @@
       {
         "site": "nicovideo",
         "id": "umineko-anime",
-        "begin": "2016-08-19T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-19T06:00:00.000Z"
       }
     ]
   },
@@ -141,7 +103,6 @@
     "officialSite": "http://elementhunters.com/",
     "begin": "2009-07-04T09:00:00.000Z",
     "end": "2010-03-27T09:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -150,12 +111,7 @@
       {
         "site": "bilibili",
         "id": "4693",
-        "begin": "2009-07-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-03T16:00:01.000Z"
       }
     ]
   },
@@ -171,27 +127,16 @@
     "officialSite": "http://www.starchild.co.jp/special/zetsubou3/",
     "begin": "2009-07-04T15:30:00.000Z",
     "end": "2009-09-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RurVU7shkc8ysBg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hknmxhv34qii4o0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -200,22 +145,12 @@
       {
         "site": "nicovideo",
         "id": "zetsubou3",
-        "begin": "2016-10-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-31T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1794",
-        "begin": "2009-07-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -231,17 +166,11 @@
     "officialSite": "http://web.archive.org/web/*/needless.jp/",
     "begin": "2009-07-02T16:30:00.000Z",
     "end": "2009-12-10T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uuicZV78lldM2tBw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -250,12 +179,7 @@
       {
         "site": "bilibili",
         "id": "1147",
-        "begin": "2009-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -271,17 +195,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/taisho/",
     "begin": "2009-07-02T16:59:00.000Z",
     "end": "2009-09-24T17:39:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Kgv2dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -290,12 +208,7 @@
       {
         "site": "nicovideo",
         "id": "taisho-y",
-        "begin": "2014-01-24T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-24T06:00:00.000Z"
       }
     ]
   },
@@ -314,17 +227,11 @@
     "officialSite": "http://mv.avex.jp/ga/",
     "begin": "2009-07-06T17:29:00.000Z",
     "end": "2009-09-21T17:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hp5p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -333,22 +240,12 @@
       {
         "site": "nicovideo",
         "id": "ga",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1153",
-        "begin": "2009-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -367,7 +264,6 @@
     "officialSite": "http://www.prilover.tv/",
     "begin": "2009-07-05T15:30:00.000Z",
     "end": "2009-09-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -376,12 +272,7 @@
       {
         "site": "bilibili",
         "id": "1083",
-        "begin": "2009-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -397,7 +288,6 @@
     "officialSite": "http://www.canaan.jp/index.html",
     "begin": "2009-07-04T13:30:00.000Z",
     "end": "2009-09-26T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -406,12 +296,7 @@
       {
         "site": "nicovideo",
         "id": "canaan",
-        "begin": "2012-04-15T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-15T15:30:00.000Z"
       }
     ]
   },
@@ -427,7 +312,6 @@
     "officialSite": "http://www.monogatari-series.com/bakemonogatari/",
     "begin": "2009-07-03T14:00:00.000Z",
     "end": "2010-06-25T15:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -436,12 +320,7 @@
       {
         "site": "nicovideo",
         "id": "ch330",
-        "begin": "2011-01-03T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-03T09:30:00.000Z"
       }
     ]
   },
@@ -458,37 +337,21 @@
     "officialSite": "http://www.spicy-wolf.com/",
     "begin": "2009-07-08T16:15:00.000Z",
     "end": "2009-09-23T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QPDLSbEXh8Uopg4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9migt",
-        "begin": "2016-08-31T16:02:29.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:02:29.000Z"
       },
       {
         "site": "qq",
         "id": "s/smr5eh1p3iqyj3e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -497,22 +360,12 @@
       {
         "site": "nicovideo",
         "id": "spicy-wolf-02",
-        "begin": "2011-10-30T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-30T10:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1072",
-        "begin": "2009-07-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-08T16:00:00.000Z"
       }
     ]
   },
@@ -530,17 +383,11 @@
     "officialSite": "http://www.aoihana.tv/",
     "begin": "2009-07-01T17:08:00.000Z",
     "end": "2009-09-09T17:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WPzHRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -549,22 +396,12 @@
       {
         "site": "nicovideo",
         "id": "aoihana",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1146",
-        "begin": "2009-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -583,37 +420,21 @@
     "officialSite": "http://tokyo-m8.com/index.shtml",
     "begin": "2009-07-09T16:00:00.000Z",
     "end": "2009-09-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "m7uGBGzSQoDjYck",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0265",
-        "begin": "2014-11-03T09:51:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-03T09:51:15.000Z"
       },
       {
         "site": "mgtv",
         "id": "109735",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -622,22 +443,12 @@
       {
         "site": "letv",
         "id": "5543",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1080",
-        "begin": "2009-07-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-08T16:00:00.000Z"
       }
     ]
   },
@@ -653,17 +464,11 @@
     "officialSite": "http://kuruneko-komichi.jp/",
     "begin": "2009-07-04T23:55:00.000Z",
     "end": "2011-06-29T16:18:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "X5Fr6VG3J2XIRq4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -683,17 +488,11 @@
     "officialSite": "http://www.gendaimahou.com/",
     "begin": "2009-07-11T15:00:00.000Z",
     "end": "2009-09-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibjQQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -702,22 +501,12 @@
       {
         "site": "bilibili",
         "id": "3129",
-        "begin": "2009-07-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-10T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "5434",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -733,17 +522,11 @@
     "officialSite": "http://hetalia.com/",
     "begin": "2009-07-27T07:00:00.000Z",
     "end": "2010-01-18T07:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10018939",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -752,12 +535,7 @@
       {
         "site": "bilibili",
         "id": "3474",
-        "begin": "2009-07-26T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-26T16:00:01.000Z"
       }
     ]
   },
@@ -773,37 +551,21 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2009-07-18T16:00:00.000Z",
     "end": "2009-07-18T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "71823",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -812,22 +574,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5746",
-        "begin": "2009-07-17T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-17T16:00:01.000Z"
       }
     ]
   },
@@ -843,7 +595,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/k-on/",
     "begin": "2009-07-29T16:00:00.000Z",
     "end": "2010-01-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -863,7 +614,6 @@
     "officialSite": "",
     "begin": "2009-07-25T16:00:00.000Z",
     "end": "2009-07-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -872,12 +622,7 @@
       {
         "site": "nicovideo",
         "id": "as",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -893,7 +638,6 @@
     "officialSite": "http://www.cencoroll.com",
     "begin": "2009-07-28T16:00:00.000Z",
     "end": "2009-07-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -902,22 +646,12 @@
       {
         "site": "nicovideo",
         "id": "cencoroll",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2907",
-        "begin": "2009-07-27T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-07-27T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2009/08.json
+++ b/data/items/2009/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://anime-ch.nicovideo.jp/ontama/",
     "begin": "2009-08-07T10:00:00.000Z",
     "end": "2009-11-06T10:13:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -27,7 +26,6 @@
     "officialSite": "http://www.uchurei.com/",
     "begin": "2009-08-09T08:15:00.000Z",
     "end": "2009-09-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -47,7 +45,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2009-08-01T17:10:00.000Z",
     "end": "2009-08-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -67,17 +64,11 @@
     "officialSite": "http://www.barnumlaboratory.com/",
     "begin": "2009-08-31T16:00:00.000Z",
     "end": "2009-08-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CvLeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -97,7 +88,6 @@
     "officialSite": "http://utsuru.jp/",
     "begin": "2009-08-21T16:00:00.000Z",
     "end": "2009-10-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -106,12 +96,7 @@
       {
         "site": "nicovideo",
         "id": "ch287",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -127,7 +112,6 @@
     "officialSite": "",
     "begin": "2009-08-26T16:00:00.000Z",
     "end": "2010-11-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -136,12 +120,7 @@
       {
         "site": "pptv",
         "id": "p4eCAGjOPnzfXcU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -160,7 +139,6 @@
     "officialSite": "http://www.naruto-movie.com/",
     "begin": "2009-08-01T00:00:00.000Z",
     "end": "2009-08-01T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -169,12 +147,7 @@
       {
         "site": "netflix",
         "id": "80045673",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2009/09.json
+++ b/data/items/2009/09.json
@@ -11,7 +11,6 @@
     "officialSite": "http://queensblade.tv/",
     "begin": "2009-09-23T23:00:00.000Z",
     "end": "2009-12-09T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "queensblade02",
-        "begin": "2012-04-11T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-11T06:00:00.000Z"
       }
     ]
   },
@@ -41,27 +35,16 @@
     "officialSite": "http://www.sunrise-inc.co.jp/battlespirits2/",
     "begin": "2009-09-12T22:00:00.000Z",
     "end": "2010-09-04T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hMfBP6cNfbsenAQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk7hgtt",
-        "begin": "2012-12-11T11:56:51.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-11T11:56:51.000Z"
       },
       {
         "site": "bangumi",
@@ -81,7 +64,6 @@
     "officialSite": "http://wwwz.fujitv.co.jp/leo/index.html",
     "begin": "2009-09-05T16:00:00.000Z",
     "end": "2009-09-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -101,17 +83,11 @@
     "officialSite": "http://www.a1c.jp/~chuchu/top.html",
     "begin": "2009-09-26T16:00:00.000Z",
     "end": "2009-11-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "30210",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -131,17 +107,11 @@
     "officialSite": "http://negima.kc.kodansha.co.jp",
     "begin": "2009-09-17T16:00:00.000Z",
     "end": "2010-08-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4CwYlv5k1BJ181s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,22 +120,12 @@
       {
         "site": "nicovideo",
         "id": "negima-oad02",
-        "begin": "2017-09-07T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-07T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3773",
-        "begin": "2009-09-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-09-16T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2009/10.json
+++ b/data/items/2009/10.json
@@ -14,27 +14,16 @@
     "officialSite": "http://www.sasameki.com/",
     "begin": "2009-10-07T17:20:00.000Z",
     "end": "2009-12-30T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IWtV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "6/69tc05qe77vdi2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -43,12 +32,7 @@
       {
         "site": "bilibili",
         "id": "1166",
-        "begin": "2009-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -64,17 +48,11 @@
     "officialSite": "http://www.starchild.co.jp/special/natsunoarashi2/",
     "begin": "2009-10-04T16:30:00.000Z",
     "end": "2009-12-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Jgr1c9tBse9S0Dg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -83,12 +61,7 @@
       {
         "site": "bilibili",
         "id": "1136",
-        "begin": "2009-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -104,7 +77,6 @@
     "officialSite": "http://www.maql.co.jp/special/shinkoihime/",
     "begin": "2009-10-05T02:30:00.000Z",
     "end": "2009-12-21T03:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -113,12 +85,7 @@
       {
         "site": "nicovideo",
         "id": "shinkoihime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -134,17 +101,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/nyankoi/",
     "begin": "2009-10-01T17:19:00.000Z",
     "end": "2009-12-17T17:33:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ymFc2kKoGFa5N58",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -153,22 +114,12 @@
       {
         "site": "nicovideo",
         "id": "nyankoi",
-        "begin": "2014-02-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-02-06T06:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7n4zx",
-        "begin": "2019-01-25T02:12:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-25T02:12:13.000Z"
       }
     ]
   },
@@ -184,7 +135,6 @@
     "officialSite": "http://newtype.kadocomic.jp/soraoto/",
     "begin": "2009-10-04T15:00:00.000Z",
     "end": "2009-12-27T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -193,12 +143,7 @@
       {
         "site": "nicovideo",
         "id": "ch636",
-        "begin": "2010-10-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-07T15:00:00.000Z"
       }
     ]
   },
@@ -214,7 +159,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/kenpu/",
     "begin": "2009-10-01T16:49:00.000Z",
     "end": "2009-12-17T17:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -237,17 +181,11 @@
     "officialSite": "http://www.blasmi.com/",
     "begin": "2009-10-03T00:30:00.000Z",
     "end": "2009-12-19T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IwcCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -256,12 +194,7 @@
       {
         "site": "nicovideo",
         "id": "blasmi",
-        "begin": "2013-03-17T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-17T07:00:00.000Z"
       }
     ]
   },
@@ -277,17 +210,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/kuchu_buranko/",
     "begin": "2009-10-15T15:45:00.000Z",
     "end": "2009-12-24T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AiaYhnwdt3RtibicGQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -296,12 +223,7 @@
       {
         "site": "bilibili",
         "id": "1169",
-        "begin": "2009-10-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-14T16:00:00.000Z"
       }
     ]
   },
@@ -317,17 +239,11 @@
     "officialSite": "http://www.ntv.co.jp/kiminitodoke/1st/index.html",
     "begin": "2009-10-06T16:14:00.000Z",
     "end": "2010-03-30T16:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4kk0shqA8C6RD3c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -336,12 +252,7 @@
       {
         "site": "nicovideo",
         "id": "kiminitodoke01",
-        "begin": "2014-04-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-15T06:00:00.000Z"
       }
     ]
   },
@@ -357,37 +268,21 @@
     "officialSite": "http://www.kobato.tv/",
     "begin": "2009-10-06T11:00:00.000Z",
     "end": "2010-03-23T11:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6kE8uiaKIibDaZF38",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhabjst",
-        "begin": "2016-01-08T10:38:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T10:38:32.000Z"
       },
       {
         "site": "mgtv",
         "id": "167651",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -396,12 +291,7 @@
       {
         "site": "bilibili",
         "id": "1164",
-        "begin": "2009-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -417,17 +307,11 @@
     "officialSite": "http://www.bantorra.com/",
     "begin": "2009-10-02T13:00:00.000Z",
     "end": "2010-04-02T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "y2Bb2UGnF1W4Np4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -436,12 +320,7 @@
       {
         "site": "bilibili",
         "id": "1155",
-        "begin": "2009-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -458,37 +337,21 @@
     "officialSite": "http://www.ytv.co.jp/yumepati_first/",
     "begin": "2009-10-03T22:00:00.000Z",
     "end": "2010-09-25T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JAz3dd1DsicFU0jo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/l988l4lq9fjb13g",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "9151",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -497,12 +360,7 @@
       {
         "site": "bilibili",
         "id": "1000",
-        "begin": "2009-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -518,7 +376,6 @@
     "officialSite": "http://www.kirumin.com/index.html",
     "begin": "2009-10-05T08:30:00.000Z",
     "end": "2010-09-20T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -539,37 +396,21 @@
     "officialSite": "http://www.project-railgun.net/1/",
     "begin": "2009-10-02T17:30:00.000Z",
     "end": "2010-03-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9odwl",
-        "begin": "2016-08-16T02:36:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-16T02:36:05.000Z"
       },
       {
         "site": "letv",
         "id": "35765",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2011/kxcdcp",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -578,22 +419,12 @@
       {
         "site": "nicovideo",
         "id": "ch642",
-        "begin": "2010-09-17T03:00:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-09-17T03:00:01.000Z"
       },
       {
         "site": "bilibili",
         "id": "425",
-        "begin": "2009-10-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -609,17 +440,11 @@
     "officialSite": "http://www.sunred.jp/",
     "begin": "2009-10-03T14:30:00.000Z",
     "end": "2010-03-27T14:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JQ34dt5EtPJV0zs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -628,22 +453,12 @@
       {
         "site": "nicovideo",
         "id": "ch243",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1160",
-        "begin": "2009-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -659,7 +474,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tegamibachi/",
     "begin": "2009-10-03T13:55:00.000Z",
     "end": "2010-03-27T14:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -679,17 +493,11 @@
     "officialSite": "http://www.ytv.co.jp/inuyasha/",
     "begin": "2009-10-03T17:20:00.000Z",
     "end": "2010-03-29T17:19:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "46368",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -709,7 +517,6 @@
     "officialSite": "http://www.miracle-train.tv/",
     "begin": "2009-10-04T17:00:00.000Z",
     "end": "2009-12-27T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -729,7 +536,6 @@
     "officialSite": "http://www.nogizaka-haruka.com/",
     "begin": "2009-10-05T17:29:00.000Z",
     "end": "2009-12-21T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -738,22 +544,12 @@
       {
         "site": "nicovideo",
         "id": "nogizaka-haruka-pure",
-        "begin": "2011-10-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-26T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1063",
-        "begin": "2009-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -769,17 +565,11 @@
     "officialSite": "http://seitokai-no-ichizon.com/seitokai/",
     "begin": "2009-10-02T16:58:00.000Z",
     "end": "2009-12-18T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "z2Rf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -788,12 +578,7 @@
       {
         "site": "nicovideo",
         "id": "seitokai",
-        "begin": "2012-10-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-13T15:00:00.000Z"
       }
     ]
   },
@@ -813,27 +598,16 @@
     "officialSite": "http://www.maql.co.jp/special/11eyes/",
     "begin": "2009-10-06T16:00:00.000Z",
     "end": "2009-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6T4Jhib9VxQNm5Ew",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "2/272o2s3pkvl37u8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -842,22 +616,12 @@
       {
         "site": "nicovideo",
         "id": "11eyes",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4677",
-        "begin": "2009-10-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -873,7 +637,6 @@
     "officialSite": "http://www.starchild.co.jp/special/asura/",
     "begin": "2009-10-01T00:30:00.000Z",
     "end": "2009-12-24T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -882,12 +645,7 @@
       {
         "site": "bilibili",
         "id": "3813",
-        "begin": "2009-09-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-09-30T16:00:01.000Z"
       }
     ]
   },
@@ -903,7 +661,6 @@
     "officialSite": "http://www.d-black.net/",
     "begin": "2009-10-08T16:25:00.000Z",
     "end": "2009-12-24T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -912,12 +669,7 @@
       {
         "site": "bilibili",
         "id": "1065",
-        "begin": "2009-10-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -933,7 +685,6 @@
     "officialSite": "http://xn--u9j429qiq1a.jp/",
     "begin": "2009-10-06T16:21:00.000Z",
     "end": "2009-12-22T16:51:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -953,7 +704,6 @@
     "officialSite": "http://www.whitealbum-tv.com/",
     "begin": "2009-10-02T16:30:00.000Z",
     "end": "2009-12-23T18:54:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -976,17 +726,11 @@
     "officialSite": "http://ani.tv/fairytail/",
     "begin": "2009-10-12T10:30:00.000Z",
     "end": "2013-03-30T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2011/yjdwb",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -995,32 +739,17 @@
       {
         "site": "nicovideo",
         "id": "fairytail01",
-        "begin": "2014-07-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-01T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70266998",
-        "begin": "2017-04-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-01T07:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbp78p",
-        "begin": "2017-11-30T16:04:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-30T16:04:45.000Z"
       }
     ]
   },
@@ -1039,17 +768,11 @@
     "officialSite": "http://www.kiddygirl-and.com/",
     "begin": "2009-10-15T15:40:00.000Z",
     "end": "2010-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DCQfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1058,12 +781,7 @@
       {
         "site": "bilibili",
         "id": "2060",
-        "begin": "2009-10-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-14T16:00:00.000Z"
       }
     ]
   },
@@ -1079,17 +797,11 @@
     "officialSite": "http://ameblo.jp/velvet-kotatsuneko/",
     "begin": "2009-10-02T23:25:00.000Z",
     "end": "2010-03-28T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Z6iaUEnrgUI7xb9c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1109,7 +821,6 @@
     "officialSite": "http://www.tv-asahi.co.jp/gokyoudai/",
     "begin": "2009-10-10T02:20:00.000Z",
     "end": "2010-06-26T02:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1132,17 +843,11 @@
     "officialSite": "http://www.tv-asahi.co.jp/kaidan/",
     "begin": "2009-10-13T10:30:00.000Z",
     "end": "2010-06-08T10:54:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91wnpQ1z4yGEAmo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1151,22 +856,12 @@
       {
         "site": "letv",
         "id": "10961",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3363",
-        "begin": "2009-10-12T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-12T16:00:01.000Z"
       }
     ]
   },
@@ -1182,17 +877,11 @@
     "officialSite": "http://www.ntv.co.jp/bungaku/",
     "begin": "2009-10-10T16:50:00.000Z",
     "end": "2011-12-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SODbWcEnl9U4th4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1201,12 +890,7 @@
       {
         "site": "bilibili",
         "id": "3341",
-        "begin": "2009-10-09T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-09T16:00:01.000Z"
       }
     ]
   },
@@ -1222,7 +906,6 @@
     "officialSite": "http://shugo-chara.com/",
     "begin": "2009-10-03T00:30:00.000Z",
     "end": "2010-03-27T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1242,7 +925,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tamagotchi/",
     "begin": "2009-10-12T10:00:00.000Z",
     "end": "2012-09-03T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1262,7 +944,6 @@
     "officialSite": "http://www.tv-asahi.co.jp/stitch/",
     "begin": "2009-10-13T10:00:00.000Z",
     "end": "2010-06-29T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1282,17 +963,11 @@
     "officialSite": "http://www.mahoro-matic.com/",
     "begin": "2009-10-17T12:00:00.000Z",
     "end": "2009-10-24T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XZFr6VG3J2XIRq4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1312,7 +987,6 @@
     "officialSite": "http://www.usaru.jp/",
     "begin": "2009-10-03T16:00:00.000Z",
     "end": "2009-10-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1321,12 +995,7 @@
       {
         "site": "bilibili",
         "id": "4678",
-        "begin": "2009-10-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-02T16:00:01.000Z"
       }
     ]
   },
@@ -1343,17 +1012,11 @@
     "officialSite": "http://www.cheb-tv.com/",
     "begin": "2009-10-07T16:00:00.000Z",
     "end": "2010-03-31T16:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgiiw51",
-        "begin": "2014-07-11T02:55:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T02:55:09.000Z"
       },
       {
         "site": "bangumi",
@@ -1374,27 +1037,16 @@
     "officialSite": "",
     "begin": "2009-10-23T16:00:00.000Z",
     "end": "2010-09-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk069b9",
-        "begin": "2012-06-01T01:22:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-01T01:22:10.000Z"
       },
       {
         "site": "pptv",
         "id": "3mpV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1403,22 +1055,12 @@
       {
         "site": "letv",
         "id": "10221",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1605",
-        "begin": "2009-10-22T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-22T16:00:00.000Z"
       }
     ]
   },
@@ -1434,17 +1076,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/kemocha/",
     "begin": "2009-10-23T16:00:00.000Z",
     "end": "2009-10-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Z8u2NJwCcrATkfk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1464,17 +1100,11 @@
     "officialSite": "http://anime-wintersonata.com/index.html",
     "begin": "2009-10-17T16:00:00.000Z",
     "end": "2010-05-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GTEMiavJYyAZp508",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1483,12 +1113,7 @@
       {
         "site": "bilibili",
         "id": "1171",
-        "begin": "2009-10-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-16T16:00:00.000Z"
       }
     ]
   },
@@ -1504,7 +1129,6 @@
     "officialSite": "",
     "begin": "2009-10-17T16:00:00.000Z",
     "end": "2009-10-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1513,22 +1137,12 @@
       {
         "site": "pptv",
         "id": "50s2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3822",
-        "begin": "2009-10-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-10-16T16:00:01.000Z"
       }
     ]
   },
@@ -1544,7 +1158,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2009_fresh_precure/",
     "begin": "2009-10-31T16:00:00.000Z",
     "end": "2009-10-31T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1553,22 +1166,12 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   }

--- a/data/items/2009/11.json
+++ b/data/items/2009/11.json
@@ -12,17 +12,11 @@
     "officialSite": "http://juiz.jp/blog/",
     "begin": "2009-11-28T16:00:00.000Z",
     "end": "2009-11-28T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg7wdlp",
-        "begin": "2013-06-06T06:26:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-06T06:26:05.000Z"
       },
       {
         "site": "bangumi",
@@ -31,12 +25,7 @@
       {
         "site": "bilibili",
         "id": "2675",
-        "begin": "2009-11-27T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-11-27T16:00:00.000Z"
       }
     ]
   },
@@ -52,7 +41,6 @@
     "officialSite": "http://www.mai-mai.jp/index.html",
     "begin": "2009-11-21T16:00:00.000Z",
     "end": "2009-11-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,12 +49,7 @@
       {
         "site": "nicovideo",
         "id": "mai-mai",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -82,7 +65,6 @@
     "officialSite": "http://www.macrossf.com",
     "begin": "2009-11-21T16:00:00.000Z",
     "end": "2009-11-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,12 +73,7 @@
       {
         "site": "pptv",
         "id": "kHicUUrogkM4xrxc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -112,7 +89,6 @@
     "officialSite": "http://zetsubou.kc.kodansha.co.jp/",
     "begin": "2009-11-17T16:00:00.000Z",
     "end": "2009-11-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -121,12 +97,7 @@
       {
         "site": "pptv",
         "id": "T39JxyibVBUOmJIw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2009/12.json
+++ b/data/items/2009/12.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.hipira.net/",
     "begin": "2009-12-21T07:30:00.000Z",
     "end": "2009-12-25T08:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,17 +30,11 @@
     "officialSite": "http://www.ne.jp/asahi/magneticwave/popcan/kowa/",
     "begin": "2009-12-29T16:00:00.000Z",
     "end": "2009-12-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "6307",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "bilibili",
         "id": "3292",
-        "begin": "2009-12-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2009-12-28T16:00:01.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "http://www.onepiece-movie.com/",
     "begin": "2009-12-12T16:00:00.000Z",
     "end": "2009-12-12T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,17 +78,11 @@
     "officialSite": "",
     "begin": "2009-12-23T16:00:00.000Z",
     "end": "2009-12-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EAicpZ881peNGxCw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -121,7 +102,6 @@
     "officialSite": "http://yanyan-machiko.com/",
     "begin": "2009-12-25T16:00:00.000Z",
     "end": "2015-08-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,12 +110,7 @@
       {
         "site": "nicovideo",
         "id": "ch313",
-        "begin": "2010-01-26T07:32:57.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-26T07:32:57.000Z"
       }
     ]
   }

--- a/data/items/2010/01.json
+++ b/data/items/2010/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.reinya.jp/",
     "begin": "2010-01-08T14:54:00.000Z",
     "end": "2010-03-27T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EzYRjicddzQtu7FQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1051",
-        "begin": "2010-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://web.archive.org/web/*/www.cobra30th-anime.com/",
     "begin": "2010-01-02T14:30:00.000Z",
     "end": "2010-03-27T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RYaCAGjOPnzfXcU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -81,17 +64,11 @@
     "officialSite": "http://www.starchild.co.jp/special/hanamaru/index.html",
     "begin": "2010-01-10T16:30:00.000Z",
     "end": "2010-03-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FD0Ihu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,22 +77,12 @@
       {
         "site": "letv",
         "id": "15245",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "982",
-        "begin": "2010-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -131,27 +98,16 @@
     "officialSite": "http://www.bakatest.com/1st/",
     "begin": "2010-01-06T17:50:00.000Z",
     "end": "2010-03-31T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qEIurBR66iaiaLCXE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jmkd3oxjnao8ixj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -160,22 +116,12 @@
       {
         "site": "nicovideo",
         "id": "ch60020",
-        "begin": "2011-04-29T03:00:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-29T03:00:01.000Z"
       },
       {
         "site": "bilibili",
         "id": "842",
-        "begin": "2010-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -191,7 +137,6 @@
     "officialSite": "http://www.ladies-vs-butlers.com/",
     "begin": "2010-01-05T13:00:00.000Z",
     "end": "2010-03-23T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -211,7 +156,6 @@
     "officialSite": "http://www.sorawoto.com/",
     "begin": "2010-01-04T17:00:00.000Z",
     "end": "2010-03-22T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -220,12 +164,7 @@
       {
         "site": "nicovideo",
         "id": "sorawoto",
-        "begin": "2012-07-25T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-25T06:00:00.000Z"
       }
     ]
   },
@@ -241,27 +180,11 @@
     "officialSite": "http://www.durarara.com/1st/",
     "begin": "2010-01-07T16:25:00.000Z",
     "end": "2010-06-24T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "45206",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470030",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -270,32 +193,17 @@
       {
         "site": "nicovideo",
         "id": "ch332",
-        "begin": "2011-02-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-02-26T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80040119",
-        "begin": "2015-10-09T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1656",
-        "begin": "2010-01-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -314,17 +222,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/hidamari/",
     "begin": "2010-01-07T16:29:00.000Z",
     "end": "2010-03-25T17:04:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HzINiaicNZyQdq6FA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -333,32 +235,17 @@
       {
         "site": "nicovideo",
         "id": "hidamari_03",
-        "begin": "2014-12-19T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-19T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "733",
-        "begin": "2010-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-06T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhe2qfx",
-        "begin": "2019-01-24T09:28:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-24T09:28:03.000Z"
       }
     ]
   },
@@ -374,7 +261,6 @@
     "officialSite": "http://www.starchild.co.jp/special/chuubra/",
     "begin": "2010-01-04T14:30:00.000Z",
     "end": "2010-03-22T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -394,27 +280,16 @@
     "officialSite": "http://www.tbs.co.jp/anime/okami/",
     "begin": "2010-01-07T16:59:00.000Z",
     "end": "2010-03-25T17:34:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DCUgngZs3Bp9ib2M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/wc73ikus18i9wm7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -423,12 +298,7 @@
       {
         "site": "nicovideo",
         "id": "okami",
-        "begin": "2012-09-05T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-05T06:00:00.000Z"
       }
     ]
   },
@@ -447,7 +317,6 @@
     "officialSite": "http://www.vampirebund.com/",
     "begin": "2010-01-07T00:00:00.000Z",
     "end": "2010-04-01T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -470,21 +339,10 @@
     "officialSite": "http://newtype.kadocomic.jp/omahima/",
     "begin": "2010-01-06T16:30:00.000Z",
     "end": "2010-03-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "3449"
-      },
-      {
-        "site": "bilibili",
-        "id": "991",
-        "begin": "2010-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -500,17 +358,11 @@
     "officialSite": "http://www.nodame-anime.com/",
     "begin": "2010-01-14T15:45:00.000Z",
     "end": "2010-03-25T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ogic6eOBGtvRX1T0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -519,22 +371,12 @@
       {
         "site": "bilibili",
         "id": "1041",
-        "begin": "2010-01-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-13T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "15039",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -550,17 +392,11 @@
     "officialSite": "http://www.katanagatari.com/",
     "begin": "2010-01-25T16:10:00.000Z",
     "end": "2010-12-10T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "b59p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -569,12 +405,7 @@
       {
         "site": "bilibili",
         "id": "983",
-        "begin": "2010-01-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-24T16:00:00.000Z"
       }
     ]
   },
@@ -590,7 +421,6 @@
     "officialSite": "http://www.qwaser.jp/1st/",
     "begin": "2010-01-09T18:28:00.000Z",
     "end": "2010-06-19T18:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -610,37 +440,21 @@
     "officialSite": "http://www.kids-station.com/minisite/gag/",
     "begin": "2010-01-04T17:44:00.000Z",
     "end": "2010-06-27T08:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZLCMCnLYSIbpZ88",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/zx5pd5zbkdiebcq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "42751",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -649,32 +463,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgjb7zt",
-        "begin": "2014-04-09T23:30:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:30:39.000Z"
       },
       {
         "site": "bilibili",
         "id": "1596",
-        "begin": "2010-01-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-03T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "14551",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -690,31 +489,15 @@
     "officialSite": "http://www.yugioh10th.com/",
     "begin": "2010-01-23T16:00:00.000Z",
     "end": "2010-01-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "44175",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "23303"
-      },
-      {
-        "site": "bilibili",
-        "id": "4654",
-        "begin": "2010-01-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -730,17 +513,11 @@
     "officialSite": "http://www.fatestaynight.jp/",
     "begin": "2010-01-23T16:00:00.000Z",
     "end": "2010-01-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10010546",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -760,17 +537,11 @@
     "officialSite": "",
     "begin": "2010-01-29T16:00:00.000Z",
     "end": "2010-01-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jIpm5EyyImDDQak",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -790,17 +561,11 @@
     "officialSite": "http://www.d-black.net/",
     "begin": "2010-01-27T16:00:00.000Z",
     "end": "2010-07-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uJFs6lK4KGbJR68",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -809,12 +574,7 @@
       {
         "site": "bilibili",
         "id": "1066",
-        "begin": "2010-01-26T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-01-26T16:00:00.000Z"
       }
     ]
   },
@@ -830,17 +590,11 @@
     "officialSite": "",
     "begin": "2010-01-10T16:00:00.000Z",
     "end": "2010-02-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "D0E7uSGH9zWYFn4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -849,12 +603,7 @@
       {
         "site": "letv",
         "id": "41192",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -870,7 +619,6 @@
     "officialSite": "http://www.nanoha.com/archive4/",
     "begin": "2010-01-23T16:00:00.000Z",
     "end": "2010-01-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -879,12 +627,7 @@
       {
         "site": "pptv",
         "id": "oFw4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -900,7 +643,6 @@
     "officialSite": "http://www.gamecity.ne.jp/neoromance/tv/haruka/destiny/",
     "begin": "2010-01-03T16:00:00.000Z",
     "end": "2010-01-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -909,12 +651,7 @@
       {
         "site": "letv",
         "id": "41924",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2010/02.json
+++ b/data/items/2010/02.json
@@ -15,31 +15,15 @@
     "officialSite": "http://asahi.co.jp/heartcatch_precure/",
     "begin": "2010-02-06T23:30:00.000Z",
     "end": "2011-01-30T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb14tx",
-        "begin": "2015-08-14T17:08:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:08:16.000Z"
       },
       {
         "site": "bangumi",
         "id": "4124"
-      },
-      {
-        "site": "bilibili",
-        "id": "1709",
-        "begin": "2010-02-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -55,7 +39,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2010-02-12T16:00:00.000Z",
     "end": "2010-02-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -64,22 +47,12 @@
       {
         "site": "pptv",
         "id": "ibZ32dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3951",
-        "begin": "2010-02-11T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-02-11T16:00:01.000Z"
       }
     ]
   },
@@ -95,47 +68,21 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2010-02-06T16:00:00.000Z",
     "end": "2010-11-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kolj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjtkzih",
-        "begin": "2012-12-14T06:06:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-14T06:06:06.000Z"
       },
       {
         "site": "qq",
         "id": "7/7p6lgztb38ciaam",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1463012",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -155,17 +102,11 @@
     "officialSite": "http://www.kyotoanimation.co.jp/haruhi/movie/index.html",
     "begin": "2010-02-06T16:00:00.000Z",
     "end": "2010-02-06T18:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WNu1M5sBca8SkPg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -174,22 +115,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgip5o1",
-        "begin": "2018-02-27T10:03:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-27T10:03:08.000Z"
       },
       {
         "site": "bilibili",
         "id": "2809",
-        "begin": "2010-02-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-02-05T16:00:00.000Z"
       }
     ]
   },
@@ -205,7 +136,6 @@
     "officialSite": "http://www.keroro-movie.net/",
     "begin": "2010-02-27T16:00:00.000Z",
     "end": "2010-02-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -214,22 +144,12 @@
       {
         "site": "pptv",
         "id": "9LQdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1751",
-        "begin": "2010-02-26T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-02-26T16:00:00.000Z"
       }
     ]
   },
@@ -245,7 +165,6 @@
     "officialSite": "http://warnervideo.com/halolegendsdvd/",
     "begin": "2010-02-16T00:00:00.000Z",
     "end": "2010-02-16T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -254,12 +173,7 @@
       {
         "site": "netflix",
         "id": "70129415",
-        "begin": "2017-05-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-05-01T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2010/03.json
+++ b/data/items/2010/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.ikkitousen.com/",
     "begin": "2010-03-26T01:00:00.000Z",
     "end": "2010-06-11T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://www.hanakappa.jp/",
     "begin": "2010-03-28T22:15:00.000Z",
     "end": "2010-12-10T22:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -51,17 +49,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/marie_gali/",
     "begin": "2010-03-30T09:55:00.000Z",
     "end": "2011-03-22T10:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12wx",
-        "begin": "2015-08-14T17:09:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:09:03.000Z"
       },
       {
         "site": "bangumi",
@@ -81,17 +73,11 @@
     "officialSite": "http://yutori-chan.jp/",
     "begin": "2010-03-16T03:30:00.000Z",
     "end": "2010-11-29T04:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XOicaWMAmltQ3tR0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,22 +86,7 @@
       {
         "site": "nicovideo",
         "id": "yutori-chan",
-        "begin": "2012-07-18T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1049",
-        "begin": "2010-03-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-18T06:00:00.000Z"
       }
     ]
   },
@@ -131,17 +102,11 @@
     "officialSite": "http://hetalia.com/top.htm",
     "begin": "2010-03-26T07:00:00.000Z",
     "end": "2010-09-03T07:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10018939",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,12 +115,7 @@
       {
         "site": "nicovideo",
         "id": "hetaria-world-series",
-        "begin": "2012-12-28T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-28T07:00:00.000Z"
       }
     ]
   },
@@ -171,31 +131,15 @@
     "officialSite": "http://www.animax.co.jp/feature/index.php?code=NN10000946",
     "begin": "2010-03-27T16:00:00.000Z",
     "end": "2010-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "j6CbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4282"
-      },
-      {
-        "site": "bilibili",
-        "id": "5928",
-        "begin": "2010-03-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -211,17 +155,11 @@
     "officialSite": "http://doraeiga.com/2010/",
     "begin": "2010-03-06T16:00:00.000Z",
     "end": "2010-03-06T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "30066",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -230,42 +168,22 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mk3l",
-        "begin": "2018-05-31T16:00:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:00:22.000Z"
       },
       {
         "site": "bilibili",
         "id": "3883",
-        "begin": "2010-03-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-03-05T16:00:01.000Z"
       }
     ]
   },
@@ -282,17 +200,11 @@
     "officialSite": "http://juiz.jp/blog/",
     "begin": "2010-03-13T16:00:00.000Z",
     "end": "2010-03-13T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg7wfm5",
-        "begin": "2013-06-06T06:26:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-06T06:26:12.000Z"
       },
       {
         "site": "bangumi",
@@ -301,12 +213,7 @@
       {
         "site": "bilibili",
         "id": "5106",
-        "begin": "2010-03-12T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-03-12T16:00:01.000Z"
       }
     ]
   },
@@ -322,7 +229,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2010-03-29T08:35:00.000Z",
     "end": "2010-09-16T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -342,17 +248,11 @@
     "officialSite": "http://ova-tos.com/index.php",
     "begin": "2010-03-25T16:00:00.000Z",
     "end": "2011-02-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZcbBP6cNfbsenAQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -361,22 +261,12 @@
       {
         "site": "nicovideo",
         "id": "TOS-anime02",
-        "begin": "2016-07-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3975",
-        "begin": "2010-03-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-03-24T16:00:01.000Z"
       }
     ]
   },
@@ -392,7 +282,6 @@
     "officialSite": "http://ga.sbcr.jp/bunko_blog/nyaruani/",
     "begin": "2010-03-15T16:00:00.000Z",
     "end": "2010-03-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -401,12 +290,7 @@
       {
         "site": "nicovideo",
         "id": "ch820",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -422,7 +306,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2010_precure_allstars//index.html",
     "begin": "2010-03-20T16:00:00.000Z",
     "end": "2010-03-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -431,12 +314,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   }

--- a/data/items/2010/04.json
+++ b/data/items/2010/04.json
@@ -12,27 +12,16 @@
     "officialSite": "http://www9.nhk.or.jp/anime/major/index.html",
     "begin": "2010-04-03T09:00:00.000Z",
     "end": "2010-09-25T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0HtGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc3irp",
-        "begin": "2014-12-24T06:19:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-24T06:19:58.000Z"
       },
       {
         "site": "bangumi",
@@ -52,17 +41,11 @@
     "officialSite": "http://yojouhan.noitamina.tv/",
     "begin": "2010-04-22T15:45:00.000Z",
     "end": "2010-07-01T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OhLta9M5qedKyDA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,12 +54,7 @@
       {
         "site": "bilibili",
         "id": "3258",
-        "begin": "2010-04-21T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-21T16:00:01.000Z"
       }
     ]
   },
@@ -95,7 +73,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/k-on/k-on_tv/index-j.html",
     "begin": "2010-04-06T16:29:00.000Z",
     "end": "2011-11-13T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -104,12 +81,7 @@
       {
         "site": "nicovideo",
         "id": "k-on_anime2",
-        "begin": "2018-12-27T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-27T15:00:00.000Z"
       }
     ]
   },
@@ -125,7 +97,6 @@
     "officialSite": "http://www.maql.co.jp/special/shinkoihime/",
     "begin": "2010-04-01T00:00:00.000Z",
     "end": "2010-06-17T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -134,12 +105,7 @@
       {
         "site": "nicovideo",
         "id": "shinkoihime-otome",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -155,7 +121,6 @@
     "officialSite": "http://www.wagnaria.com/1st/",
     "begin": "2010-04-04T14:00:00.000Z",
     "end": "2010-06-27T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -164,22 +129,12 @@
       {
         "site": "nicovideo",
         "id": "working",
-        "begin": "2011-09-24T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-24T11:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "866",
-        "begin": "2010-04-04T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-04T14:00:00.000Z"
       }
     ]
   },
@@ -195,7 +150,6 @@
     "officialSite": "http://www.bgata-hkei.com/",
     "begin": "2010-04-01T16:00:00.000Z",
     "end": "2010-06-17T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -215,17 +169,11 @@
     "officialSite": "http://www.goyou-anime.jp/",
     "begin": "2010-04-15T16:30:00.000Z",
     "end": "2010-07-01T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icU45txibF9TOWFHw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -234,22 +182,12 @@
       {
         "site": "bilibili",
         "id": "3248",
-        "begin": "2010-04-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-14T16:00:01.000Z"
       },
       {
         "site": "letv",
         "id": "42722",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -265,7 +203,6 @@
     "officialSite": "http://www.maql.co.jp/special/daimao/",
     "begin": "2010-04-02T16:30:00.000Z",
     "end": "2010-06-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -274,12 +211,7 @@
       {
         "site": "nicovideo",
         "id": "daimao",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -295,31 +227,15 @@
     "officialSite": "http://www.patisserie-straycats.com/",
     "begin": "2010-04-06T14:00:00.000Z",
     "end": "2010-06-29T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lrmEAmrQQH7hX8c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4292"
-      },
-      {
-        "site": "bilibili",
-        "id": "990",
-        "begin": "2010-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -335,7 +251,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/maidsama/",
     "begin": "2010-04-01T17:09:00.000Z",
     "end": "2010-09-23T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -344,12 +259,7 @@
       {
         "site": "bilibili",
         "id": "969",
-        "begin": "2010-04-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -365,17 +275,11 @@
     "officialSite": "http://www.oofuri.com/",
     "begin": "2010-04-01T16:30:00.000Z",
     "end": "2010-06-24T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cdqlI4vxYZ8CgOg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -384,22 +288,12 @@
       {
         "site": "nicovideo",
         "id": "oofuri02",
-        "begin": "2017-09-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-26T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1016",
-        "begin": "2010-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -415,17 +309,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/giantkilling/",
     "begin": "2010-04-04T00:25:00.000Z",
     "end": "2010-09-26T00:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "l7iaDAWnPP33gXsY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -434,22 +322,12 @@
       {
         "site": "bilibili",
         "id": "1020",
-        "begin": "2010-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-03T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "43222",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -465,7 +343,6 @@
     "officialSite": "http://www.1931.tv/",
     "begin": "2010-04-05T16:30:00.000Z",
     "end": "2010-06-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -489,27 +366,16 @@
     "officialSite": "http://www.angelbeats.jp/",
     "begin": "2010-04-02T17:25:00.000Z",
     "end": "2010-06-25T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "19360",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "959",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -518,12 +384,7 @@
       {
         "site": "nicovideo",
         "id": "angelbeats",
-        "begin": "2012-07-22T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-22T14:00:00.000Z"
       }
     ]
   },
@@ -539,37 +400,21 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/hakuoki/tv/",
     "begin": "2010-04-03T15:30:00.000Z",
     "end": "2010-06-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ia6SfHYXrW5n8euI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzm2wt",
-        "begin": "2012-07-01T06:23:36.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:23:36.000Z"
       },
       {
         "site": "qq",
         "id": "x/x0ltc9qnko89th2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -578,32 +423,17 @@
       {
         "site": "nicovideo",
         "id": "ch632",
-        "begin": "2010-09-17T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-09-17T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "761",
-        "begin": "2010-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-02T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "19457",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -619,17 +449,11 @@
     "officialSite": "http://www.starchild.co.jp/special/arakawa_ub/",
     "begin": "2010-04-04T16:35:00.000Z",
     "end": "2010-06-27T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "t/t3mbe3r3j8au5xs",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -638,32 +462,17 @@
       {
         "site": "mgtv",
         "id": "319820",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjatl1",
-        "begin": "2017-11-30T16:01:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-30T16:01:08.000Z"
       },
       {
         "site": "bilibili",
         "id": "978",
-        "begin": "2010-04-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -679,7 +488,6 @@
     "officialSite": "http://www.starchild.co.jp/special/kiss_sis/",
     "begin": "2010-04-05T14:30:00.000Z",
     "end": "2010-06-21T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -699,27 +507,16 @@
     "officialSite": "http://www.jewelpet.jp/",
     "begin": "2010-04-03T00:30:00.000Z",
     "end": "2011-04-02T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wGtW1DyiaElCzMZk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "20638",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -728,12 +525,7 @@
       {
         "site": "bilibili",
         "id": "123",
-        "begin": "2010-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -749,37 +541,21 @@
     "officialSite": "http://www.uraboku.jp/",
     "begin": "2010-04-11T15:30:00.000Z",
     "end": "2010-09-19T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "v5Br6VG3J2XIRq4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "n/nq9eg84cyrges4e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "20071",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -788,12 +564,7 @@
       {
         "site": "bilibili",
         "id": "1021",
-        "begin": "2010-04-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-10T16:00:00.000Z"
       }
     ]
   },
@@ -810,27 +581,16 @@
     "officialSite": "http://www.heroman.jp/",
     "begin": "2010-04-01T09:00:00.000Z",
     "end": "2010-09-23T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ct2oJo70ZKIFgibs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb0ru5",
-        "begin": "2015-03-27T02:03:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-27T02:03:34.000Z"
       },
       {
         "site": "bangumi",
@@ -839,12 +599,7 @@
       {
         "site": "bilibili",
         "id": "1026",
-        "begin": "2010-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -861,41 +616,20 @@
     "officialSite": "http://lilpri.com/animation/index.html",
     "begin": "2010-04-04T00:00:00.000Z",
     "end": "2011-03-27T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "na6ZF3iclVZP2dNw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "19646",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "4530"
-      },
-      {
-        "site": "bilibili",
-        "id": "1036",
-        "begin": "2010-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -914,17 +648,11 @@
     "officialSite": "http://www.takaratomy.co.jp/products/TF/products/animated/index2.html",
     "begin": "2010-04-02T23:00:00.000Z",
     "end": "2010-12-24T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lbaRD3fdTYvubNQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -947,7 +675,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mf-beyblade/",
     "begin": "2010-04-03T23:30:00.000Z",
     "end": "2011-03-27T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -967,17 +694,11 @@
     "officialSite": "http://www.ntv.co.jp/rainbow/",
     "begin": "2010-04-02T03:00:00.000Z",
     "end": "2010-09-28T16:43:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Zd2oJo70ZKIFgibs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -998,27 +719,16 @@
     "officialSite": "http://www.sdgundam3gd.net/index.html",
     "begin": "2010-04-03T01:15:00.000Z",
     "end": "2011-03-26T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iaqWgHobsXJr9eibM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk0argh",
-        "begin": "2016-08-09T08:01:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-09T08:01:14.000Z"
       },
       {
         "site": "bangumi",
@@ -1038,17 +748,11 @@
     "officialSite": "http://mechamote.tv/",
     "begin": "2010-04-03T00:00:00.000Z",
     "end": "2011-04-10T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IQL9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1069,27 +773,11 @@
     "officialSite": "http://www.animax.co.jp/feature/index.php?code=NN10000960",
     "begin": "2010-04-16T23:30:00.000Z",
     "end": "2012-12-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc0add",
-        "begin": "2014-10-27T09:38:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "65442",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-27T09:38:08.000Z"
       },
       {
         "site": "bangumi",
@@ -1098,12 +786,7 @@
       {
         "site": "qq",
         "id": "x/xk9j6a00x1qh2tu",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1119,17 +802,11 @@
     "officialSite": "http://www.toei-anim.co.jp/sp/rin-kake1_shadow/",
     "begin": "2010-04-02T11:00:00.000Z",
     "end": "2010-06-17T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ic0w3tR2D8zGUEno",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1138,22 +815,12 @@
       {
         "site": "bilibili",
         "id": "3980",
-        "begin": "2010-04-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-01T16:00:01.000Z"
       },
       {
         "site": "letv",
         "id": "29297",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1169,7 +836,6 @@
     "officialSite": "http://wwws.warnerbros.co.jp/gintama/",
     "begin": "2010-04-24T16:00:00.000Z",
     "end": "2010-04-24T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1178,12 +844,7 @@
       {
         "site": "nicovideo",
         "id": "gintama-benizakura",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1199,27 +860,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2010-04-17T16:00:00.000Z",
     "end": "2010-04-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/bd9fa0657ec6d9b7.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/bd9fa0657ec6d9b7.html"
       },
       {
         "site": "bangumi",
@@ -1228,22 +878,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3891",
-        "begin": "2010-04-16T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "14512",
+        "begin": "2010-04-16T16:00:01.000Z"
       }
     ]
   },
@@ -1259,17 +899,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2010-04-17T16:00:00.000Z",
     "end": "2010-04-17T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -1278,22 +912,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1309,7 +933,6 @@
     "officialSite": "http://kc.kodansha.co.jp/tsubaholi/",
     "begin": "2010-04-23T16:00:00.000Z",
     "end": "2010-04-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1318,22 +941,12 @@
       {
         "site": "pptv",
         "id": "icEMibvCSKibjiabGYE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3391",
-        "begin": "2010-04-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-04-22T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2010/05.json
+++ b/data/items/2010/05.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.bakugan.jp/",
     "begin": "2010-05-23T16:30:00.000Z",
     "end": "2011-01-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -31,7 +30,6 @@
     "officialSite": "http://www.bungakushoujo.jp/",
     "begin": "2010-05-01T16:00:00.000Z",
     "end": "2010-05-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -40,42 +38,22 @@
       {
         "site": "nicovideo",
         "id": "bungakushoujo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "nnBc2kKoGFa5N58",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10010017",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3575",
-        "begin": "2010-04-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "73292",
+        "begin": "2010-04-30T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2010/06.json
+++ b/data/items/2010/06.json
@@ -11,27 +11,16 @@
     "officialSite": "",
     "begin": "2010-06-23T16:00:00.000Z",
     "end": "2010-06-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "29836",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "bNynJY3zY6EEguo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -51,7 +40,6 @@
     "officialSite": "",
     "begin": "2010-06-25T16:00:00.000Z",
     "end": "2010-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,32 +48,17 @@
       {
         "site": "nicovideo",
         "id": "bungakushoujo-memoire",
-        "begin": "2011-11-23T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-23T06:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "WJRw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "29271",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -101,7 +74,6 @@
     "officialSite": "http://www.uchushow.net/index.html",
     "begin": "2010-06-26T16:00:00.000Z",
     "end": "2010-06-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,12 +82,7 @@
       {
         "site": "nicovideo",
         "id": "uchushow",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2010/07.json
+++ b/data/items/2010/07.json
@@ -15,27 +15,16 @@
     "officialSite": "http://www.starchild.co.jp/special/seitokai/",
     "begin": "2010-07-03T15:30:00.000Z",
     "end": "2010-09-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pZNu7FS6KmjLSbE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgiaqht",
-        "begin": "2014-04-09T23:28:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:28:46.000Z"
       },
       {
         "site": "bangumi",
@@ -44,12 +33,7 @@
       {
         "site": "nicovideo",
         "id": "seitokai01",
-        "begin": "2013-12-18T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-18T06:00:00.000Z"
       }
     ]
   },
@@ -68,17 +52,11 @@
     "officialSite": "http://www.otogi-bank.com/",
     "begin": "2010-07-01T00:00:00.000Z",
     "end": "2010-09-16T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "j72IBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -87,32 +65,17 @@
       {
         "site": "nicovideo",
         "id": "otogi-bank",
-        "begin": "2011-11-30T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-30T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "981",
-        "begin": "2010-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-06-30T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "29333",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -128,17 +91,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/amagami/1st/",
     "begin": "2010-07-01T16:40:00.000Z",
     "end": "2014-08-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jryHBW3TQ4HkYso",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -147,12 +104,7 @@
       {
         "site": "bilibili",
         "id": "815",
-        "begin": "2010-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -168,7 +120,6 @@
     "officialSite": "http://www.sekirei-tv.com/",
     "begin": "2010-07-04T14:30:00.000Z",
     "end": "2010-09-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -192,27 +143,16 @@
     "officialSite": "http://www.denyuden.jp/",
     "begin": "2010-07-01T17:15:00.000Z",
     "end": "2010-12-16T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjq84sl",
-        "begin": "2013-03-14T11:32:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-14T11:32:16.000Z"
       },
       {
         "site": "letv",
         "id": "29337",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -221,22 +161,12 @@
       {
         "site": "nicovideo",
         "id": "denyudenr",
-        "begin": "2012-03-28T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-28T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "984",
-        "begin": "2010-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -255,57 +185,31 @@
     "officialSite": "http://www.nuramago.jp/index_1st.html",
     "begin": "2010-07-05T17:19:00.000Z",
     "end": "2010-12-20T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "r51o5k60JGLFQ6s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzlz3p",
-        "begin": "2012-07-01T06:23:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:23:28.000Z"
       },
       {
         "site": "qq",
         "id": "c/coo4nrqxo0iru10",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "29294",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "899",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -325,7 +229,6 @@
     "officialSite": "http://www.occult-gakuin.jp/",
     "begin": "2010-07-05T16:30:00.000Z",
     "end": "2010-09-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -334,12 +237,7 @@
       {
         "site": "nicovideo",
         "id": "occult-gakuin",
-        "begin": "2012-07-25T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-25T06:00:00.000Z"
       }
     ]
   },
@@ -355,7 +253,6 @@
     "officialSite": "http://web.archive.org/web/*/asoiku.com/",
     "begin": "2010-07-10T16:58:00.000Z",
     "end": "2010-09-25T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -375,7 +272,6 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/hotd/",
     "begin": "2010-07-05T02:30:00.000Z",
     "end": "2010-09-20T03:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -384,12 +280,7 @@
       {
         "site": "nicovideo",
         "id": "ch326",
-        "begin": "2010-07-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-07-09T03:00:00.000Z"
       }
     ]
   },
@@ -406,37 +297,16 @@
     "officialSite": "http://web.archive.org/web/*/www.sengokubasara.tv/",
     "begin": "2010-07-11T08:00:00.000Z",
     "end": "2010-09-26T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ey4KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk441z9",
-        "begin": "2012-11-30T16:00:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1463049",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-30T16:00:28.000Z"
       },
       {
         "site": "bangumi",
@@ -445,12 +315,7 @@
       {
         "site": "bilibili",
         "id": "1591",
-        "begin": "2010-07-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-07-10T16:00:00.000Z"
       }
     ]
   },
@@ -466,17 +331,11 @@
     "officialSite": "http://www.mitsudomoe-anime.com/",
     "begin": "2010-07-02T17:00:00.000Z",
     "end": "2010-09-25T19:48:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "29367",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -485,22 +344,12 @@
       {
         "site": "nicovideo",
         "id": "ch323",
-        "begin": "2010-10-24T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-24T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "949",
-        "begin": "2010-07-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -516,7 +365,6 @@
     "officialSite": "http://www.maql.co.jp/special/campanella/",
     "begin": "2010-07-02T16:30:00.000Z",
     "end": "2010-09-17T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -525,32 +373,17 @@
       {
         "site": "nicovideo",
         "id": "campanella",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "29292",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4642",
-        "begin": "2010-07-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-07-01T16:00:01.000Z"
       }
     ]
   },
@@ -567,17 +400,11 @@
     "officialSite": "http://www.kuroshitsuji.tv/",
     "begin": "2010-07-01T16:20:00.000Z",
     "end": "2010-09-16T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "50143",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -585,13 +412,8 @@
       },
       {
         "site": "bilibili",
-        "id": "4586",
-        "begin": "2010-06-30T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8312",
+        "begin": "2010-06-30T16:00:01.000Z"
       }
     ]
   },
@@ -610,7 +432,6 @@
     "officialSite": "http://s-witch.cute.or.jp/pc/",
     "begin": "2010-07-07T16:30:00.000Z",
     "end": "2010-09-22T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -619,12 +440,7 @@
       {
         "site": "letv",
         "id": "29309",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -640,21 +456,10 @@
     "officialSite": "http://www.okiagari.net/",
     "begin": "2010-07-08T16:30:00.000Z",
     "end": "2010-12-30T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "5653"
-      },
-      {
-        "site": "bilibili",
-        "id": "988",
-        "begin": "2010-07-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -674,17 +479,11 @@
     "officialSite": "http://www.tv-asahi.co.jp/digimon/",
     "begin": "2010-07-06T10:27:00.000Z",
     "end": "2012-03-24T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb13eh",
-        "begin": "2015-08-17T03:27:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-17T03:27:33.000Z"
       },
       {
         "site": "bangumi",
@@ -704,17 +503,11 @@
     "officialSite": "http://tono-anime.com/",
     "begin": "2010-07-05T17:49:00.000Z",
     "end": "2010-09-20T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "t4WAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -723,12 +516,7 @@
       {
         "site": "bilibili",
         "id": "936",
-        "begin": "2010-07-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -744,7 +532,6 @@
     "officialSite": "http://www.tv-asahi.co.jp/stitch/",
     "begin": "2010-07-06T10:00:00.000Z",
     "end": "2011-03-08T10:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -764,37 +551,21 @@
     "officialSite": "http://www.pokemon-movie.jp/index.html#/top",
     "begin": "2010-07-10T16:00:00.000Z",
     "end": "2010-07-10T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "71824",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -803,22 +574,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5745",
-        "begin": "2010-07-09T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-07-09T16:00:01.000Z"
       }
     ]
   },
@@ -834,37 +595,16 @@
     "officialSite": "http://www.hutch-movie.jp/",
     "begin": "2010-07-31T16:00:00.000Z",
     "end": "2010-07-31T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "s0slowtx4RibCAGg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/v_19rrifvb3v.html",
-        "exist": null
-      },
-      {
-        "site": "kankan",
-        "id": "70807",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "url": "http://www.iqiyi.com/v_19rrifvb3v.html"
       },
       {
         "site": "bangumi",
@@ -885,17 +625,11 @@
     "officialSite": "http://catshitone.jp/",
     "begin": "2010-07-17T16:00:00.000Z",
     "end": "2010-07-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qK2HBW3TQ4HkYso",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -904,12 +638,7 @@
       {
         "site": "letv",
         "id": "29187",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -925,17 +654,11 @@
     "officialSite": "http://www.blacklagoon.jp/index.html",
     "begin": "2010-07-17T16:00:00.000Z",
     "end": "2011-06-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "a9mkIorwYJ4Bfibc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -944,22 +667,7 @@
       {
         "site": "nicovideo",
         "id": "blacklagoon_ova",
-        "begin": "2014-05-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1381",
-        "begin": "2010-07-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-15T15:00:00.000Z"
       }
     ]
   },
@@ -975,17 +683,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/k-on/",
     "begin": "2010-07-30T16:00:00.000Z",
     "end": "2011-03-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hsfBP6cNfbsenAQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1005,7 +707,6 @@
     "officialSite": "",
     "begin": "2010-07-02T16:00:00.000Z",
     "end": "2010-12-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1014,12 +715,7 @@
       {
         "site": "pptv",
         "id": "oI5591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1038,7 +734,6 @@
     "officialSite": "http://www.naruto-movie.com/",
     "begin": "2010-07-30T16:00:00.000Z",
     "end": "2010-07-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1047,12 +742,7 @@
       {
         "site": "netflix",
         "id": "70275937",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   },
@@ -1068,7 +758,6 @@
     "officialSite": "",
     "begin": "2010-07-21T16:00:00.000Z",
     "end": "2010-07-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1077,12 +766,7 @@
       {
         "site": "letv",
         "id": "28993",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2010/08.json
+++ b/data/items/2010/08.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.capcom.co.jp/monsterhunter/pokapoka_airu/airuanimation.html",
     "begin": "2010-08-05T13:55:00.000Z",
     "end": "2010-10-07T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "g7CLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "letv",
         "id": "29273",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://www.hanakosan.net/",
     "begin": "2010-08-12T22:00:00.000Z",
     "end": "2011-03-24T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,7 +59,6 @@
     "officialSite": "http://colorful-movie.jp/",
     "begin": "2010-08-21T16:00:00.000Z",
     "end": "2010-08-21T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -91,7 +78,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2010-08-01T17:10:00.000Z",
     "end": "2010-08-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2010/09.json
+++ b/data/items/2010/09.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.nagoyatv.com/battlespirits_brave/",
     "begin": "2010-09-11T22:00:00.000Z",
     "end": "2011-09-10T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjskcw9",
-        "begin": "2013-01-29T04:25:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-29T04:25:14.000Z"
       },
       {
         "site": "bangumi",
@@ -46,57 +40,31 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_bw/",
     "begin": "2010-09-23T08:30:00.000Z",
     "end": "2012-06-14T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icFdBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjtscel",
-        "begin": "2012-12-25T00:42:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-25T00:42:07.000Z"
       },
       {
         "site": "qq",
         "id": "h/hibacbz0801byjb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10006539",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2017/dhpjlbkm4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -105,12 +73,7 @@
       {
         "site": "bilibili",
         "id": "6164",
-        "begin": "2010-09-22T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-09-22T16:00:01.000Z"
       }
     ]
   },
@@ -126,17 +89,11 @@
     "officialSite": "http://hetalia.com/top.htm",
     "begin": "2010-09-10T07:00:00.000Z",
     "end": "2011-02-18T07:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10018939",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -145,12 +102,7 @@
       {
         "site": "nicovideo",
         "id": "hetaria-world-series",
-        "begin": "2012-12-28T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-28T07:00:00.000Z"
       }
     ]
   },
@@ -162,7 +114,6 @@
     "officialSite": "http://aquaplus.jp/th2adnext/index.html",
     "begin": "2010-09-23T16:00:00.000Z",
     "end": "2010-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -171,22 +122,12 @@
       {
         "site": "nicovideo",
         "id": "th2adnext",
-        "begin": "2012-03-03T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-03T13:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "vIx39V3DM3HUUro",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -198,7 +139,6 @@
     "officialSite": "http://puyukai.com/agukaru/",
     "begin": "2010-09-17T16:00:00.000Z",
     "end": "2014-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -207,12 +147,7 @@
       {
         "site": "nicovideo",
         "id": "agukaru",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2010/10.json
+++ b/data/items/2010/10.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.rita-machin.jp/",
     "begin": "2010-10-31T22:35:00.000Z",
     "end": "2010-12-23T22:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,17 +33,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/soremachi/",
     "begin": "2010-10-07T16:55:00.000Z",
     "end": "2010-12-23T17:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DzoFgibtRwf9ia4Eg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -53,12 +46,7 @@
       {
         "site": "bilibili",
         "id": "992",
-        "begin": "2010-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -74,27 +62,16 @@
     "officialSite": "http://www.starchild.co.jp/special/arakawa_ub/",
     "begin": "2010-10-03T16:35:00.000Z",
     "end": "2010-12-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9UVAviaaMicDqdG4M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/f9ftjy7repojj4j",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -103,32 +80,17 @@
       {
         "site": "mgtv",
         "id": "319822",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjatpd",
-        "begin": "2017-11-30T16:01:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-30T16:01:05.000Z"
       },
       {
         "site": "bilibili",
         "id": "979",
-        "begin": "2010-10-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -144,7 +106,6 @@
     "officialSite": "http://www.otome-zakuro.jp/index.html",
     "begin": "2010-10-04T16:30:00.000Z",
     "end": "2010-12-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -153,12 +114,7 @@
       {
         "site": "nicovideo",
         "id": "ch638",
-        "begin": "2010-10-08T18:45:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-08T18:45:00.000Z"
       }
     ]
   },
@@ -174,7 +130,6 @@
     "officialSite": "http://www.hyakka-ryoran.tv/sg/",
     "begin": "2010-10-03T15:30:00.000Z",
     "end": "2010-12-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -183,12 +138,7 @@
       {
         "site": "nicovideo",
         "id": "hyakka-ryoran",
-        "begin": "2013-03-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-15T06:00:00.000Z"
       }
     ]
   },
@@ -204,27 +154,16 @@
     "officialSite": "http://milky-holmes.com/",
     "begin": "2010-10-07T14:00:00.000Z",
     "end": "2010-12-23T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LxrlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/fzigceu8ir3k1bg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -233,22 +172,12 @@
       {
         "site": "nicovideo",
         "id": "ch631",
-        "begin": "2010-10-10T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-10T20:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1691",
-        "begin": "2010-10-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -264,27 +193,16 @@
     "officialSite": "http://www9.nhk.or.jp/anime/yakumo/",
     "begin": "2010-10-03T14:00:00.000Z",
     "end": "2010-12-26T14:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Iw75d99FtfNW1Dw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "29825",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -293,12 +211,7 @@
       {
         "site": "bilibili",
         "id": "3484",
-        "begin": "2010-10-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-02T16:00:01.000Z"
       }
     ]
   },
@@ -314,7 +227,6 @@
     "officialSite": "http://www.starchild.co.jp/special/yosuganosora/",
     "begin": "2010-10-04T14:30:00.000Z",
     "end": "2010-12-20T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -323,12 +235,7 @@
       {
         "site": "nicovideo",
         "id": "yosuganosora",
-        "begin": "2014-01-29T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-29T15:00:00.000Z"
       }
     ]
   },
@@ -345,37 +252,21 @@
     "officialSite": "http://www.project-index.net/tv/",
     "begin": "2010-10-08T14:30:00.000Z",
     "end": "2011-04-01T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9objl",
-        "begin": "2016-08-15T08:29:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-15T08:29:44.000Z"
       },
       {
         "site": "letv",
         "id": "48910",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2011/mfjsml2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -384,22 +275,12 @@
       {
         "site": "nicovideo",
         "id": "ch640",
-        "begin": "2010-10-14T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-14T03:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "964",
-        "begin": "2010-10-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -415,7 +296,6 @@
     "officialSite": "http://newtype.kadocomic.jp/soraoto/",
     "begin": "2010-10-01T16:00:00.000Z",
     "end": "2010-12-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -435,37 +315,21 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/hakuoki/tv/",
     "begin": "2010-10-04T00:30:00.000Z",
     "end": "2010-12-06T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Kxbxb9c9retOzDQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "o/oeumrq4cl65k3h2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "29801",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -474,12 +338,7 @@
       {
         "site": "bilibili",
         "id": "762",
-        "begin": "2010-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -495,27 +354,16 @@
     "officialSite": "http://www.togainu.tv/index.html",
     "begin": "2010-10-07T16:25:00.000Z",
     "end": "2010-12-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LB3oZs40pOJFwys",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/8xcawqzxvuchjso",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -524,22 +372,7 @@
       {
         "site": "nicovideo",
         "id": "ch633",
-        "begin": "2010-10-13T18:15:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1003",
-        "begin": "2010-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-13T18:15:00.000Z"
       }
     ]
   },
@@ -555,7 +388,6 @@
     "officialSite": "http://www.j-toloveru.com/old/",
     "begin": "2010-10-05T17:00:00.000Z",
     "end": "2010-12-21T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -564,12 +396,7 @@
       {
         "site": "nicovideo",
         "id": "to-love-ru2",
-        "begin": "2012-10-17T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-17T06:00:00.000Z"
       }
     ]
   },
@@ -585,17 +412,11 @@
     "officialSite": "http://www.oreimo-anime.com/1st/index.html",
     "begin": "2010-10-03T14:30:00.000Z",
     "end": "2011-05-31T03:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "29884",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -604,22 +425,12 @@
       {
         "site": "nicovideo",
         "id": "ch639",
-        "begin": "2010-10-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-10T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2660",
-        "begin": "2010-10-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-03T14:30:00.000Z"
       }
     ]
   },
@@ -635,17 +446,11 @@
     "officialSite": "http://www.suparobo.jp/srw_lineup/srw_ogin/",
     "begin": "2010-10-01T16:00:00.000Z",
     "end": "2011-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cMG8OqIIeLYZlic8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -654,12 +459,7 @@
       {
         "site": "bilibili",
         "id": "1002",
-        "begin": "2010-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -675,7 +475,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tegamibachi/",
     "begin": "2010-10-02T15:10:00.000Z",
     "end": "2011-03-26T15:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -695,7 +494,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/bakuman/",
     "begin": "2010-10-02T09:00:00.000Z",
     "end": "2011-04-02T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -704,22 +502,12 @@
       {
         "site": "nicovideo",
         "id": "bakuman1",
-        "begin": "2012-10-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-20T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "727",
-        "begin": "2010-10-02T09:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-02T09:00:00.000Z"
       }
     ]
   },
@@ -735,21 +523,10 @@
     "officialSite": "http://www.butaro.net/",
     "begin": "2010-10-02T00:30:00.000Z",
     "end": "2010-12-18T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "8390"
-      },
-      {
-        "site": "bilibili",
-        "id": "980",
-        "begin": "2010-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -768,7 +545,6 @@
     "officialSite": "http://kaminomi.jp/index.html",
     "begin": "2010-10-06T16:50:00.000Z",
     "end": "2010-12-22T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -777,12 +553,7 @@
       {
         "site": "nicovideo",
         "id": "kaminomi1",
-        "begin": "2013-07-09T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-09T06:00:00.000Z"
       }
     ]
   },
@@ -801,7 +572,6 @@
     "officialSite": "http://newtype.kadocomic.jp/psg/",
     "begin": "2010-10-01T18:00:00.000Z",
     "end": "2010-12-24T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -810,22 +580,7 @@
       {
         "site": "nicovideo",
         "id": "ch635",
-        "begin": "2011-06-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "977",
-        "begin": "2010-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-06-09T15:00:00.000Z"
       }
     ]
   },
@@ -844,7 +599,6 @@
     "officialSite": "http://www.ika-musume.com/season_1/",
     "begin": "2010-10-04T17:00:00.000Z",
     "end": "2010-12-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -853,12 +607,7 @@
       {
         "site": "nicovideo",
         "id": "ika-musume-01",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -875,27 +624,16 @@
     "officialSite": "http://newtype.kadocomic.jp/fortune/",
     "begin": "2010-10-08T16:23:00.000Z",
     "end": "2010-12-24T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MQD7eeFHticVY1j4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk77zg1",
-        "begin": "2012-09-01T10:01:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-01T10:01:32.000Z"
       },
       {
         "site": "bangumi",
@@ -904,22 +642,12 @@
       {
         "site": "nicovideo",
         "id": "ch634",
-        "begin": "2010-10-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-14T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "996",
-        "begin": "2010-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -935,27 +663,16 @@
     "officialSite": "http://www.star-driver.net/",
     "begin": "2010-10-03T08:00:00.000Z",
     "end": "2011-04-03T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LhvmZMwyouBDwSk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/zk2apezuzr2du42",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -964,22 +681,12 @@
       {
         "site": "nicovideo",
         "id": "star-driver",
-        "begin": "2014-06-09T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-06-09T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "994",
-        "begin": "2010-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -995,17 +702,11 @@
     "officialSite": "http://kuragehime.noitamina.tv/",
     "begin": "2010-10-14T15:55:00.000Z",
     "end": "2010-12-30T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZNWwLpb8bKoNiaicM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1014,22 +715,12 @@
       {
         "site": "bilibili",
         "id": "995",
-        "begin": "2010-10-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-13T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "30332",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1046,7 +737,6 @@
     "officialSite": "http://www.tatsunoko.co.jp/tachumaru/",
     "begin": "2010-10-04T18:19:00.000Z",
     "end": "2011-03-28T17:52:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1055,12 +745,7 @@
       {
         "site": "letv",
         "id": "30258",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1077,27 +762,16 @@
     "officialSite": "",
     "begin": "2010-10-16T16:00:00.000Z",
     "end": "2010-10-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RfLeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0nzd",
-        "begin": "2014-09-04T16:20:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-04T16:20:17.000Z"
       },
       {
         "site": "bangumi",
@@ -1106,12 +780,7 @@
       {
         "site": "bilibili",
         "id": "4555",
-        "begin": "2010-10-15T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-15T16:00:01.000Z"
       }
     ]
   },
@@ -1130,7 +799,6 @@
     "officialSite": "http://www.robin100f.com/jhome.html",
     "begin": "2010-10-10T22:00:00.000Z",
     "end": "2011-01-02T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1150,7 +818,6 @@
     "officialSite": "http://www.karl-tower.net/",
     "begin": "2010-10-08T16:00:00.000Z",
     "end": "2011-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1170,27 +837,16 @@
     "officialSite": "http://www.animax.co.jp/marvelanime/",
     "begin": "2010-10-01T16:00:00.000Z",
     "end": "2010-12-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IRDradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/ironman",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1199,22 +855,12 @@
       {
         "site": "qq",
         "id": "i/i3iua4ffo320s2g",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1004",
-        "begin": "2010-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -1230,27 +876,16 @@
     "officialSite": "",
     "begin": "2010-10-04T16:00:00.000Z",
     "end": "2010-10-29T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8GZS0DiaeDkyvLZU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "30195",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1270,7 +905,6 @@
     "officialSite": "http://www.precure-movie.com/",
     "begin": "2010-10-30T16:00:00.000Z",
     "end": "2010-10-30T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1279,22 +913,12 @@
       {
         "site": "letv",
         "id": "39896",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   },
@@ -1310,7 +934,6 @@
     "officialSite": "",
     "begin": "2010-10-29T16:00:00.000Z",
     "end": "2010-10-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1319,32 +942,17 @@
       {
         "site": "nicovideo",
         "id": "bungakushoujo-memoire",
-        "begin": "2011-11-23T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-23T06:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "WJRw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "29271",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1356,7 +964,6 @@
     "officialSite": "",
     "begin": "2010-10-03T16:00:00.000Z",
     "end": "2010-12-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1376,7 +983,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/hidamari/index-j.html",
     "begin": "2010-10-27T16:00:00.000Z",
     "end": "2010-10-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1385,22 +991,12 @@
       {
         "site": "pptv",
         "id": "LxnkYsowoN5Bvyc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3821",
-        "begin": "2010-10-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-26T16:00:01.000Z"
       }
     ]
   },
@@ -1416,7 +1012,6 @@
     "officialSite": "http://kc.kodansha.co.jp/yozakura/",
     "begin": "2010-10-08T16:00:00.000Z",
     "end": "2011-11-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1425,22 +1020,12 @@
       {
         "site": "pptv",
         "id": "ZdSvLZX7a6kMiavI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "474",
-        "begin": "2010-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -1456,7 +1041,6 @@
     "officialSite": "",
     "begin": "2010-10-02T16:00:00.000Z",
     "end": "2010-10-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1465,22 +1049,12 @@
       {
         "site": "pptv",
         "id": "JBXwbtY8rOpNyzM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "29873",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2010/11.json
+++ b/data/items/2010/11.json
@@ -11,17 +11,11 @@
     "officialSite": "http://kakokawa.com/",
     "begin": "2010-11-05T09:55:00.000Z",
     "end": "2010-12-03T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rpZx71e9LWvOTLQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "kakokawa",
-        "begin": "2010-10-12T03:00:05.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-10-12T03:00:05.000Z"
       },
       {
         "site": "bilibili",
         "id": "1757",
-        "begin": "2010-11-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-11-04T16:00:00.000Z"
       }
     ]
   },
@@ -64,7 +48,6 @@
     "officialSite": "http://nelly-caesar.com/",
     "begin": "2010-11-09T16:00:00.000Z",
     "end": "2011-11-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -84,47 +67,26 @@
     "officialSite": "",
     "begin": "2010-11-16T16:00:00.000Z",
     "end": "2012-09-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TOHLSbEXh8Uopg4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhabi5p",
-        "begin": "2016-01-08T03:33:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T03:33:40.000Z"
       },
       {
         "site": "qq",
         "id": "h/h6ve1mfenzo3v0f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2016/dhpxxcr",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -133,22 +95,12 @@
       {
         "site": "mgtv",
         "id": "167707",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10016940",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -164,17 +116,11 @@
     "officialSite": "",
     "begin": "2010-11-29T16:00:00.000Z",
     "end": "2011-02-14T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "34350",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -194,27 +140,16 @@
     "officialSite": "http://www.tamayura.info/",
     "begin": "2010-11-26T16:00:00.000Z",
     "end": "2010-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BDQPjfVbywls6lI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hsac5f0iqzra0pl",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -223,22 +158,12 @@
       {
         "site": "nicovideo",
         "id": "tamayura",
-        "begin": "2012-02-29T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-02-29T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjbxcp",
-        "begin": "2014-01-15T08:57:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-15T08:57:11.000Z"
       }
     ]
   },
@@ -250,7 +175,6 @@
     "officialSite": "http://trip.oh-news.net/",
     "begin": "2010-11-10T16:00:00.000Z",
     "end": "2011-01-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -259,12 +183,7 @@
       {
         "site": "nicovideo",
         "id": "ch84",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -280,7 +199,6 @@
     "officialSite": "http://meganenakanojo.com/",
     "begin": "2010-11-25T16:00:00.000Z",
     "end": "2010-11-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -289,12 +207,7 @@
       {
         "site": "pptv",
         "id": "4FMurBR66iaiaLCXE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -310,7 +223,6 @@
     "officialSite": "",
     "begin": "2010-11-17T16:00:00.000Z",
     "end": "2011-06-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -319,32 +231,12 @@
       {
         "site": "pptv",
         "id": "ROicaWMAmltQ3tR0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2939",
-        "begin": "2010-11-16T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "39836",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2010/12.json
+++ b/data/items/2010/12.json
@@ -14,17 +14,11 @@
     "officialSite": "http://sta-ska.com/index.html",
     "begin": "2010-12-23T17:10:00.000Z",
     "end": "2011-06-16T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ADUQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,22 +27,12 @@
       {
         "site": "nicovideo",
         "id": "ch331",
-        "begin": "2011-02-03T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-02-03T18:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "954",
-        "begin": "2010-12-22T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-12-22T16:00:00.000Z"
       }
     ]
   },
@@ -64,7 +48,6 @@
     "officialSite": "http://ga.sbcr.jp/bunko_blog/nyaruani/",
     "begin": "2010-12-10T15:30:00.000Z",
     "end": "2011-03-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -73,22 +56,12 @@
       {
         "site": "nicovideo",
         "id": "ch820",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "408",
-        "begin": "2010-12-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-12-09T16:00:00.000Z"
       }
     ]
   },
@@ -104,17 +77,11 @@
     "officialSite": "",
     "begin": "2010-12-29T16:00:00.000Z",
     "end": "2010-12-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "42248",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -134,7 +101,6 @@
     "officialSite": "",
     "begin": "2010-12-23T16:00:00.000Z",
     "end": "2010-12-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -155,17 +121,11 @@
     "officialSite": "",
     "begin": "2010-12-18T16:00:00.000Z",
     "end": "2010-12-18T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dLaSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -186,17 +146,11 @@
     "officialSite": "http://www.fafner.jp/h-and-e/index.html",
     "begin": "2010-12-25T16:00:00.000Z",
     "end": "2010-12-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjzmwtl",
-        "begin": "2012-07-01T06:24:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:24:13.000Z"
       },
       {
         "site": "bangumi",
@@ -205,12 +159,7 @@
       {
         "site": "bilibili",
         "id": "3847",
-        "begin": "2010-12-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2010-12-24T16:00:01.000Z"
       }
     ]
   },
@@ -226,17 +175,11 @@
     "officialSite": "http://www.ciao.shogakukan.co.jp/",
     "begin": "2010-12-28T16:00:00.000Z",
     "end": "2013-04-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EP7aWMAmltQ3tR0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -256,31 +199,15 @@
     "officialSite": "",
     "begin": "2010-12-18T16:00:00.000Z",
     "end": "2010-12-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "M2lT0TmfD02wLpY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "10954"
-      },
-      {
-        "site": "bilibili",
-        "id": "4610",
-        "begin": "2012-02-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -296,7 +223,6 @@
     "officialSite": "",
     "begin": "2010-12-24T16:00:00.000Z",
     "end": "2010-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -305,32 +231,17 @@
       {
         "site": "nicovideo",
         "id": "bungakushoujo-memoire",
-        "begin": "2011-11-23T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-23T06:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "WJRw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "29271",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -346,7 +257,6 @@
     "officialSite": "http://goulart.jp/",
     "begin": "2010-12-18T16:00:00.000Z",
     "end": "2010-12-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -355,12 +265,7 @@
       {
         "site": "pptv",
         "id": "gLaRD3fdTYvubNQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -376,7 +281,6 @@
     "officialSite": "",
     "begin": "2010-12-09T16:00:00.000Z",
     "end": "2011-10-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -385,12 +289,7 @@
       {
         "site": "pptv",
         "id": "b9eyMJjibbqwPjfU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -406,7 +305,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/bleach/",
     "begin": "2010-12-03T16:00:00.000Z",
     "end": "2010-12-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -415,12 +313,7 @@
       {
         "site": "netflix",
         "id": "70260383",
-        "begin": "2016-10-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-15T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2011/01.json
+++ b/data/items/2011/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.showa-movie.jp/index.php",
     "begin": "2011-01-07T09:00:00.000Z",
     "end": "2011-06-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "A003tR2D8zGUEno",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "1739",
-        "begin": "2011-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -52,7 +41,6 @@
     "officialSite": "http://riorainbowgate.com/",
     "begin": "2011-01-04T14:00:00.000Z",
     "end": "2011-03-29T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,12 +49,7 @@
       {
         "site": "nicovideo",
         "id": "ch246",
-        "begin": "2011-01-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-07T15:00:00.000Z"
       }
     ]
   },
@@ -85,17 +68,11 @@
     "officialSite": "http://dragoncrisis.jp/",
     "begin": "2011-01-10T16:30:00.000Z",
     "end": "2011-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "114ppw915SOGBGw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -104,22 +81,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgigw49",
-        "begin": "2017-11-30T16:05:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-30T16:05:46.000Z"
       },
       {
         "site": "bilibili",
         "id": "3361",
-        "begin": "2011-01-09T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-09T16:00:01.000Z"
       }
     ]
   },
@@ -135,27 +102,16 @@
     "officialSite": "http://www.gosick.tv/",
     "begin": "2011-01-07T16:53:00.000Z",
     "end": "2011-07-01T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vYhz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk46kn5",
-        "begin": "2012-11-30T16:00:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-30T16:00:31.000Z"
       },
       {
         "site": "bangumi",
@@ -164,12 +120,7 @@
       {
         "site": "bilibili",
         "id": "856",
-        "begin": "2011-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -188,7 +139,6 @@
     "officialSite": "http://freezing.tv/season1/",
     "begin": "2011-01-08T00:30:00.000Z",
     "end": "2011-04-07T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -197,12 +147,7 @@
       {
         "site": "nicovideo",
         "id": "freezing",
-        "begin": "2013-09-09T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-09-09T06:00:00.000Z"
       }
     ]
   },
@@ -218,7 +163,6 @@
     "officialSite": "http://newtype.kadocomic.jp/zombie/",
     "begin": "2011-01-10T16:30:00.000Z",
     "end": "2011-03-29T18:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -227,22 +171,12 @@
       {
         "site": "nicovideo",
         "id": "ch279",
-        "begin": "2011-01-13T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-13T13:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "697",
-        "begin": "2011-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -261,31 +195,15 @@
     "officialSite": "http://www.ytv.co.jp/beelze/",
     "begin": "2011-01-08T22:00:00.000Z",
     "end": "2012-03-24T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbarjh",
-        "begin": "2016-12-15T00:49:56.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-15T00:49:56.000Z"
       },
       {
         "site": "bangumi",
         "id": "9779"
-      },
-      {
-        "site": "bilibili",
-        "id": "952",
-        "begin": "2011-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -304,7 +222,6 @@
     "officialSite": "http://www.madoka-magica.com/tv/",
     "begin": "2011-01-06T16:25:00.000Z",
     "end": "2011-04-21T18:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -313,32 +230,17 @@
       {
         "site": "nicovideo",
         "id": "ch260",
-        "begin": "2011-01-12T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-12T18:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70302572",
-        "begin": "2017-04-05T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-05T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2539",
-        "begin": "2011-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -357,7 +259,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/is/",
     "begin": "2011-01-06T16:25:00.000Z",
     "end": "2011-03-31T17:49:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -366,12 +267,7 @@
       {
         "site": "nicovideo",
         "id": "is",
-        "begin": "2011-09-29T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-29T15:00:00.000Z"
       }
     ]
   },
@@ -387,17 +283,11 @@
     "officialSite": "http://www.starchild.co.jp/special/oniichan/",
     "begin": "2011-01-08T15:30:00.000Z",
     "end": "2011-03-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "b/buifm97guxf51ld",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -406,12 +296,7 @@
       {
         "site": "nicovideo",
         "id": "ch319",
-        "begin": "2011-01-11T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-11T17:00:00.000Z"
       }
     ]
   },
@@ -428,17 +313,11 @@
     "officialSite": "http://www.mitsudomoe-anime.com/",
     "begin": "2011-01-08T17:58:00.000Z",
     "end": "2011-02-26T18:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "35949",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -461,27 +340,16 @@
     "officialSite": "http://cf-vanguard.com/",
     "begin": "2011-01-07T23:00:00.000Z",
     "end": "2012-03-30T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vIl08lrAMG7RT7c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "35930",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -490,12 +358,7 @@
       {
         "site": "nicovideo",
         "id": "ch318",
-        "begin": "2011-01-09T01:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-09T01:30:00.000Z"
       }
     ]
   },
@@ -511,17 +374,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/yumekui/",
     "begin": "2011-01-06T16:55:00.000Z",
     "end": "2011-04-07T17:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qZxn5U2zI2HEQqo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -530,12 +387,7 @@
       {
         "site": "bilibili",
         "id": "865",
-        "begin": "2011-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -554,17 +406,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/level-e/",
     "begin": "2011-01-10T16:45:00.000Z",
     "end": "2011-04-04T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "22pV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -573,22 +419,12 @@
       {
         "site": "bilibili",
         "id": "947",
-        "begin": "2011-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-09T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "level-e",
-        "begin": "2019-01-24T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-24T15:00:00.000Z"
       }
     ]
   },
@@ -604,17 +440,11 @@
     "officialSite": "http://www.houroumusuko.jp/",
     "begin": "2011-01-13T16:15:00.000Z",
     "end": "2011-03-31T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EF0npQ1z4yGEAmo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -623,12 +453,7 @@
       {
         "site": "bilibili",
         "id": "951",
-        "begin": "2011-01-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-12T16:00:00.000Z"
       }
     ]
   },
@@ -647,27 +472,11 @@
     "officialSite": "http://fractale-anime.com/",
     "begin": "2011-01-13T15:45:00.000Z",
     "end": "2011-03-31T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HSMenARq2hh7ibWE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2735",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -676,12 +485,7 @@
       {
         "site": "bilibili",
         "id": "953",
-        "begin": "2011-01-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-12T16:00:00.000Z"
       }
     ]
   },
@@ -700,27 +504,16 @@
     "officialSite": "http://www.animax.co.jp/marvelanime/wolverine/",
     "begin": "2011-01-07T13:00:00.000Z",
     "end": "2011-03-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wHVQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/wolverine",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -729,12 +522,7 @@
       {
         "site": "bilibili",
         "id": "956",
-        "begin": "2011-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -750,7 +538,6 @@
     "officialSite": "http://www.ktv.jp/hokuto/index.html",
     "begin": "2011-01-11T18:00:00.000Z",
     "end": "2011-04-05T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -770,31 +557,15 @@
     "officialSite": "http://www.nhk.or.jp/tamago/program/20110107_doc.html",
     "begin": "2011-01-07T15:15:00.000Z",
     "end": "2011-01-07T15:41:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CfXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "12351"
-      },
-      {
-        "site": "bilibili",
-        "id": "4545",
-        "begin": "2011-01-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -810,17 +581,11 @@
     "officialSite": "http://www.ntv.co.jp/kiminitodoke/",
     "begin": "2011-01-04T17:05:00.000Z",
     "end": "2011-03-29T17:34:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "naiaTEXnfT43wbtY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -829,12 +594,7 @@
       {
         "site": "bilibili",
         "id": "858",
-        "begin": "2011-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-01-03T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2011/02.json
+++ b/data/items/2011/02.json
@@ -15,17 +15,11 @@
     "officialSite": "http://asahi.co.jp/suite_precure/",
     "begin": "2011-02-05T23:30:00.000Z",
     "end": "2012-01-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb14k1",
-        "begin": "2015-08-14T17:08:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:08:48.000Z"
       },
       {
         "site": "bangumi",
@@ -48,7 +42,6 @@
     "officialSite": "http://wwws.warnerbros.co.jp/supernatural/",
     "begin": "2011-02-23T13:00:00.000Z",
     "end": "2011-04-06T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -68,7 +61,6 @@
     "officialSite": "http://www.bakugan.jp/",
     "begin": "2011-02-13T16:30:00.000Z",
     "end": "2012-01-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -88,17 +80,11 @@
     "officialSite": "http://sbr-gx.jp",
     "begin": "2011-02-01T16:00:00.000Z",
     "end": "2011-02-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AEo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -118,17 +104,11 @@
     "officialSite": "http://dbeat.bandaivisual.co.jp/koisento/",
     "begin": "2011-02-25T16:00:00.000Z",
     "end": "2011-02-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hb2IBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -148,7 +128,6 @@
     "officialSite": "http://www.bakatest.com/ova/index.html",
     "begin": "2011-02-23T16:00:00.000Z",
     "end": "2011-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -157,32 +136,17 @@
       {
         "site": "nicovideo",
         "id": "ch60021",
-        "begin": "2011-04-29T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-29T03:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "PQUAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3486",
-        "begin": "2011-02-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-02-22T16:00:01.000Z"
       }
     ]
   },
@@ -198,7 +162,6 @@
     "officialSite": "http://kc.kodansha.co.jp/megamisama/",
     "begin": "2011-02-23T16:00:00.000Z",
     "end": "2013-08-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -207,22 +170,12 @@
       {
         "site": "pptv",
         "id": "Vdu1M5sBca8SkPg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3759",
-        "begin": "2011-02-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-02-22T16:00:01.000Z"
       }
     ]
   },
@@ -238,7 +191,6 @@
     "officialSite": "http://www.macrossf.com/movie2/",
     "begin": "2011-02-26T16:00:00.000Z",
     "end": "2011-02-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -247,12 +199,7 @@
       {
         "site": "pptv",
         "id": "kHicUUrogkM4xrxc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2011/03.json
+++ b/data/items/2011/03.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/lbx/",
     "begin": "2011-03-02T10:27:00.000Z",
     "end": "2012-01-11T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9k04th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk6f6c9",
-        "begin": "2012-10-15T01:29:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-15T01:29:39.000Z"
       },
       {
         "site": "bangumi",
@@ -40,22 +29,12 @@
       {
         "site": "letv",
         "id": "39210",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1695",
-        "begin": "2011-03-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-03-01T16:00:00.000Z"
       }
     ]
   },
@@ -71,17 +50,11 @@
     "officialSite": "http://www.janica.jp/pja/tansu/",
     "begin": "2011-03-26T16:00:00.000Z",
     "end": "2011-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wwYCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -90,12 +63,7 @@
       {
         "site": "letv",
         "id": "42060",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -111,17 +79,11 @@
     "officialSite": "http://www.janica.jp/pja/kizuna/",
     "begin": "2011-03-19T16:00:00.000Z",
     "end": "2011-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wwYCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -130,12 +92,7 @@
       {
         "site": "letv",
         "id": "42060",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -151,17 +108,11 @@
     "officialSite": "http://www.janica.jp/pja/ninnin/",
     "begin": "2011-03-05T16:00:00.000Z",
     "end": "2011-03-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wwYCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -170,22 +121,12 @@
       {
         "site": "bilibili",
         "id": "958",
-        "begin": "2011-03-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-03-04T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "42060",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -201,17 +142,11 @@
     "officialSite": "http://www.janica.jp/pja/ojisan/",
     "begin": "2011-03-19T16:00:00.000Z",
     "end": "2011-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wwYCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -220,12 +155,7 @@
       {
         "site": "letv",
         "id": "42060",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -241,17 +171,11 @@
     "officialSite": "http://doraeiga.com/2011/",
     "begin": "2011-03-05T16:00:00.000Z",
     "end": "2011-03-05T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "46395",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -260,32 +184,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mmzt",
-        "begin": "2018-05-31T16:12:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:12:44.000Z"
       }
     ]
   },
@@ -301,17 +210,11 @@
     "officialSite": "",
     "begin": "2011-03-22T16:00:00.000Z",
     "end": "2011-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "41120",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -331,7 +234,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2011_precure_allstars/",
     "begin": "2011-03-19T16:00:00.000Z",
     "end": "2011-03-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -340,22 +242,12 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   },
@@ -371,7 +263,6 @@
     "officialSite": "http://www.jump-heroesfilm.com/",
     "begin": "2011-03-19T16:00:00.000Z",
     "end": "2011-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -392,27 +283,16 @@
     "officialSite": "http://www.mtvjapan.com/usavich/",
     "begin": "2011-03-26T16:00:00.000Z",
     "end": "2011-09-15T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GxD8euJIuPZZ1z8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha81ux",
-        "begin": "2016-12-13T09:02:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-13T09:02:47.000Z"
       },
       {
         "site": "bangumi",
@@ -432,7 +312,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2011-03-28T08:35:00.000Z",
     "end": "2011-09-12T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -452,17 +331,11 @@
     "officialSite": "http://saiyuki-gaiden.com/",
     "begin": "2011-03-25T16:00:00.000Z",
     "end": "2011-11-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sPvFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -471,22 +344,12 @@
       {
         "site": "nicovideo",
         "id": "saiyuki-gaiden",
-        "begin": "2014-03-24T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-24T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2147",
-        "begin": "2011-03-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-03-24T16:00:00.000Z"
       }
     ]
   },
@@ -502,7 +365,6 @@
     "officialSite": "",
     "begin": "2011-03-03T16:00:00.000Z",
     "end": "2012-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -511,22 +373,12 @@
       {
         "site": "pptv",
         "id": "Zb6aGIDmVpT3dd0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5067",
-        "begin": "2011-03-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-03-02T16:00:01.000Z"
       }
     ]
   },
@@ -538,7 +390,6 @@
     "officialSite": "http://www.nhk.or.jp/kids/program/pakkororin.html",
     "begin": "2011-03-28T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -547,12 +398,7 @@
       {
         "site": "nicovideo",
         "id": "pakkororin",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2011/04.json
+++ b/data/items/2011/04.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.moshidora.tv/",
     "begin": "2011-04-25T13:55:00.000Z",
     "end": "2011-05-06T14:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cbqGBGzSQoDjYck",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,7 +35,6 @@
     "officialSite": "http://www.mariaholic.com/",
     "begin": "2011-04-07T17:15:00.000Z",
     "end": "2011-06-23T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,22 +43,12 @@
       {
         "site": "nicovideo",
         "id": "ch60017",
-        "begin": "2011-04-22T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-22T12:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "921",
-        "begin": "2011-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -81,7 +64,6 @@
     "officialSite": "http://kc.kodansha.co.jp/hensemi/",
     "begin": "2011-04-08T14:15:00.000Z",
     "end": "2011-07-01T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -90,12 +72,7 @@
       {
         "site": "nicovideo",
         "id": "ch60012",
-        "begin": "2011-04-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-11T14:30:00.000Z"
       }
     ]
   },
@@ -111,27 +88,16 @@
     "officialSite": "http://www.shinonome-lab.com/",
     "begin": "2011-04-02T17:20:00.000Z",
     "end": "2011-09-24T18:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "0/0vl60i78k9w8qoe",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "844",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,12 +106,7 @@
       {
         "site": "nicovideo",
         "id": "ch60005",
-        "begin": "2017-01-08T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T04:00:00.000Z"
       }
     ]
   },
@@ -161,7 +122,6 @@
     "officialSite": "http://30sai.jp/",
     "begin": "2011-04-06T18:00:00.000Z",
     "end": "2011-06-22T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,12 +130,7 @@
       {
         "site": "nicovideo",
         "id": "ch60007",
-        "begin": "2011-04-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-08T15:30:00.000Z"
       }
     ]
   },
@@ -191,17 +146,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/hyouge/",
     "begin": "2011-04-07T14:00:00.000Z",
     "end": "2012-01-26T14:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibDELiafFXxwVo5k4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -210,12 +159,7 @@
       {
         "site": "bilibili",
         "id": "929",
-        "begin": "2011-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -231,17 +175,11 @@
     "officialSite": "http://www.starchild.co.jp/special/dororon-enmakun/",
     "begin": "2011-04-07T17:05:00.000Z",
     "end": "2011-06-23T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GVMtqxN56SeKCHA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -250,22 +188,7 @@
       {
         "site": "nicovideo",
         "id": "ch60011",
-        "begin": "2011-04-17T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "941",
-        "begin": "2011-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-17T14:30:00.000Z"
       }
     ]
   },
@@ -281,7 +204,6 @@
     "officialSite": "http://www.rotte-omocha.com/",
     "begin": "2011-04-10T16:30:00.000Z",
     "end": "2011-06-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -290,12 +212,7 @@
       {
         "site": "nicovideo",
         "id": "ch60010",
-        "begin": "2011-04-18T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-18T03:00:00.000Z"
       }
     ]
   },
@@ -311,7 +228,6 @@
     "officialSite": "http://www.qwaser.jp/",
     "begin": "2011-04-11T17:30:00.000Z",
     "end": "2011-06-27T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -334,37 +250,21 @@
     "officialSite": "http://www.ao-ex.com/tv/index2.html",
     "begin": "2011-04-17T08:00:00.000Z",
     "end": "2011-10-02T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uicXPTbUbia8ksqhI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "t/tk8rb24s5sx9p4u",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10032034",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -373,32 +273,17 @@
       {
         "site": "nicovideo",
         "id": "ao-ex",
-        "begin": "2012-08-08T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-08T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70304252",
-        "begin": "2017-03-02T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-02T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "861",
-        "begin": "2011-04-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-16T16:00:00.000Z"
       }
     ]
   },
@@ -417,7 +302,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/aria/",
     "begin": "2011-04-14T16:40:00.000Z",
     "end": "2011-06-30T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -426,22 +310,12 @@
       {
         "site": "nicovideo",
         "id": "hidannoaria",
-        "begin": "2011-09-29T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-29T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2993",
-        "begin": "2011-04-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-13T16:00:00.000Z"
       }
     ]
   },
@@ -457,7 +331,6 @@
     "officialSite": "http://prettyrhythm.dive2ent.com/",
     "begin": "2011-04-09T01:00:00.000Z",
     "end": "2012-03-31T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -466,12 +339,7 @@
       {
         "site": "nicovideo",
         "id": "prettyrhythm_n",
-        "begin": "2012-09-28T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-28T11:00:00.000Z"
       }
     ]
   },
@@ -490,17 +358,11 @@
     "officialSite": "http://www.a-ch.jp/",
     "begin": "2011-04-07T16:35:00.000Z",
     "end": "2011-06-23T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9TwIhu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -509,22 +371,12 @@
       {
         "site": "nicovideo",
         "id": "ch60015",
-        "begin": "2011-04-18T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-18T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "915",
-        "begin": "2011-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -541,47 +393,26 @@
     "officialSite": "http://www.hanasakuiroha.jp/",
     "begin": "2011-04-03T13:00:00.000Z",
     "end": "2011-09-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hrqFA2vRQXiciaYMg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk8ckhp",
-        "begin": "2014-04-09T23:06:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:06:23.000Z"
       },
       {
         "site": "qq",
         "id": "h/hfkua5bftt1i1gu",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2012/hkwy",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -590,22 +421,12 @@
       {
         "site": "nicovideo",
         "id": "ch60008",
-        "begin": "2011-04-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-09T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "845",
-        "begin": "2011-04-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -621,7 +442,6 @@
     "officialSite": "http://sekai-ichi.jp/",
     "begin": "2011-04-08T16:05:00.000Z",
     "end": "2011-06-24T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -641,17 +461,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/denpa/",
     "begin": "2011-04-14T17:10:00.000Z",
     "end": "2015-02-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "k92nJY3zY6EEguo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -660,12 +474,7 @@
       {
         "site": "bilibili",
         "id": "846",
-        "begin": "2011-04-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-13T16:00:00.000Z"
       }
     ]
   },
@@ -681,7 +490,6 @@
     "officialSite": "http://sengokuotome.com/",
     "begin": "2011-04-04T17:00:00.000Z",
     "end": "2011-06-27T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -701,7 +509,6 @@
     "officialSite": "http://kaminomi.jp/",
     "begin": "2011-04-11T16:45:00.000Z",
     "end": "2011-06-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -710,12 +517,7 @@
       {
         "site": "nicovideo",
         "id": "kaminomi2",
-        "begin": "2013-07-12T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-12T06:00:00.000Z"
       }
     ]
   },
@@ -731,17 +533,11 @@
     "officialSite": "http://www.maql.co.jp/special/hoshikaka/",
     "begin": "2011-04-11T00:00:00.000Z",
     "end": "2011-06-27T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "M31HxS2TA0GkIoo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -750,22 +546,12 @@
       {
         "site": "nicovideo",
         "id": "ch60018",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "919",
-        "begin": "2011-04-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-10T16:00:00.000Z"
       }
     ]
   },
@@ -781,17 +567,11 @@
     "officialSite": "http://www.maql.co.jp/special/oretsuba/",
     "begin": "2011-04-03T15:30:00.000Z",
     "end": "2011-06-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gLiaDAWnPP33gXsY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -800,12 +580,7 @@
       {
         "site": "nicovideo",
         "id": "ch60019",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -821,37 +596,16 @@
     "officialSite": "http://steinsgate.tv/",
     "begin": "2011-04-03T13:00:00.000Z",
     "end": "2011-09-13T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hLyHBW3TQ4HkYso",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "60612",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "40912",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -860,22 +614,12 @@
       {
         "site": "nicovideo",
         "id": "ch60001",
-        "begin": "2011-04-07T04:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-07T04:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "g/gu5m5d0ccelhqw9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -891,17 +635,11 @@
     "officialSite": "http://www.softenni.com/",
     "begin": "2011-04-07T17:30:00.000Z",
     "end": "2011-06-23T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DkA8uiaKIibDaZF38",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -910,22 +648,12 @@
       {
         "site": "nicovideo",
         "id": "ch60009",
-        "begin": "2011-04-10T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-10T13:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "933",
-        "begin": "2011-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -941,7 +669,6 @@
     "officialSite": "http://sketdance.jp/",
     "begin": "2011-04-07T09:00:00.000Z",
     "end": "2012-09-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -964,27 +691,16 @@
     "officialSite": "http://www.dogdays.tv/1st/",
     "begin": "2011-04-02T14:30:00.000Z",
     "end": "2011-06-25T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "f8OibPKQKergbmQE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "40865",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -993,22 +709,12 @@
       {
         "site": "nicovideo",
         "id": "ch60022",
-        "begin": "2011-05-20T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-05-20T17:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1631",
-        "begin": "2011-04-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -1024,7 +730,6 @@
     "officialSite": "http://kc.kodansha.co.jp/azazel/1st/",
     "begin": "2011-04-08T14:00:00.000Z",
     "end": "2011-07-01T14:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1033,22 +738,7 @@
       {
         "site": "nicovideo",
         "id": "ch60014",
-        "begin": "2011-04-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "566",
-        "begin": "2011-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-11T14:30:00.000Z"
       }
     ]
   },
@@ -1065,27 +755,16 @@
     "officialSite": "http://www.tigerandbunny.net/tv/index.html",
     "begin": "2011-04-02T16:58:00.000Z",
     "end": "2011-09-17T17:43:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/ozq3fih3howyni3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "41020",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1094,22 +773,12 @@
       {
         "site": "netflix",
         "id": "80039972",
-        "begin": "2017-10-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-15T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3332",
-        "begin": "2011-04-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-01T16:00:01.000Z"
       }
     ]
   },
@@ -1128,7 +797,6 @@
     "officialSite": "http://dwl.jp/",
     "begin": "2011-04-16T16:00:00.000Z",
     "end": "2011-07-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1137,12 +805,7 @@
       {
         "site": "nicovideo",
         "id": "ch60013",
-        "begin": "2011-04-23T04:30:30.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-23T04:30:30.000Z"
       }
     ]
   },
@@ -1158,27 +821,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/jp-sunshine/",
     "begin": "2011-04-09T00:30:00.000Z",
     "end": "2012-03-30T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WJJu7FS6KmjLSbE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "41855",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1187,12 +839,7 @@
       {
         "site": "bilibili",
         "id": "124",
-        "begin": "2011-04-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-08T16:00:00.000Z"
       }
     ]
   },
@@ -1208,17 +855,11 @@
     "officialSite": "http://www.anohana.jp/tv/",
     "begin": "2011-04-14T16:35:00.000Z",
     "end": "2011-06-23T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "41908",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1227,12 +868,7 @@
       {
         "site": "bilibili",
         "id": "835",
-        "begin": "2011-04-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-13T16:00:00.000Z"
       }
     ]
   },
@@ -1248,17 +884,11 @@
     "officialSite": "http://www.disneychannel.jp/dc/program/anime/fireball/",
     "begin": "2011-04-04T10:27:00.000Z",
     "end": "2011-06-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jLSPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1267,12 +897,7 @@
       {
         "site": "bilibili",
         "id": "2885",
-        "begin": "2011-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -1290,27 +915,16 @@
     "officialSite": "http://www.noitamina-control.jp/",
     "begin": "2011-04-14T16:05:00.000Z",
     "end": "2011-06-23T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ktyoJo70ZKIFgibs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "41887",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1330,21 +944,10 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yugioh-zexal/",
     "begin": "2011-04-11T10:30:00.000Z",
     "end": "2012-09-24T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "10760"
-      },
-      {
-        "site": "bilibili",
-        "id": "159",
-        "begin": "2011-04-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1361,17 +964,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/toriko/",
     "begin": "2011-04-03T00:00:00.000Z",
     "end": "2014-03-30T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1dv1",
-        "begin": "2015-08-15T06:29:54.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-15T06:29:54.000Z"
       },
       {
         "site": "bangumi",
@@ -1391,7 +988,6 @@
     "officialSite": "http://www.toei-anim.co.jp/sp/rin-kake1_wcs/",
     "begin": "2011-04-10T12:00:00.000Z",
     "end": "2011-06-12T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1414,27 +1010,11 @@
     "officialSite": "http://www.animax.co.jp/marvelanime/x-men/",
     "begin": "2011-04-01T13:00:00.000Z",
     "end": "2011-06-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "g7eSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464479",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1443,22 +1023,12 @@
       {
         "site": "bilibili",
         "id": "944",
-        "begin": "2011-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-03-31T16:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "4/47g5ytgl5rfww1v",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1474,7 +1044,6 @@
     "officialSite": "http://www.ntv.co.jp/kaiji_hakairoku/",
     "begin": "2011-04-05T16:29:00.000Z",
     "end": "2011-09-27T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1483,12 +1052,7 @@
       {
         "site": "nicovideo",
         "id": "kaiji2_anime",
-        "begin": "2014-04-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-01T06:00:00.000Z"
       }
     ]
   },
@@ -1504,17 +1068,11 @@
     "officialSite": "http://tono-anime.com/",
     "begin": "2011-04-04T17:49:00.000Z",
     "end": "2011-06-20T17:19:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MXtFwyuRATibiaIIg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1523,12 +1081,7 @@
       {
         "site": "bilibili",
         "id": "937",
-        "begin": "2011-04-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -1544,7 +1097,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mf-beyblade/",
     "begin": "2011-04-02T23:30:00.000Z",
     "end": "2012-03-31T23:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1564,7 +1116,6 @@
     "officialSite": "http://www.j-gintama.com/",
     "begin": "2011-04-04T09:00:00.000Z",
     "end": "2012-03-26T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1573,12 +1124,7 @@
       {
         "site": "nicovideo",
         "id": "gintama-dash",
-        "begin": "2015-05-15T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-15T06:00:00.000Z"
       }
     ]
   },
@@ -1594,7 +1140,6 @@
     "officialSite": "http://www.hamutaro.com/",
     "begin": "2011-04-02T00:00:00.000Z",
     "end": "2012-03-31T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1614,7 +1159,6 @@
     "officialSite": "http://www.jvcmusic.co.jp/fujilog/",
     "begin": "2011-04-04T10:55:00.000Z",
     "end": "2011-06-27T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1634,7 +1178,6 @@
     "officialSite": "http://ntvg-tv.jp/yuruani/",
     "begin": "2011-04-12T16:54:00.000Z",
     "end": "2011-09-13T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1643,12 +1186,7 @@
       {
         "site": "nicovideo",
         "id": "yuruani",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1667,7 +1205,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/duelmastersv/index.html",
     "begin": "2011-04-01T23:15:00.000Z",
     "end": "2012-03-30T23:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1687,7 +1224,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/kenpu/",
     "begin": "2011-04-07T16:30:00.000Z",
     "end": "2011-04-07T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1707,17 +1243,11 @@
     "officialSite": "http://www.onigamiden.jp/",
     "begin": "2011-04-29T16:00:00.000Z",
     "end": "2011-04-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "48840",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1737,7 +1267,6 @@
     "officialSite": "http://wwws.warnerbros.co.jp/tofukozo/",
     "begin": "2011-04-29T16:00:00.000Z",
     "end": "2011-04-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1757,27 +1286,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2011-04-16T16:00:00.000Z",
     "end": "2011-04-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20130715/99761270d71f8fc1.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20130715/99761270d71f8fc1.html"
       },
       {
         "site": "bangumi",
@@ -1786,22 +1304,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3892",
-        "begin": "2011-04-15T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "14532",
+        "begin": "2011-04-15T16:00:01.000Z"
       }
     ]
   },
@@ -1817,17 +1325,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2011-04-16T16:00:00.000Z",
     "end": "2011-04-16T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -1836,22 +1338,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1867,17 +1359,11 @@
     "officialSite": "http://ntvg-tv.jp/yuruani/",
     "begin": "2011-04-12T16:00:00.000Z",
     "end": "2011-09-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5yYiaoAhu3hxicicWU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1886,12 +1372,7 @@
       {
         "site": "bilibili",
         "id": "938",
-        "begin": "2011-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -1907,17 +1388,11 @@
     "officialSite": "http://www.tbs.co.jp/suzyzoo/",
     "begin": "2011-04-03T16:00:00.000Z",
     "end": "2011-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wgcBfibdNvfte3EQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1926,12 +1401,7 @@
       {
         "site": "bilibili",
         "id": "945",
-        "begin": "2011-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -1947,7 +1417,6 @@
     "officialSite": "",
     "begin": "2011-04-15T16:00:00.000Z",
     "end": "2013-10-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1956,12 +1425,7 @@
       {
         "site": "nicovideo",
         "id": "seitokai_banngaihen",
-        "begin": "2017-06-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T03:00:00.000Z"
       }
     ]
   }

--- a/data/items/2011/05.json
+++ b/data/items/2011/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/inazumago/",
     "begin": "2011-05-04T10:00:00.000Z",
     "end": "2012-04-11T10:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "42560",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgjddhh",
-        "begin": "2013-12-31T07:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-31T07:10:00.000Z"
       }
     ]
   },
@@ -51,27 +40,16 @@
     "officialSite": "http://www.hoshi-o-kodomo.jp/",
     "begin": "2011-05-07T16:00:00.000Z",
     "end": "2011-05-07T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": "",
         "url": "http://www.iqiyi.com/v_19rrk78dhk.html"
       },
       {
         "site": "letv",
         "id": "87681",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -91,7 +69,6 @@
     "officialSite": "http://wwws.warnerbros.co.jp/buddha/",
     "begin": "2011-05-28T16:00:00.000Z",
     "end": "2011-05-28T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -111,17 +88,11 @@
     "officialSite": "",
     "begin": "2011-05-06T16:00:00.000Z",
     "end": "2012-08-22T16:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "n8mzMZnicb60QjvY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -130,22 +101,12 @@
       {
         "site": "bilibili",
         "id": "930",
-        "begin": "2011-05-06T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-05-06T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "44251",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -161,17 +122,11 @@
     "officialSite": "http://www.starchild.co.jp/special/kaizo/",
     "begin": "2011-05-25T16:00:00.000Z",
     "end": "2011-05-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pOjUUrogkM4xrxc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2011/06.json
+++ b/data/items/2011/06.json
@@ -14,27 +14,16 @@
     "officialSite": "http://appleseed13.jp/",
     "begin": "2011-06-03T14:00:00.000Z",
     "end": "2012-02-03T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JXVPzTWbC0msKpI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "44683",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -43,12 +32,7 @@
       {
         "site": "nicovideo",
         "id": "ch60024",
-        "begin": "2011-06-23T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-06-23T15:00:00.000Z"
       }
     ]
   },
@@ -64,17 +48,11 @@
     "officialSite": "http://valkyria3-anime.sega.jp/",
     "begin": "2011-06-29T16:00:00.000Z",
     "end": "2011-06-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sic3HRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -94,7 +72,6 @@
     "officialSite": "http://tokai-tv.com/anime/19981231_anime_8352.php",
     "begin": "2011-06-06T16:00:00.000Z",
     "end": "2014-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -103,12 +80,7 @@
       {
         "site": "nicovideo",
         "id": "kayochu",
-        "begin": "2011-10-07T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-07T06:00:00.000Z"
       }
     ]
   },
@@ -124,7 +96,6 @@
     "officialSite": "http://www.towanoquon.com/",
     "begin": "2011-06-18T16:00:00.000Z",
     "end": "2011-06-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -133,12 +104,7 @@
       {
         "site": "letv",
         "id": "46312",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2011/07.json
+++ b/data/items/2011/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://yuruyuri.com/1st/",
     "begin": "2011-07-04T17:00:00.000Z",
     "end": "2011-09-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "yuruyuri",
-        "begin": "2011-07-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-11T15:30:00.000Z"
       }
     ]
   },
@@ -44,47 +38,26 @@
     "officialSite": "http://www.idolmaster-anime.jp/tv/index2.html",
     "begin": "2011-07-07T17:10:00.000Z",
     "end": "2012-06-16T19:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8RicpZ881peNGxCw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaxy5x",
-        "begin": "2015-01-14T01:26:56.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-14T01:26:56.000Z"
       },
       {
         "site": "qq",
         "id": "0/0qoarswaom7cfu4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "45084",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -93,22 +66,12 @@
       {
         "site": "nicovideo",
         "id": "idolmaster-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2684",
-        "begin": "2011-07-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-06T16:00:00.000Z"
       }
     ]
   },
@@ -127,7 +90,6 @@
     "officialSite": "http://www.blood-c.jp/",
     "begin": "2011-07-07T16:55:00.000Z",
     "end": "2011-09-29T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -136,12 +98,7 @@
       {
         "site": "nicovideo",
         "id": "blood-c",
-        "begin": "2011-07-13T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-13T18:00:00.000Z"
       }
     ]
   },
@@ -160,17 +117,11 @@
     "officialSite": "http://www.kamisama-anime.jp/",
     "begin": "2011-07-05T16:30:00.000Z",
     "end": "2011-09-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yRfxb9c9retOzDQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -179,32 +130,17 @@
       {
         "site": "nicovideo",
         "id": "kamisama-anime",
-        "begin": "2011-07-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-17T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "898",
-        "begin": "2011-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-04T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "44978",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -223,21 +159,10 @@
     "officialSite": "http://www.tbs.co.jp/anime/mayochiki/",
     "begin": "2011-07-07T17:40:00.000Z",
     "end": "2011-09-29T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "10459"
-      },
-      {
-        "site": "bilibili",
-        "id": "853",
-        "begin": "2011-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -253,17 +178,11 @@
     "officialSite": "http://www.nyanpire.jp/",
     "begin": "2011-07-06T13:54:00.000Z",
     "end": "2011-09-21T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4C4amABm1hR39V0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -272,12 +191,7 @@
       {
         "site": "bilibili",
         "id": "907",
-        "begin": "2011-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -293,27 +207,11 @@
     "officialSite": "http://archive1000.utapri.tv/",
     "begin": "2011-07-02T15:00:00.000Z",
     "end": "2011-09-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "44837",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "3390",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -322,32 +220,17 @@
       {
         "site": "nicovideo",
         "id": "utapri",
-        "begin": "2011-07-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-04T19:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1mtk5",
-        "begin": "2017-11-01T09:34:20.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-01T09:34:20.000Z"
       },
       {
         "site": "bilibili",
         "id": "1561",
-        "begin": "2011-07-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -366,17 +249,11 @@
     "officialSite": "http://dantalian.tv/",
     "begin": "2011-07-15T16:23:00.000Z",
     "end": "2011-09-30T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AE85txibF9TOWFHw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -385,12 +262,7 @@
       {
         "site": "bilibili",
         "id": "862",
-        "begin": "2011-07-14T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-14T16:00:00.000Z"
       }
     ]
   },
@@ -406,17 +278,11 @@
     "officialSite": "http://twin-angel.tv/",
     "begin": "2011-07-04T16:45:00.000Z",
     "end": "2011-09-19T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3w33dd1DsicFU0jo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -425,22 +291,12 @@
       {
         "site": "nicovideo",
         "id": "twin-angel",
-        "begin": "2011-07-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-08T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "45008",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -456,17 +312,11 @@
     "officialSite": "http://www.bakatest.com/",
     "begin": "2011-07-07T17:15:00.000Z",
     "end": "2011-09-29T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7z0Hhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -475,22 +325,12 @@
       {
         "site": "nicovideo",
         "id": "bakatest2",
-        "begin": "2011-07-15T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-15T03:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "843",
-        "begin": "2011-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-06T16:00:00.000Z"
       }
     ]
   },
@@ -506,7 +346,6 @@
     "officialSite": "http://www.maql.co.jp/special/nekogami/",
     "begin": "2011-07-08T23:30:00.000Z",
     "end": "2011-09-24T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -515,32 +354,17 @@
       {
         "site": "nicovideo",
         "id": "nekogami",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "45154",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "904",
-        "begin": "2011-07-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-08T16:00:00.000Z"
       }
     ]
   },
@@ -556,27 +380,16 @@
     "officialSite": "http://ikokumeiro.com/",
     "begin": "2011-07-03T15:30:00.000Z",
     "end": "2011-09-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kL6KCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "44865",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -585,22 +398,12 @@
       {
         "site": "nicovideo",
         "id": "ikokumeiro",
-        "begin": "2011-07-19T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-19T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3433",
-        "begin": "2011-07-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-02T16:00:01.000Z"
       }
     ]
   },
@@ -616,27 +419,16 @@
     "officialSite": "http://www.kamimemo.com/",
     "begin": "2011-07-02T14:00:00.000Z",
     "end": "2011-09-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iatiakIorwYJ4Bfibc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk77p5x",
-        "begin": "2012-09-01T10:01:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-01T10:01:05.000Z"
       },
       {
         "site": "bangumi",
@@ -645,22 +437,12 @@
       {
         "site": "nicovideo",
         "id": "kamimemo",
-        "begin": "2011-07-14T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-14T03:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "897",
-        "begin": "2011-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -679,27 +461,16 @@
     "officialSite": "http://www.ro-kyu-bu.com/1st/",
     "begin": "2011-07-01T14:30:00.000Z",
     "end": "2011-09-23T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "htSwLpb8bKoNiaicM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgi9sax",
-        "begin": "2014-06-11T03:27:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-06-11T03:27:46.000Z"
       },
       {
         "site": "bangumi",
@@ -708,22 +479,12 @@
       {
         "site": "nicovideo",
         "id": "ro-kyu-bu",
-        "begin": "2011-07-16T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-16T03:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2682",
-        "begin": "2011-06-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -742,7 +503,6 @@
     "officialSite": "http://kadokawa-anime.jp/itsu-ten/",
     "begin": "2011-07-08T16:05:00.000Z",
     "end": "2011-09-23T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -751,22 +511,7 @@
       {
         "site": "nicovideo",
         "id": "itsu-ten",
-        "begin": "2011-07-15T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "902",
-        "begin": "2011-07-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-15T17:00:00.000Z"
       }
     ]
   },
@@ -783,57 +528,31 @@
     "officialSite": "http://www.nasinc.co.jp/jp/natsume-anime/",
     "begin": "2011-07-04T16:30:00.000Z",
     "end": "2011-09-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rvzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjpu3yl",
-        "begin": "2013-03-06T01:12:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-06T01:12:09.000Z"
       },
       {
         "site": "qq",
         "id": "3/30m0u3k41os7s5d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "44936",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/xmyrz3",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -842,22 +561,12 @@
       {
         "site": "nicovideo",
         "id": "natsume3",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1662",
-        "begin": "2011-07-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -873,17 +582,11 @@
     "officialSite": "http://www.capcom.co.jp/monsterhunter/pokapoka_airuG/anime.html",
     "begin": "2011-07-01T13:54:00.000Z",
     "end": "2011-09-29T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NWVf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -892,12 +595,7 @@
       {
         "site": "bilibili",
         "id": "912",
-        "begin": "2011-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -916,17 +614,11 @@
     "officialSite": "http://www.sacred7.jp/",
     "begin": "2011-07-02T17:28:00.000Z",
     "end": "2011-09-16T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jdulI4vxYZ8CgOg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -935,12 +627,7 @@
       {
         "site": "bilibili",
         "id": "901",
-        "begin": "2011-07-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -956,7 +643,6 @@
     "officialSite": "http://oppaidaisuki.jp/",
     "begin": "2011-07-10T16:00:00.000Z",
     "end": "2011-09-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -979,47 +665,26 @@
     "officialSite": "http://www.nuramago.jp/",
     "begin": "2011-07-03T08:30:00.000Z",
     "end": "2011-12-18T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kbibJB2icVRYPmZMw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzlgy9",
-        "begin": "2012-07-01T06:24:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:24:47.000Z"
       },
       {
         "site": "qq",
         "id": "y/ycyf0eg8qkroxrp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "44862",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1028,22 +693,12 @@
       {
         "site": "netflix",
         "id": "80040089",
-        "begin": "2016-12-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-01T08:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "900",
-        "begin": "2011-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-02T16:00:00.000Z"
       }
     ]
   },
@@ -1059,17 +714,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_moritasan/",
     "begin": "2011-07-05T16:30:00.000Z",
     "end": "2011-09-27T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iabGMCnLYSIbpZ88",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1078,12 +727,7 @@
       {
         "site": "nicovideo",
         "id": "moritasan",
-        "begin": "2011-07-07T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-07T16:30:00.000Z"
       }
     ]
   },
@@ -1102,7 +746,6 @@
     "officialSite": "http://kadokawa-anime.jp/R-15/",
     "begin": "2011-07-09T16:00:00.000Z",
     "end": "2011-09-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1111,12 +754,7 @@
       {
         "site": "nicovideo",
         "id": "R-15",
-        "begin": "2011-07-19T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-19T16:00:00.000Z"
       }
     ]
   },
@@ -1132,47 +770,26 @@
     "officialSite": "http://www.usagi-drop.tv/",
     "begin": "2011-07-07T16:00:00.000Z",
     "end": "2011-09-15T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8iaAcmgJo2BZ5918",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "48902",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "291730",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "893",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1192,17 +809,11 @@
     "officialSite": "http://www.no-6.jp/",
     "begin": "2011-07-07T16:30:00.000Z",
     "end": "2011-09-15T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "45101",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1225,7 +836,6 @@
     "officialSite": "http://penguindrum.jp/",
     "begin": "2011-07-07T17:25:00.000Z",
     "end": "2011-12-22T17:39:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1234,12 +844,7 @@
       {
         "site": "nicovideo",
         "id": "penguindrum",
-        "begin": "2011-08-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-08-11T15:30:00.000Z"
       }
     ]
   },
@@ -1255,41 +860,20 @@
     "officialSite": "http://www.animax.co.jp/marvelanime/blade/",
     "begin": "2011-07-01T16:00:00.000Z",
     "end": "2011-09-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iaNayMJjibbqwPjfU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/blade",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "10601"
-      },
-      {
-        "site": "bilibili",
-        "id": "909",
-        "begin": "2011-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1305,17 +889,11 @@
     "officialSite": "http://baby-princess3d.jp/",
     "begin": "2011-07-20T16:00:00.000Z",
     "end": "2011-07-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "45645",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1335,27 +913,16 @@
     "officialSite": "http://www.kokurikozaka.jp/",
     "begin": "2011-07-16T16:00:00.000Z",
     "end": "2011-07-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9spg5",
-        "begin": "2017-01-24T08:06:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T08:06:01.000Z"
       },
       {
         "site": "letv",
         "id": "78631",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1375,37 +942,21 @@
     "officialSite": "http://www.pokemon-movie.jp/white/",
     "begin": "2011-07-16T16:00:00.000Z",
     "end": "2011-07-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "74292",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1414,22 +965,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4475",
-        "begin": "2011-07-15T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-15T16:00:01.000Z"
       }
     ]
   },
@@ -1445,37 +986,21 @@
     "officialSite": "http://www.pokemon-movie.jp/white/",
     "begin": "2011-07-16T16:00:00.000Z",
     "end": "2011-07-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "74292",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1484,22 +1009,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4477",
-        "begin": "2011-07-15T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-15T16:00:01.000Z"
       }
     ]
   },
@@ -1515,18 +1030,7 @@
     "officialSite": "http://www.naruto-movie.com/",
     "begin": "2011-07-30T16:00:00.000Z",
     "end": "2011-07-30T17:50:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "65773",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "33514"
@@ -1534,12 +1038,7 @@
       {
         "site": "netflix",
         "id": "80152537",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   },
@@ -1555,7 +1054,6 @@
     "officialSite": "http://www.oyashirosama.com/web/kira/index.html",
     "begin": "2011-07-21T16:00:00.000Z",
     "end": "2012-01-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1564,12 +1062,7 @@
       {
         "site": "nicovideo",
         "id": "oyashirosama04",
-        "begin": "2017-06-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-16T15:00:00.000Z"
       }
     ]
   },
@@ -1585,7 +1078,6 @@
     "officialSite": "http://www.hagaren.jp",
     "begin": "2011-07-02T16:00:00.000Z",
     "end": "2011-07-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1594,32 +1086,17 @@
       {
         "site": "nicovideo",
         "id": "hagaren-milos",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1090",
-        "begin": "2011-07-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-07-01T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "71857",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1635,7 +1112,6 @@
     "officialSite": "http://www.towanoquon.com",
     "begin": "2011-07-16T16:00:00.000Z",
     "end": "2011-07-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1644,12 +1120,7 @@
       {
         "site": "letv",
         "id": "46312",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2011/08.json
+++ b/data/items/2011/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://kakokawa.com/",
     "begin": "2011-08-26T09:55:00.000Z",
     "end": "2011-10-28T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -32,37 +31,21 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/hakuoki/",
     "begin": "2011-08-05T16:00:00.000Z",
     "end": "2012-06-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ia9exL5f9basOjPQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzlxfh",
-        "begin": "2012-07-01T06:23:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:23:59.000Z"
       },
       {
         "site": "letv",
         "id": "47164",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,12 +54,7 @@
       {
         "site": "bilibili",
         "id": "764",
-        "begin": "2011-08-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-08-04T16:00:00.000Z"
       }
     ]
   },
@@ -92,27 +70,16 @@
     "officialSite": "http://www.typemoon.com/products/cp/index.html",
     "begin": "2011-08-14T16:00:00.000Z",
     "end": "2012-12-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LHxIxia6UBEKlI4s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "46478",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -121,12 +88,7 @@
       {
         "site": "bilibili",
         "id": "1732",
-        "begin": "2011-08-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-08-13T16:00:00.000Z"
       }
     ]
   },
@@ -142,17 +104,11 @@
     "officialSite": "http://manpukujinja.blog135.fc2.com/",
     "begin": "2011-08-13T16:00:00.000Z",
     "end": "2011-08-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "46494",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -172,7 +128,6 @@
     "officialSite": "http://www.hayate-project.com/",
     "begin": "2011-08-27T16:00:00.000Z",
     "end": "2011-08-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -181,22 +136,7 @@
       {
         "site": "nicovideo",
         "id": "hayate-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "6067",
-        "begin": "2011-08-26T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -212,7 +152,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2011-08-01T17:10:00.000Z",
     "end": "2011-08-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -232,17 +171,11 @@
     "officialSite": "http://copihan.com",
     "begin": "2011-08-11T16:00:00.000Z",
     "end": "2011-11-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GEkzsRlic7y2QDnY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -251,22 +184,12 @@
       {
         "site": "nicovideo",
         "id": "copihan",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "910",
-        "begin": "2011-08-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-08-10T16:00:00.000Z"
       }
     ]
   },
@@ -282,17 +205,11 @@
     "officialSite": "http://milky-holmes.com/anime/",
     "begin": "2011-08-25T16:00:00.000Z",
     "end": "2011-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tOTgXsYsnNo9uyM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -301,12 +218,7 @@
       {
         "site": "letv",
         "id": "46989",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -322,7 +234,6 @@
     "officialSite": "http://www.negihaya.com/index.html",
     "begin": "2011-08-27T16:00:00.000Z",
     "end": "2011-08-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -331,22 +242,12 @@
       {
         "site": "nicovideo",
         "id": "negima-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3775",
-        "begin": "2011-08-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-08-26T16:00:01.000Z"
       }
     ]
   },
@@ -362,7 +263,6 @@
     "officialSite": "http://www.towanoquon.com",
     "begin": "2011-08-13T16:00:00.000Z",
     "end": "2011-08-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -371,12 +271,7 @@
       {
         "site": "letv",
         "id": "46312",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2011/09.json
+++ b/data/items/2011/09.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www.wagnaria.com/2nd/",
     "begin": "2011-09-03T14:30:00.000Z",
     "end": "2011-12-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "47403",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -33,22 +27,12 @@
       {
         "site": "nicovideo",
         "id": "working-02",
-        "begin": "2011-10-08T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-08T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "867",
-        "begin": "2011-09-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-03T14:30:00.000Z"
       }
     ]
   },
@@ -67,7 +51,6 @@
     "officialSite": "http://www.ika-musume.com/",
     "begin": "2011-09-26T17:00:00.000Z",
     "end": "2011-12-26T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -76,12 +59,7 @@
       {
         "site": "nicovideo",
         "id": "ikamusume-02",
-        "begin": "2011-10-03T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-03T15:30:00.000Z"
       }
     ]
   },
@@ -100,7 +78,6 @@
     "officialSite": "http://www.nagoyatv.com/battlespirits_heroes/",
     "begin": "2011-09-17T22:00:00.000Z",
     "end": "2012-09-01T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -120,17 +97,11 @@
     "officialSite": "http://www.hotarubi.info/",
     "begin": "2011-09-17T16:00:00.000Z",
     "end": "2011-09-17T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/dongman/20120626/ece98897b70d6a00.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/dongman/20120626/ece98897b70d6a00.html"
       },
       {
         "site": "bangumi",
@@ -150,17 +121,11 @@
     "officialSite": "http://www.busou.konami.jp/",
     "begin": "2011-09-22T16:00:00.000Z",
     "end": "2011-09-22T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xhDsatI4qOZJxy8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -169,12 +134,7 @@
       {
         "site": "bilibili",
         "id": "740",
-        "begin": "2011-09-21T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-21T16:00:00.000Z"
       }
     ]
   },
@@ -190,7 +150,6 @@
     "officialSite": "http://www.towanoquon.com",
     "begin": "2011-09-10T16:00:00.000Z",
     "end": "2011-09-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -199,12 +158,7 @@
       {
         "site": "letv",
         "id": "46312",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2011/10.json
+++ b/data/items/2011/10.json
@@ -16,47 +16,26 @@
     "officialSite": "http://www.ntv.co.jp/hunterhunter/",
     "begin": "2011-10-02T01:55:00.000Z",
     "end": "2014-09-23T16:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WIlz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9my1p",
-        "begin": "2016-08-26T02:54:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-26T02:54:40.000Z"
       },
       {
         "site": "letv",
         "id": "49119",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2012/hunter",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -79,17 +58,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/hidamari/",
     "begin": "2011-10-29T16:30:00.000Z",
     "end": "2011-11-05T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IHNNyzOZCUeqKJA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -98,22 +71,12 @@
       {
         "site": "bilibili",
         "id": "3825",
-        "begin": "2011-10-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-28T16:00:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7o0lx",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -132,17 +95,11 @@
     "officialSite": "http://www.lastexile-fam.com/",
     "begin": "2011-10-14T17:00:00.000Z",
     "end": "2012-03-23T17:33:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OWtV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -151,12 +108,7 @@
       {
         "site": "nicovideo",
         "id": "lastexile-fam",
-        "begin": "2011-11-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-07T03:00:00.000Z"
       }
     ]
   },
@@ -175,27 +127,16 @@
     "officialSite": "http://genesis-horizon.net/",
     "begin": "2011-10-01T17:58:00.000Z",
     "end": "2011-12-24T18:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk50zlh",
-        "begin": "2014-09-12T06:37:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:37:43.000Z"
       },
       {
         "site": "letv",
         "id": "49115",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -204,12 +145,7 @@
       {
         "site": "bilibili",
         "id": "2676",
-        "begin": "2011-09-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -225,17 +161,11 @@
     "officialSite": "http://www.mashiro.tv/",
     "begin": "2011-10-04T17:00:00.000Z",
     "end": "2011-12-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HUdBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -244,22 +174,12 @@
       {
         "site": "nicovideo",
         "id": "mashiro",
-        "begin": "2011-10-05T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-05T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "868",
-        "begin": "2011-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -279,27 +199,16 @@
     "officialSite": "http://www.phibrain.net/01/",
     "begin": "2011-10-02T08:30:00.000Z",
     "end": "2012-04-01T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vezYVr4klNI1sxs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk46ca5",
-        "begin": "2012-11-30T16:00:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-30T16:00:48.000Z"
       },
       {
         "site": "bangumi",
@@ -308,12 +217,7 @@
       {
         "site": "bilibili",
         "id": "487",
-        "begin": "2011-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -332,7 +236,6 @@
     "officialSite": "http://www.un-go.com/",
     "begin": "2011-10-13T16:00:00.000Z",
     "end": "2011-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -341,12 +244,7 @@
       {
         "site": "bilibili",
         "id": "869",
-        "begin": "2011-10-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-12T16:00:00.000Z"
       }
     ]
   },
@@ -365,47 +263,26 @@
     "officialSite": "http://www.guilty-crown.jp/",
     "begin": "2011-10-13T16:30:00.000Z",
     "end": "2012-03-22T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1ficJR68VhcMmpAw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk6ivf1",
-        "begin": "2012-09-06T04:55:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-06T04:55:52.000Z"
       },
       {
         "site": "qq",
         "id": "b/b33p36z5zgr170f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "53658",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -414,22 +291,12 @@
       {
         "site": "bilibili",
         "id": "1588",
-        "begin": "2011-10-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-12T16:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80113904",
-        "begin": "2019-01-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-31T16:00:00.000Z"
       }
     ]
   },
@@ -448,17 +315,11 @@
     "officialSite": "http://www.p4a.jp/",
     "begin": "2011-10-06T16:30:00.000Z",
     "end": "2014-07-03T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk6gfk9",
-        "begin": "2014-09-12T06:29:53.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:29:53.000Z"
       },
       {
         "site": "bangumi",
@@ -467,22 +328,12 @@
       {
         "site": "nicovideo",
         "id": "p4a",
-        "begin": "2011-10-15T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-15T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2717",
-        "begin": "2011-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -502,37 +353,21 @@
     "officialSite": "http://www.shakugan.com/",
     "begin": "2011-10-07T16:30:00.000Z",
     "end": "2012-03-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "L3lDwSmPicz2gHoY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk8btex",
-        "begin": "2012-09-01T09:59:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-01T09:59:16.000Z"
       },
       {
         "site": "letv",
         "id": "49272",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -541,12 +376,7 @@
       {
         "site": "nicovideo",
         "id": "shakugan-03",
-        "begin": "2011-10-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-13T15:30:00.000Z"
       }
     ]
   },
@@ -565,27 +395,16 @@
     "officialSite": "http://tamayura.info/hitotose/",
     "begin": "2011-10-03T00:00:00.000Z",
     "end": "2011-12-19T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Gkw4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "1/1vopmg6vm19rsni",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -594,32 +413,17 @@
       {
         "site": "nicovideo",
         "id": "tamayura-tv",
-        "begin": "2012-03-11T11:15:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-11T11:15:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjc7u9",
-        "begin": "2014-01-14T08:10:29.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-14T08:10:29.000Z"
       },
       {
         "site": "bilibili",
         "id": "514",
-        "begin": "2011-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -635,17 +439,11 @@
     "officialSite": "http://www.gundam-age.net/",
     "begin": "2011-10-09T08:00:00.000Z",
     "end": "2012-09-23T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "8/8ufe8nnbe1h85gk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -668,7 +466,6 @@
     "officialSite": "http://maken-ki.com/",
     "begin": "2011-10-04T16:05:00.000Z",
     "end": "2011-12-20T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -688,7 +485,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/haganai/1st/",
     "begin": "2011-10-06T16:55:00.000Z",
     "end": "2011-12-22T17:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -697,12 +493,7 @@
       {
         "site": "nicovideo",
         "id": "haganai",
-        "begin": "2012-09-27T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-27T15:00:00.000Z"
       }
     ]
   },
@@ -719,57 +510,31 @@
     "officialSite": "http://www.ntv.co.jp/chihayafuru/",
     "begin": "2011-10-04T15:59:00.000Z",
     "end": "2012-03-27T16:49:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "J3FLyTGXB0WoJo4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk4v019",
-        "begin": "2012-11-27T03:46:51.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-27T03:46:51.000Z"
       },
       {
         "site": "qq",
         "id": "5/524dazlp04ww8uh",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "49208",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2012/hpqy",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -778,22 +543,12 @@
       {
         "site": "nicovideo",
         "id": "chihayafuru",
-        "begin": "2014-04-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-01T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "616",
-        "begin": "2011-10-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -809,7 +564,6 @@
     "officialSite": "http://www.kimiboku.tv/",
     "begin": "2011-10-03T16:30:00.000Z",
     "end": "2011-12-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -818,12 +572,7 @@
       {
         "site": "nicovideo",
         "id": "kimiboku",
-        "begin": "2011-10-06T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-06T18:30:00.000Z"
       }
     ]
   },
@@ -842,27 +591,16 @@
     "officialSite": "http://www.future-diary.tv/",
     "begin": "2011-10-09T14:00:00.000Z",
     "end": "2012-04-15T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ncfBP6cNfbsenAQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/8d4x210hpoji73w",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -871,12 +609,7 @@
       {
         "site": "nicovideo",
         "id": "future-diary",
-        "begin": "2011-10-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-09T14:30:00.000Z"
       }
     ]
   },
@@ -895,17 +628,11 @@
     "officialSite": "http://www.starchild.co.jp/special/c3/",
     "begin": "2011-10-01T14:30:00.000Z",
     "end": "2012-09-10T21:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VYSAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -914,12 +641,7 @@
       {
         "site": "nicovideo",
         "id": "c3",
-        "begin": "2011-10-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-04T15:30:00.000Z"
       }
     ]
   },
@@ -939,27 +661,16 @@
     "officialSite": "http://ben-to.net/",
     "begin": "2011-10-08T17:20:00.000Z",
     "end": "2011-12-24T18:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lsC8OqIIeLYZlic8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/lhe85mcrkwpi92f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -968,22 +679,12 @@
       {
         "site": "nicovideo",
         "id": "ben-to",
-        "begin": "2011-10-12T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-12T03:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "864",
-        "begin": "2011-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -999,7 +700,6 @@
     "officialSite": "http://www.anime-majikoi.com/",
     "begin": "2011-10-01T16:00:00.000Z",
     "end": "2011-12-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1008,12 +708,7 @@
       {
         "site": "nicovideo",
         "id": "majikoi",
-        "begin": "2011-10-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-08T14:30:00.000Z"
       }
     ]
   },
@@ -1033,27 +728,16 @@
     "officialSite": "http://www.fate-zero.jp/",
     "begin": "2011-10-01T15:00:00.000Z",
     "end": "2011-12-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VoN9ib2PJOXfaWMA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjzlx29",
-        "begin": "2012-07-01T06:25:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-01T06:25:12.000Z"
       },
       {
         "site": "bangumi",
@@ -1062,22 +746,12 @@
       {
         "site": "nicovideo",
         "id": "fate-zero",
-        "begin": "2011-10-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-07T17:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70304256",
-        "begin": "2017-04-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-15T07:00:00.000Z"
       }
     ]
   },
@@ -1093,7 +767,6 @@
     "officialSite": "http://sekai-ichi.jp/",
     "begin": "2011-10-07T16:05:00.000Z",
     "end": "2011-12-23T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1116,7 +789,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/bakuman/",
     "begin": "2011-10-01T08:30:00.000Z",
     "end": "2012-03-24T08:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1125,22 +797,12 @@
       {
         "site": "nicovideo",
         "id": "bakuman2",
-        "begin": "2012-10-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-20T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "728",
-        "begin": "2011-10-01T08:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-01T08:30:00.000Z"
       }
     ]
   },
@@ -1156,7 +818,6 @@
     "officialSite": "http://gdgdfairy.com/index.html",
     "begin": "2011-10-12T18:00:00.000Z",
     "end": "2011-12-28T18:13:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1165,12 +826,7 @@
       {
         "site": "nicovideo",
         "id": "gdgd",
-        "begin": "2011-10-27T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-27T04:00:00.000Z"
       }
     ]
   },
@@ -1186,27 +842,16 @@
     "officialSite": "http://www.b-daman.tv/",
     "begin": "2011-10-01T23:45:00.000Z",
     "end": "2012-09-30T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3gj0ctpAsO5Rzzc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "49659",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1215,22 +860,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh7rlhp",
-        "begin": "2017-06-14T16:15:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T16:15:34.000Z"
       },
       {
         "site": "bilibili",
         "id": "750",
-        "begin": "2011-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -1246,7 +881,6 @@
     "officialSite": "http://www.jvcmusic.co.jp/fujilog/",
     "begin": "2011-10-02T11:55:00.000Z",
     "end": "2011-12-25T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1266,17 +900,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_moritasan/",
     "begin": "2011-10-04T16:30:00.000Z",
     "end": "2011-12-27T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "InRQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1285,12 +913,7 @@
       {
         "site": "nicovideo",
         "id": "moritasan-02",
-        "begin": "2011-10-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-06T16:30:00.000Z"
       }
     ]
   },
@@ -1306,17 +929,11 @@
     "officialSite": "http://sgpk.jp/",
     "begin": "2011-10-03T18:15:00.000Z",
     "end": "2012-03-26T18:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3QcBfibdNvfte3EQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1325,12 +942,7 @@
       {
         "site": "bilibili",
         "id": "892",
-        "begin": "2011-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -1346,17 +958,11 @@
     "officialSite": "http://www.shopro.co.jp/tv/chibidevi/",
     "begin": "2011-10-10T09:20:00.000Z",
     "end": "2014-02-17T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2Qv1c9tBse9S0Dg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1376,17 +982,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/digimon_xw/",
     "begin": "2011-10-01T21:30:00.000Z",
     "end": "2012-03-25T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb13eh",
-        "begin": "2015-08-17T03:27:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-17T03:27:33.000Z"
       },
       {
         "site": "bangumi",
@@ -1402,7 +1002,6 @@
     "officialSite": "",
     "begin": "2011-10-05T16:00:00.000Z",
     "end": "2012-04-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1411,12 +1010,7 @@
       {
         "site": "nicovideo",
         "id": "kimezo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1432,7 +1026,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2011_suite_precure/",
     "begin": "2011-10-29T16:00:00.000Z",
     "end": "2011-10-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1441,22 +1034,12 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   }

--- a/data/items/2011/11.json
+++ b/data/items/2011/11.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.ribon-highscore.com/",
     "begin": "2011-11-28T11:56:00.000Z",
     "end": "2012-01-30T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iciakTkflfzw1w7lY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "nicovideo",
         "id": "ribon-highscore",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -52,17 +41,11 @@
     "officialSite": "http://www.s-cry-ed.net/",
     "begin": "2011-11-19T16:00:00.000Z",
     "end": "2011-11-19T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk4e195",
-        "begin": "2012-11-30T16:00:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-30T16:00:37.000Z"
       },
       {
         "site": "bangumi",
@@ -82,17 +65,11 @@
     "officialSite": "http://ova-tos.com/",
     "begin": "2011-11-23T16:00:00.000Z",
     "end": "2012-10-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pe7aWMAmltQ3tR0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,22 +78,12 @@
       {
         "site": "nicovideo",
         "id": "TOS-anime03",
-        "begin": "2016-07-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3976",
-        "begin": "2011-11-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-22T16:00:01.000Z"
       }
     ]
   },
@@ -132,17 +99,11 @@
     "officialSite": "http://www.sora-anime.com/",
     "begin": "2011-11-25T16:00:00.000Z",
     "end": "2012-02-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QJNt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -151,32 +112,17 @@
       {
         "site": "nicovideo",
         "id": "sora-anime",
-        "begin": "2012-02-17T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-02-17T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2882",
-        "begin": "2011-11-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-24T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "50781",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -188,7 +134,6 @@
     "officialSite": "",
     "begin": "2011-11-28T16:00:00.000Z",
     "end": "2012-02-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -197,12 +142,7 @@
       {
         "site": "nicovideo",
         "id": "nom",
-        "begin": "2011-11-28T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-11-28T03:00:00.000Z"
       }
     ]
   },
@@ -218,7 +158,6 @@
     "officialSite": "http://www.konodan.com/",
     "begin": "2011-11-18T16:00:00.000Z",
     "end": "2011-11-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -227,12 +166,7 @@
       {
         "site": "nicovideo",
         "id": "konodan",
-        "begin": "2012-04-27T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-27T06:00:00.000Z"
       }
     ]
   },
@@ -248,7 +182,6 @@
     "officialSite": "http://www.towanoquon.com",
     "begin": "2011-11-05T16:00:00.000Z",
     "end": "2011-11-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -257,12 +190,7 @@
       {
         "site": "letv",
         "id": "46312",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -278,7 +206,6 @@
     "officialSite": "http://www.towanoquon.com",
     "begin": "2011-11-26T16:00:00.000Z",
     "end": "2011-11-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -287,12 +214,7 @@
       {
         "site": "letv",
         "id": "46312",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2011/12.json
+++ b/data/items/2011/12.json
@@ -12,27 +12,16 @@
     "officialSite": "http://www.gundam-seed.net/",
     "begin": "2011-12-23T16:00:00.000Z",
     "end": "2012-11-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk21ldh",
-        "begin": "2017-03-02T09:20:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-02T09:20:16.000Z"
       },
       {
         "site": "qq",
         "id": "d/dm1mifa4wc4jssg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -52,7 +41,6 @@
     "officialSite": "",
     "begin": "2011-12-01T16:00:00.000Z",
     "end": "2011-12-01T16:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -72,7 +60,6 @@
     "officialSite": "",
     "begin": "2011-12-23T16:00:00.000Z",
     "end": "2011-12-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -92,17 +79,11 @@
     "officialSite": "http://basketarmy.jp/",
     "begin": "2011-12-22T16:00:00.000Z",
     "end": "2012-12-20T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ncmzMZnicb60QjvY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -111,22 +92,7 @@
       {
         "site": "letv",
         "id": "72940",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "830",
-        "begin": "2011-12-21T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -142,17 +108,11 @@
     "officialSite": "",
     "begin": "2011-12-14T16:00:00.000Z",
     "end": "2012-01-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3gYCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -172,7 +132,6 @@
     "officialSite": "http://lupin-3rd.net/",
     "begin": "2011-12-02T16:00:00.000Z",
     "end": "2011-12-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -181,12 +140,7 @@
       {
         "site": "bilibili",
         "id": "3953",
-        "begin": "2011-12-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-12-01T16:00:01.000Z"
       }
     ]
   },
@@ -202,17 +156,11 @@
     "officialSite": "http://www.kyousogiga.com/",
     "begin": "2011-12-10T16:00:00.000Z",
     "end": "2011-12-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UYVicicWXLO3ncWsI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -221,12 +169,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4oit",
-        "begin": "2015-09-23T08:10:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-23T08:10:24.000Z"
       }
     ]
   },
@@ -242,7 +185,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/k-on/",
     "begin": "2011-12-03T16:00:00.000Z",
     "end": "2011-12-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -251,12 +193,7 @@
       {
         "site": "nicovideo",
         "id": "k-on_movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2012/01.json
+++ b/data/items/2012/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://milky-holmes.com/anime/series/",
     "begin": "2012-01-05T14:00:00.000Z",
     "end": "2012-03-22T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yhrmZMwyouBDwSk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "milky-holmes2",
-        "begin": "2012-01-08T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-08T17:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1692",
-        "begin": "2012-01-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -61,27 +45,16 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_rikoran/",
     "begin": "2012-01-05T16:00:00.000Z",
     "end": "2012-03-27T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4zMNiaicNZyQdq6FA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "k/kotdhba6by0q3bf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -90,22 +63,12 @@
       {
         "site": "nicovideo",
         "id": "rikoran",
-        "begin": "2012-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-05T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1673",
-        "begin": "2012-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -121,7 +84,6 @@
     "officialSite": "http://www.zero-tsukaima.com/",
     "begin": "2012-01-06T23:30:00.000Z",
     "end": "2012-03-24T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,22 +92,12 @@
       {
         "site": "nicovideo",
         "id": "zero-tsukaima-f",
-        "begin": "2012-02-10T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-02-10T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "821",
-        "begin": "2012-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -161,7 +113,6 @@
     "officialSite": "http://www.haremking.tv/season1/",
     "begin": "2012-01-06T02:00:00.000Z",
     "end": "2012-03-23T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,12 +121,7 @@
       {
         "site": "nicovideo",
         "id": "haremking",
-        "begin": "2012-01-27T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-27T06:00:00.000Z"
       }
     ]
   },
@@ -192,57 +138,31 @@
     "officialSite": "http://www.nasinc.co.jp/jp/natsume-anime/",
     "begin": "2012-01-02T16:30:00.000Z",
     "end": "2012-03-26T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yBzoZs40pOJFwys",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjptx89",
-        "begin": "2013-03-06T01:14:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-06T01:14:22.000Z"
       },
       {
         "site": "qq",
         "id": "9/9u9pl7dbnoclzhd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "70404",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/xmyrz4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -251,22 +171,12 @@
       {
         "site": "nicovideo",
         "id": "natsume4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1663",
-        "begin": "2012-01-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-01T16:00:00.000Z"
       }
     ]
   },
@@ -282,27 +192,16 @@
     "officialSite": "http://www.ichika-ichika.com/",
     "begin": "2012-01-09T16:30:00.000Z",
     "end": "2012-03-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AlMtqxN56SeKCHA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "70709",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -311,22 +210,12 @@
       {
         "site": "nicovideo",
         "id": "ichika-ichika",
-        "begin": "2014-06-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-06-20T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "814",
-        "begin": "2012-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-08T16:00:00.000Z"
       }
     ]
   },
@@ -342,7 +231,6 @@
     "officialSite": "http://www.starchild.co.jp/special/mo-retsu/",
     "begin": "2012-01-07T15:30:00.000Z",
     "end": "2012-06-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -351,22 +239,12 @@
       {
         "site": "nicovideo",
         "id": "mo-retsu",
-        "begin": "2012-01-14T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-14T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "817",
-        "begin": "2012-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -385,17 +263,11 @@
     "officialSite": "http://killmebaby.tv/",
     "begin": "2012-01-05T16:45:00.000Z",
     "end": "2012-03-29T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4TUPjfVbywls6lI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -404,22 +276,12 @@
       {
         "site": "nicovideo",
         "id": "kmb",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "709",
-        "begin": "2012-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -435,7 +297,6 @@
     "officialSite": "http://www.another-anime.jp/",
     "begin": "2012-01-10T16:00:00.000Z",
     "end": "2012-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -444,12 +305,7 @@
       {
         "site": "nicovideo",
         "id": "Another_anime",
-        "begin": "2016-09-02T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-02T06:00:00.000Z"
       }
     ]
   },
@@ -465,7 +321,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/amagami/",
     "begin": "2012-01-05T17:15:00.000Z",
     "end": "2012-03-29T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -474,22 +329,12 @@
       {
         "site": "bilibili",
         "id": "816",
-        "begin": "2012-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-04T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "8iaIenARq2hh7ibWE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -505,17 +350,11 @@
     "officialSite": "http://www.symphogear.com/",
     "begin": "2012-01-06T14:00:00.000Z",
     "end": "2012-03-30T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "70579",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -524,32 +363,17 @@
       {
         "site": "nicovideo",
         "id": "symphogear",
-        "begin": "2012-01-10T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-10T13:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcmikl",
-        "begin": "2017-10-31T16:01:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-31T16:01:23.000Z"
       },
       {
         "site": "bilibili",
         "id": "526",
-        "begin": "2012-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -566,37 +390,21 @@
     "officialSite": "http://www.inuboku.tv/",
     "begin": "2012-01-12T17:27:00.000Z",
     "end": "2013-04-04T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JXBMyjKYCEapJ48",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk52409",
-        "begin": "2012-11-13T01:23:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-13T01:23:24.000Z"
       },
       {
         "site": "letv",
         "id": "70921",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -605,22 +413,12 @@
       {
         "site": "nicovideo",
         "id": "inuboku",
-        "begin": "2012-01-22T12:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-22T12:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "809",
-        "begin": "2012-01-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-11T16:00:00.000Z"
       }
     ]
   },
@@ -636,27 +434,16 @@
     "officialSite": "http://www.brave10.com/",
     "begin": "2012-01-07T17:00:00.000Z",
     "end": "2012-03-24T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7zcRjicddzQtu7FQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "70651",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -665,22 +452,12 @@
       {
         "site": "nicovideo",
         "id": "brave10",
-        "begin": "2012-01-11T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-11T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "825",
-        "begin": "2012-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -696,7 +473,6 @@
     "officialSite": "http://www.starchild.co.jp/special/papakiki/",
     "begin": "2012-01-10T16:30:00.000Z",
     "end": "2012-03-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -705,22 +481,7 @@
       {
         "site": "nicovideo",
         "id": "papakiki",
-        "begin": "2012-01-16T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "714",
-        "begin": "2012-01-10T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-16T17:00:00.000Z"
       }
     ]
   },
@@ -736,37 +497,21 @@
     "officialSite": "http://www.danshinichijyo.net/",
     "begin": "2012-01-09T17:00:00.000Z",
     "end": "2012-03-26T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjtd2cp",
-        "begin": "2014-09-12T06:32:56.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:32:56.000Z"
       },
       {
         "site": "qq",
         "id": "f/fhvqqvva54yc3mz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2012/nzgzsdrc",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -775,22 +520,12 @@
       {
         "site": "nicovideo",
         "id": "danshinichijyo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2680",
-        "begin": "2012-01-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-08T16:00:00.000Z"
       }
     ]
   },
@@ -806,7 +541,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/poyo/",
     "begin": "2012-01-07T22:24:00.000Z",
     "end": "2012-12-29T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -815,12 +549,7 @@
       {
         "site": "nicovideo",
         "id": "poyo",
-        "begin": "2012-01-08T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-08T04:00:00.000Z"
       }
     ]
   },
@@ -837,27 +566,16 @@
     "officialSite": "http://lag-rin.com/",
     "begin": "2012-01-08T13:00:00.000Z",
     "end": "2012-03-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qvrGRKwSgsAjoQk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjvj47d",
-        "begin": "2014-09-12T06:22:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:22:23.000Z"
       },
       {
         "site": "bangumi",
@@ -866,12 +584,7 @@
       {
         "site": "bilibili",
         "id": "2678",
-        "begin": "2012-01-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -887,17 +600,11 @@
     "officialSite": "http://www.nisemonogatari-anime.com/",
     "begin": "2012-01-07T15:00:00.000Z",
     "end": "2012-03-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/wwy",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -906,12 +613,7 @@
       {
         "site": "nicovideo",
         "id": "nisemonogatari-anime",
-        "begin": "2012-01-14T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-14T17:00:00.000Z"
       }
     ]
   },
@@ -930,31 +632,15 @@
     "officialSite": "http://www.thermae-anime.jp/index.html",
     "begin": "2012-01-12T16:00:00.000Z",
     "end": "2012-01-26T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "28687"
       },
       {
-        "site": "bilibili",
-        "id": "826",
-        "begin": "2012-01-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "letv",
         "id": "71212",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -971,57 +657,31 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/shin-tenipri/",
     "begin": "2012-01-04T16:50:00.000Z",
     "end": "2012-03-28T18:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3Qnzcdkicrib1QzjY",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgiebgp",
-        "begin": "2014-06-25T06:23:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-06-25T06:23:18.000Z"
       },
       {
         "site": "qq",
         "id": "a/a3hsg6804j4xixp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "70491",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "51378",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1030,12 +690,7 @@
       {
         "site": "nicovideo",
         "id": "shin-tenipri",
-        "begin": "2012-01-29T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-29T16:30:00.000Z"
       }
     ]
   },
@@ -1051,27 +706,16 @@
     "officialSite": "http://www.tv-asahi.co.jp/knight/",
     "begin": "2012-01-06T21:00:00.000Z",
     "end": "2012-09-28T21:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjtikut",
-        "begin": "2012-12-12T09:20:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-12T09:20:52.000Z"
       },
       {
         "site": "letv",
         "id": "70628",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1080,12 +724,7 @@
       {
         "site": "bilibili",
         "id": "827",
-        "begin": "2012-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -1101,21 +740,10 @@
     "officialSite": "http://gokujyo.cammot.jp/",
     "begin": "2012-01-30T01:00:00.000Z",
     "end": "2012-03-26T16:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "23535"
-      },
-      {
-        "site": "bilibili",
-        "id": "829",
-        "begin": "2012-01-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -1131,27 +759,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/lbxw/",
     "begin": "2012-01-18T10:27:00.000Z",
     "end": "2013-03-20T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjsa8ax",
-        "begin": "2014-09-12T06:26:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:26:31.000Z"
       },
       {
         "site": "letv",
         "id": "71260",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1159,13 +776,8 @@
       },
       {
         "site": "bilibili",
-        "id": "1696",
-        "begin": "2012-01-17T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "95172",
+        "begin": "2012-01-17T16:00:00.000Z"
       }
     ]
   },
@@ -1184,17 +796,11 @@
     "officialSite": "http://aqevol.com/",
     "begin": "2012-01-08T16:35:00.000Z",
     "end": "2012-06-24T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "70688",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1203,22 +809,12 @@
       {
         "site": "nicovideo",
         "id": "aqevol",
-        "begin": "2012-01-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-16T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "696",
-        "begin": "2012-01-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -1234,17 +830,11 @@
     "officialSite": "",
     "begin": "2012-01-26T16:00:00.000Z",
     "end": "2012-01-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kaWPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1253,12 +843,7 @@
       {
         "site": "bilibili",
         "id": "5705",
-        "begin": "2012-01-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-01-25T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2012/02.json
+++ b/data/items/2012/02.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.noitamina-brs.jp/",
     "begin": "2012-02-02T15:45:00.000Z",
     "end": "2012-03-22T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,22 +22,12 @@
       {
         "site": "nicovideo",
         "id": "blackrockshooter",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "71587",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -59,27 +48,16 @@
     "officialSite": "http://asahi.co.jp/smile_precure/",
     "begin": "2012-02-04T23:30:00.000Z",
     "end": "2013-01-27T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "l76KCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb14nh",
-        "begin": "2015-10-09T03:15:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T03:15:46.000Z"
       },
       {
         "site": "bangumi",
@@ -88,12 +66,7 @@
       {
         "site": "netflix",
         "id": "80057968",
-        "begin": "2015-12-18T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-18T08:00:00.000Z"
       }
     ]
   },
@@ -109,31 +82,15 @@
     "officialSite": "http://www.animebunko.com/minori/",
     "begin": "2012-02-15T16:00:00.000Z",
     "end": "2012-02-15T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aZxo5k60JGLFQ6s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "13344"
-      },
-      {
-        "site": "bilibili",
-        "id": "4612",
-        "begin": "2012-02-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -149,17 +106,11 @@
     "officialSite": "http://patema.jp/",
     "begin": "2012-02-25T16:00:00.000Z",
     "end": "2012-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8CoWlPxia0hBz8Vk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -168,12 +119,7 @@
       {
         "site": "nicovideo",
         "id": "patema",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -189,31 +135,15 @@
     "officialSite": "http://www.animebunko.com/naokosan/",
     "begin": "2012-02-15T16:00:00.000Z",
     "end": "2012-02-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "M2lT0TmfD02wLpY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "24546"
-      },
-      {
-        "site": "bilibili",
-        "id": "4610",
-        "begin": "2012-02-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -232,7 +162,6 @@
     "officialSite": "http://www.berserkfilm.com/",
     "begin": "2012-02-04T16:00:00.000Z",
     "end": "2012-02-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -241,22 +170,12 @@
       {
         "site": "nicovideo",
         "id": "berserkfilm",
-        "begin": "2017-03-03T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-03T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70258995",
-        "begin": "2016-10-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-15T07:00:00.000Z"
       }
     ]
   },
@@ -272,7 +191,6 @@
     "officialSite": "",
     "begin": "2012-02-03T16:00:00.000Z",
     "end": "2012-02-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -281,22 +199,7 @@
       {
         "site": "pptv",
         "id": "KCQQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4616",
-        "begin": "2012-02-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2012/03.json
+++ b/data/items/2012/03.json
@@ -11,31 +11,15 @@
     "officialSite": "http://ozuma.jp/",
     "begin": "2012-03-16T15:00:00.000Z",
     "end": "2012-04-20T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BFslowtx4RibCAGg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "31417"
-      },
-      {
-        "site": "bilibili",
-        "id": "831",
-        "begin": "2012-03-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -51,47 +35,26 @@
     "officialSite": "http://www.hiironokakera.tv/",
     "begin": "2012-03-05T17:29:00.000Z",
     "end": "2012-06-24T13:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3ALibfORKuvhb2UE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjt8kf9",
-        "begin": "2013-01-09T06:48:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-09T06:48:52.000Z"
       },
       {
         "site": "qq",
         "id": "e/e7i9xvn5d08eko0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "72997",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,12 +63,7 @@
       {
         "site": "nicovideo",
         "id": "hiiro",
-        "begin": "2012-04-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-04T16:30:00.000Z"
       }
     ]
   },
@@ -121,21 +79,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/seiya/",
     "begin": "2012-03-31T21:30:00.000Z",
     "end": "2014-03-29T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1ce1",
-        "begin": "2015-08-14T17:03:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "saraba1st",
-        "id": "786461"
+        "begin": "2015-08-14T17:03:10.000Z"
       },
       {
         "site": "bangumi",
@@ -155,17 +103,11 @@
     "officialSite": "http://koiken-anime.jp/",
     "begin": "2012-03-01T16:00:00.000Z",
     "end": "2012-05-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2P7KSLAWhsQnpQ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -185,31 +127,15 @@
     "officialSite": "http://animemirai.jp/shiranpuri/",
     "begin": "2012-03-26T16:00:00.000Z",
     "end": "2012-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EAvlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "39637"
-      },
-      {
-        "site": "bilibili",
-        "id": "4582",
-        "begin": "2012-03-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -225,31 +151,15 @@
     "officialSite": "http://animemirai.jp/juju/",
     "begin": "2012-03-19T16:00:00.000Z",
     "end": "2012-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EAvlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "40247"
-      },
-      {
-        "site": "bilibili",
-        "id": "4601",
-        "begin": "2012-03-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -265,17 +175,11 @@
     "officialSite": "http://animemirai.jp/buta/",
     "begin": "2012-03-05T16:00:00.000Z",
     "end": "2012-03-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EAvlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -284,12 +188,7 @@
       {
         "site": "bilibili",
         "id": "4606",
-        "begin": "2012-03-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-04T16:00:01.000Z"
       }
     ]
   },
@@ -305,27 +204,16 @@
     "officialSite": "http://animemirai.jp/wasurenagumo/",
     "begin": "2012-03-12T16:00:00.000Z",
     "end": "2012-03-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EAvlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "76279",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -334,12 +222,7 @@
       {
         "site": "bilibili",
         "id": "5947",
-        "begin": "2012-03-11T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-11T16:00:01.000Z"
       }
     ]
   },
@@ -355,17 +238,11 @@
     "officialSite": "http://s-witch.cute.or.jp/movie/",
     "begin": "2012-03-17T16:00:00.000Z",
     "end": "2012-03-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "83122",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -374,12 +251,7 @@
       {
         "site": "bilibili",
         "id": "3843",
-        "begin": "2012-03-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-16T16:00:01.000Z"
       }
     ]
   },
@@ -395,17 +267,11 @@
     "officialSite": "http://www.precure-allstars.com/",
     "begin": "2012-03-17T16:00:00.000Z",
     "end": "2012-03-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "79497",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -414,12 +280,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   },
@@ -435,17 +296,11 @@
     "officialSite": "http://www.doraeiga.com/2012/",
     "begin": "2012-03-03T16:00:00.000Z",
     "end": "2012-03-03T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "79885",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -454,32 +309,17 @@
       {
         "site": "pptv",
         "id": "7qoHhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mmfp",
-        "begin": "2018-05-31T16:13:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:13:22.000Z"
       }
     ]
   },
@@ -495,17 +335,11 @@
     "officialSite": "http://www.s-cry-ed.net/",
     "begin": "2012-03-10T16:00:00.000Z",
     "end": "2012-03-10T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrk4e195",
-        "begin": "2012-11-30T16:00:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-30T16:00:37.000Z"
       },
       {
         "site": "bangumi",
@@ -525,17 +359,11 @@
     "officialSite": "",
     "begin": "2012-03-28T16:00:00.000Z",
     "end": "2012-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8gP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -544,12 +372,7 @@
       {
         "site": "bilibili",
         "id": "3938",
-        "begin": "2012-03-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-27T16:00:01.000Z"
       }
     ]
   },
@@ -565,17 +388,11 @@
     "officialSite": "",
     "begin": "2012-03-21T16:00:00.000Z",
     "end": "2012-08-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "InlDwSmPicz2gHoY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -584,12 +401,7 @@
       {
         "site": "nicovideo",
         "id": "kenshin-sinkilyouto",
-        "begin": "2017-08-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-03T15:00:00.000Z"
       }
     ]
   },
@@ -605,17 +417,11 @@
     "officialSite": "http://www.a-ch.jp/bd_dvd/ova.html",
     "begin": "2012-03-21T16:00:00.000Z",
     "end": "2012-03-21T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OV4qqBB25iaSHBW0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -624,12 +430,7 @@
       {
         "site": "bilibili",
         "id": "916",
-        "begin": "2012-03-20T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-20T16:00:00.000Z"
       }
     ]
   },
@@ -645,17 +446,11 @@
     "officialSite": "",
     "begin": "2012-03-21T16:00:00.000Z",
     "end": "2012-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IXZS0DiaeDkyvLZU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -675,7 +470,6 @@
     "officialSite": "http://kc.kodansha.co.jp/kimino/twilight/index.html",
     "begin": "2012-03-16T16:00:00.000Z",
     "end": "2012-06-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -684,12 +478,7 @@
       {
         "site": "nicovideo",
         "id": "kiminoirumachi_OAD",
-        "begin": "2018-10-18T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-18T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2012/04.json
+++ b/data/items/2012/04.json
@@ -11,27 +11,16 @@
     "officialSite": "http://www.ytv.co.jp/uchukyodai/",
     "begin": "2012-04-01T08:30:00.000Z",
     "end": "2013-03-22T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhayib5",
-        "begin": "2015-04-01T08:40:49.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-01T08:40:49.000Z"
       },
       {
         "site": "bilibili",
         "id": "1657",
-        "begin": "2012-03-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-31T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -40,12 +29,7 @@
       {
         "site": "nicovideo",
         "id": "uchukyodai",
-        "begin": "2014-07-10T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-10T06:00:00.000Z"
       }
     ]
   },
@@ -61,17 +45,11 @@
     "officialSite": "http://www.starchild.co.jp/special/nazokano_x/",
     "begin": "2012-04-07T16:30:00.000Z",
     "end": "2012-06-30T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "74846",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,12 +58,7 @@
       {
         "site": "nicovideo",
         "id": "nazokano_x",
-        "begin": "2012-04-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-13T15:00:00.000Z"
       }
     ]
   },
@@ -101,37 +74,16 @@
     "officialSite": "http://www.accel-world.net/",
     "begin": "2012-04-06T15:30:00.000Z",
     "end": "2012-09-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjt3kop",
-        "begin": "2017-03-08T04:25:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "64562",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-08T04:25:25.000Z"
       },
       {
         "site": "sohu",
         "id": "s2012/jssj",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,22 +92,12 @@
       {
         "site": "nicovideo",
         "id": "accel-world",
-        "begin": "2012-04-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-10T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "686",
-        "begin": "2012-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -171,17 +113,11 @@
     "officialSite": "http://www.natsuiro-kiseki.jp/",
     "begin": "2012-04-05T17:25:00.000Z",
     "end": "2012-06-28T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tu3XVb0jk9E0sho",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -190,22 +126,12 @@
       {
         "site": "nicovideo",
         "id": "natsuiro-kiseki",
-        "begin": "2012-04-13T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-13T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "787",
-        "begin": "2012-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -224,17 +150,11 @@
     "officialSite": "http://www.amnesia-tv.com/",
     "begin": "2012-04-08T15:30:00.000Z",
     "end": "2012-12-27T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AlYysBhib7iayPDXU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -243,22 +163,7 @@
       {
         "site": "nicovideo",
         "id": "amnesia-tv",
-        "begin": "2012-04-26T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "783",
-        "begin": "2012-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-26T15:00:00.000Z"
       }
     ]
   },
@@ -274,18 +179,7 @@
     "officialSite": "http://saki-anime.com/achiga/",
     "begin": "2012-04-08T16:05:00.000Z",
     "end": "2013-05-25T11:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2570",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "24165"
@@ -293,12 +187,7 @@
       {
         "site": "nicovideo",
         "id": "saki-sidea",
-        "begin": "2012-04-23T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-23T16:30:00.000Z"
       }
     ]
   },
@@ -317,7 +206,6 @@
     "officialSite": "http://eurekaao-prj.net/",
     "begin": "2012-04-12T17:22:00.000Z",
     "end": "2012-11-19T17:52:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -326,22 +214,12 @@
       {
         "site": "nicovideo",
         "id": "eurekaao",
-        "begin": "2018-03-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-26T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "791",
-        "begin": "2012-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -357,7 +235,6 @@
     "officialSite": "http://queensblade.tv/",
     "begin": "2012-04-03T01:00:00.000Z",
     "end": "2012-06-19T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -366,12 +243,7 @@
       {
         "site": "nicovideo",
         "id": "queensblade",
-        "begin": "2012-04-19T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-19T15:00:00.000Z"
       }
     ]
   },
@@ -387,17 +259,11 @@
     "officialSite": "http://akb0048.jp/",
     "begin": "2012-04-29T14:00:00.000Z",
     "end": "2012-07-22T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "B1ompAxy4iaCDAWk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -406,12 +272,7 @@
       {
         "site": "bilibili",
         "id": "643",
-        "begin": "2012-04-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-28T16:00:00.000Z"
       }
     ]
   },
@@ -427,7 +288,6 @@
     "officialSite": "http://medakabox.jp/",
     "begin": "2012-04-04T16:50:00.000Z",
     "end": "2012-06-20T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -436,12 +296,7 @@
       {
         "site": "nicovideo",
         "id": "medakabox",
-        "begin": "2012-04-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-07T17:00:00.000Z"
       }
     ]
   },
@@ -457,17 +312,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_yuru/",
     "begin": "2012-04-02T16:35:00.000Z",
     "end": "2012-06-25T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vuXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -476,22 +325,12 @@
       {
         "site": "nicovideo",
         "id": "yuru",
-        "begin": "2012-04-06T16:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-06T16:10:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "775",
-        "begin": "2012-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -510,27 +349,11 @@
     "officialSite": "http://www.jormungand.tv/",
     "begin": "2012-04-10T15:30:00.000Z",
     "end": "2012-06-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "64576",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "75045",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -539,12 +362,7 @@
       {
         "site": "nicovideo",
         "id": "jormungand",
-        "begin": "2012-04-20T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-20T16:30:00.000Z"
       }
     ]
   },
@@ -560,27 +378,16 @@
     "officialSite": "http://www.shin-ei-animation.jp/kuromajyo/",
     "begin": "2012-04-04T09:20:00.000Z",
     "end": "2014-02-19T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yxDsatI4qOZJxy8",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1669",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -589,12 +396,7 @@
       {
         "site": "letv",
         "id": "74703",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -610,7 +412,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/prettyrhythm2012/",
     "begin": "2012-04-07T01:00:00.000Z",
     "end": "2013-03-30T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -619,12 +420,7 @@
       {
         "site": "nicovideo",
         "id": "prettyrhythm_dear_n",
-        "begin": "2012-09-28T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-28T11:00:00.000Z"
       }
     ]
   },
@@ -643,41 +439,20 @@
     "officialSite": "http://zetman.jp/index.html",
     "begin": "2012-04-02T17:44:00.000Z",
     "end": "2012-06-25T17:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vibTgXsYsnNo9uyM",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "74655",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "24738"
-      },
-      {
-        "site": "bilibili",
-        "id": "792",
-        "begin": "2012-04-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -693,27 +468,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/sencolle/",
     "begin": "2012-04-05T16:45:00.000Z",
     "end": "2012-09-27T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3wQAfuZMvPpd20M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "74775",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -722,22 +486,12 @@
       {
         "site": "nicovideo",
         "id": "sencolle",
-        "begin": "2012-04-24T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-24T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "795",
-        "begin": "2012-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -753,17 +507,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/ackc/",
     "begin": "2012-04-05T17:20:00.000Z",
     "end": "2012-06-28T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3AP9eibNJufda2EA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -772,12 +520,7 @@
       {
         "site": "bilibili",
         "id": "782",
-        "begin": "2012-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -793,17 +536,11 @@
     "officialSite": "http://kadokawa-anime.jp/zombie/",
     "begin": "2012-04-04T16:00:00.000Z",
     "end": "2012-06-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yhHradE3pibVIxia4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -812,12 +549,7 @@
       {
         "site": "bilibili",
         "id": "698",
-        "begin": "2012-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -833,7 +565,6 @@
     "officialSite": "http://nyaruko.com/first/news/",
     "begin": "2012-04-09T17:00:00.000Z",
     "end": "2012-06-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -842,12 +573,7 @@
       {
         "site": "nicovideo",
         "id": "nyaruko",
-        "begin": "2012-04-10T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-10T16:30:00.000Z"
       }
     ]
   },
@@ -863,7 +589,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/sankarea/",
     "begin": "2012-04-05T17:50:00.000Z",
     "end": "2015-06-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -872,12 +597,7 @@
       {
         "site": "bilibili",
         "id": "710",
-        "begin": "2012-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -893,17 +613,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_rikoran/",
     "begin": "2012-04-03T16:30:00.000Z",
     "end": "2012-06-26T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "h/h5tv4p8g9k1ec22",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -912,22 +626,12 @@
       {
         "site": "nicovideo",
         "id": "rikoran2",
-        "begin": "2012-04-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-12T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1674",
-        "begin": "2012-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -943,7 +647,6 @@
     "officialSite": "http://www.kotenbu.com/",
     "begin": "2012-04-22T15:30:00.000Z",
     "end": "2012-09-16T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -952,22 +655,12 @@
       {
         "site": "bilibili",
         "id": "3398",
-        "begin": "2012-04-22T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-22T03:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kotenbu",
-        "begin": "2017-09-16T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-16T03:00:00.000Z"
       }
     ]
   },
@@ -983,27 +676,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/jp-kiradeco/",
     "begin": "2012-04-06T22:00:00.000Z",
     "end": "2013-03-29T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icSIenARq2hh7ibWE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "74952",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1023,7 +705,6 @@
     "officialSite": "http://shining-world.jp/heartsTV/",
     "begin": "2012-04-12T18:22:00.000Z",
     "end": "2012-06-30T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1032,32 +713,17 @@
       {
         "site": "nicovideo",
         "id": "hearts",
-        "begin": "2012-04-18T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-18T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "797",
-        "begin": "2012-04-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-11T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "75075",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1073,27 +739,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/arashinoyoruni/",
     "begin": "2012-04-04T08:30:00.000Z",
     "end": "2012-09-26T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icCMdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "74877",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1102,12 +757,7 @@
       {
         "site": "bilibili",
         "id": "796",
-        "begin": "2012-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -1123,27 +773,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/gon/",
     "begin": "2012-04-02T09:00:00.000Z",
     "end": "2013-03-25T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oicbSULgejswvrRU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "76706",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1163,7 +802,6 @@
     "officialSite": "http://www.kimiboku.tv/",
     "begin": "2012-04-02T16:30:00.000Z",
     "end": "2012-06-25T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1172,12 +810,7 @@
       {
         "site": "nicovideo",
         "id": "kimiboku2",
-        "begin": "2012-04-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-06T14:30:00.000Z"
       }
     ]
   },
@@ -1193,17 +826,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_shibainukosan/",
     "begin": "2012-04-01T13:27:00.000Z",
     "end": "2012-09-23T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sibjUUrogkM4xrxc",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1212,22 +839,12 @@
       {
         "site": "nicovideo",
         "id": "inuko",
-        "begin": "2012-04-01T13:27:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-01T13:27:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "798",
-        "begin": "2012-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-03-31T16:00:00.000Z"
       }
     ]
   },
@@ -1243,7 +860,6 @@
     "officialSite": "http://fujiko.tv/",
     "begin": "2012-04-04T16:54:00.000Z",
     "end": "2012-06-27T16:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1252,12 +868,7 @@
       {
         "site": "nicovideo",
         "id": "minefujiko",
-        "begin": "2015-07-06T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-06T06:00:00.000Z"
       }
     ]
   },
@@ -1273,7 +884,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mukashibanashi/",
     "begin": "2012-04-01T00:00:00.000Z",
     "end": "2017-03-26T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1294,18 +904,7 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/lee/",
     "begin": "2012-04-03T09:00:00.000Z",
     "end": "2013-03-26T09:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2539",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "28496"
@@ -1324,7 +923,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mf-beyblade-zero/",
     "begin": "2012-04-07T23:30:00.000Z",
     "end": "2012-12-22T23:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1333,12 +931,7 @@
       {
         "site": "bilibili",
         "id": "804",
-        "begin": "2012-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -1357,17 +950,11 @@
     "officialSite": "http://cf-vanguard.com/",
     "begin": "2012-04-08T01:00:00.000Z",
     "end": "2013-01-01T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SZFr6VG3J2XIRq4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1376,12 +963,7 @@
       {
         "site": "nicovideo",
         "id": "vanguard2",
-        "begin": "2012-04-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-08T02:00:00.000Z"
       }
     ]
   },
@@ -1400,37 +982,21 @@
     "officialSite": "http://www.noitamina-apollon.com/",
     "begin": "2012-04-12T16:10:00.000Z",
     "end": "2012-06-28T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TpJu7FS6KmjLSbE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/lqq620btdscncwi",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "291599",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1439,32 +1005,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhbsm25",
-        "begin": "2017-11-16T07:29:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-16T07:29:46.000Z"
       },
       {
         "site": "bilibili",
         "id": "780",
-        "begin": "2012-04-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-11T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "75047",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1483,21 +1034,10 @@
     "officialSite": "http://www.tsuritama.com/",
     "begin": "2012-04-12T16:40:00.000Z",
     "end": "2012-06-28T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "33255"
-      },
-      {
-        "site": "bilibili",
-        "id": "781",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
       }
     ]
   },
@@ -1513,7 +1053,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/shirokumacafe/",
     "begin": "2012-04-05T08:30:00.000Z",
     "end": "2013-03-28T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1533,7 +1072,6 @@
     "officialSite": "http://zumonupe.com/",
     "begin": "2012-04-03T09:20:00.000Z",
     "end": "2013-02-26T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1553,7 +1091,6 @@
     "officialSite": "http://xn--u9j429qiq1a.jp/",
     "begin": "2012-04-06T09:20:00.000Z",
     "end": "2013-02-15T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1562,12 +1099,7 @@
       {
         "site": "nicovideo",
         "id": "taka",
-        "begin": "2012-04-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-08T15:00:00.000Z"
       }
     ]
   },
@@ -1587,17 +1119,11 @@
     "officialSite": "http://www.phibrain.net/",
     "begin": "2012-04-08T08:30:00.000Z",
     "end": "2012-09-23T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjvmd3t",
-        "begin": "2013-05-08T12:24:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-05-08T12:24:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1618,27 +1144,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/inazumago/",
     "begin": "2012-04-18T10:00:00.000Z",
     "end": "2013-05-01T10:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgjdgdd",
-        "begin": "2013-12-31T07:09:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-31T07:09:11.000Z"
       },
       {
         "site": "letv",
         "id": "75607",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1658,17 +1173,11 @@
     "officialSite": "http://www.upotte.jp/",
     "begin": "2012-04-07T14:30:00.000Z",
     "end": "2012-06-09T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibiaEbmQFn1xV49l4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1677,32 +1186,17 @@
       {
         "site": "nicovideo",
         "id": "upotte",
-        "begin": "2013-03-02T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-02T13:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "793",
-        "begin": "2012-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-06T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "74894",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1719,17 +1213,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/ginga/",
     "begin": "2012-04-03T09:25:00.000Z",
     "end": "2013-02-26T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9CsVkicth0Q9y8Fg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1749,17 +1237,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/gakkatsu/",
     "begin": "2012-04-03T12:55:00.000Z",
     "end": "2012-09-18T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "N2xY1j6kFFK1M5s",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1779,57 +1261,31 @@
     "officialSite": "http://www.kurobas.com/",
     "begin": "2012-04-07T17:00:00.000Z",
     "end": "2012-09-22T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibR7qaNA2puRHxS0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrk4bu5x",
-        "begin": "2012-11-28T02:10:29.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-28T02:10:29.000Z"
       },
       {
         "site": "qq",
         "id": "f/f7zblmkldorv3v7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "74847",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "12032",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1838,12 +1294,7 @@
       {
         "site": "bilibili",
         "id": "1624",
-        "begin": "2012-04-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1859,57 +1310,31 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/shin-tenipri/index.html",
     "begin": "2012-04-20T16:00:00.000Z",
     "end": "2013-04-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0Qj0ctpAsO5Rzzc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgidsjx",
-        "begin": "2014-05-15T03:35:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-15T03:35:52.000Z"
       },
       {
         "site": "qq",
         "id": "2/27xlyuggmbgs294",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "77522",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "51459",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1929,17 +1354,11 @@
     "officialSite": "http://momo-letter.jp/",
     "begin": "2012-04-21T16:00:00.000Z",
     "end": "2012-04-21T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "82070",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1948,22 +1367,12 @@
       {
         "site": "nicovideo",
         "id": "momo-letter",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4544",
-        "begin": "2012-04-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-20T16:00:01.000Z"
       }
     ]
   },
@@ -1979,27 +1388,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2012-04-14T16:00:00.000Z",
     "end": "2012-04-14T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/v_19rrifx01t.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/v_19rrifx01t.html"
       },
       {
         "site": "bangumi",
@@ -2008,12 +1406,7 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2029,17 +1422,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2012-04-14T16:00:00.000Z",
     "end": "2012-04-14T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -2048,22 +1435,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2079,7 +1456,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2012-04-02T08:35:00.000Z",
     "end": "2012-11-14T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2099,7 +1475,6 @@
     "officialSite": "http://www.yamato2199.net/",
     "begin": "2012-04-07T16:00:00.000Z",
     "end": "2012-04-07T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2119,17 +1494,11 @@
     "officialSite": "http://www.square-enix.com/jp/magazine/ganganonline/special/danshinichijyo/",
     "begin": "2012-04-03T16:00:00.000Z",
     "end": "2012-09-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HhXicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2138,12 +1507,7 @@
       {
         "site": "bilibili",
         "id": "2681",
-        "begin": "2012-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -2159,7 +1523,6 @@
     "officialSite": "http://www.starchild.co.jp/special/seitokai/top.html",
     "begin": "2012-04-25T16:00:00.000Z",
     "end": "2013-07-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2168,12 +1531,7 @@
       {
         "site": "nicovideo",
         "id": "seitokai_banngaihen",
-        "begin": "2017-06-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-14T03:00:00.000Z"
       }
     ]
   }

--- a/data/items/2012/05.json
+++ b/data/items/2012/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.primetime.gs/tightrope/",
     "begin": "2012-05-30T16:00:00.000Z",
     "end": "2012-06-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "w/wgma3oj0k3xn19e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,17 +35,11 @@
     "officialSite": "http://www.nijiirohotaru.com/",
     "begin": "2012-05-19T16:00:00.000Z",
     "end": "2012-05-19T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UDchnwdt3RtibicGQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "bilibili",
         "id": "4540",
-        "begin": "2012-05-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-05-18T16:00:01.000Z"
       }
     ]
   },
@@ -81,31 +64,15 @@
     "officialSite": "http://ai-mi.jp",
     "begin": "2012-05-25T16:00:00.000Z",
     "end": "2012-05-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "T5Bs6lK4KGbJR68",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "43139"
-      },
-      {
-        "site": "bilibili",
-        "id": "4533",
-        "begin": "2012-05-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2012/06.json
+++ b/data/items/2012/06.json
@@ -14,17 +14,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/kingdom/",
     "begin": "2012-06-04T10:00:00.000Z",
     "end": "2013-02-25T09:56:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi9if1",
-        "begin": "2014-09-12T06:43:41.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:43:41.000Z"
       },
       {
         "site": "bangumi",
@@ -33,22 +27,12 @@
       {
         "site": "nicovideo",
         "id": "kingdom1",
-        "begin": "2015-12-24T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-24T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "582",
-        "begin": "2012-06-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-03T16:00:00.000Z"
       }
     ]
   },
@@ -64,27 +48,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_bw/",
     "begin": "2012-06-21T10:00:00.000Z",
     "end": "2013-09-26T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icFdBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hibacbz0801byjb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -104,7 +77,6 @@
     "officialSite": "http://www.yamato2199.net/",
     "begin": "2012-06-30T16:00:00.000Z",
     "end": "2012-06-30T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -124,17 +96,11 @@
     "officialSite": "",
     "begin": "2012-06-15T16:00:00.000Z",
     "end": "2012-06-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "F0dBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -143,12 +109,7 @@
       {
         "site": "bilibili",
         "id": "4524",
-        "begin": "2012-06-15T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-15T16:00:00.000Z"
       }
     ]
   },
@@ -167,7 +128,6 @@
     "officialSite": "http://www.berserkfilm.com/",
     "begin": "2012-06-23T16:00:00.000Z",
     "end": "2012-06-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -176,22 +136,12 @@
       {
         "site": "nicovideo",
         "id": "berserkfilm",
-        "begin": "2017-03-03T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-03T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70276596",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   },
@@ -207,7 +157,6 @@
     "officialSite": "http://www.kadokawa.co.jp/toshokan-sensou/",
     "begin": "2012-06-16T16:00:00.000Z",
     "end": "2012-06-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -216,32 +165,17 @@
       {
         "site": "nicovideo",
         "id": "toshokan",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "85725",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3805",
-        "begin": "2012-06-15T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-15T16:00:01.000Z"
       }
     ]
   },
@@ -257,7 +191,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/sankarea/",
     "begin": "2012-06-08T16:00:00.000Z",
     "end": "2012-11-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -266,12 +199,7 @@
       {
         "site": "pptv",
         "id": "pkAsqhJ46CaJB28",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2012/07.json
+++ b/data/items/2012/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://yuruyuri.com/2nd/",
     "begin": "2012-07-02T17:00:00.000Z",
     "end": "2012-09-17T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "yuruyuri2",
-        "begin": "2012-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-03T14:30:00.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "http://www.campi-anime.com/",
     "begin": "2012-07-06T14:30:00.000Z",
     "end": "2012-09-28T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6DIOjPRayghr6VE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -71,7 +59,6 @@
     "officialSite": "http://odanobuna.com/",
     "begin": "2012-07-08T16:05:00.000Z",
     "end": "2012-09-23T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,12 +67,7 @@
       {
         "site": "nicovideo",
         "id": "odanobuna",
-        "begin": "2012-07-15T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-15T15:30:00.000Z"
       }
     ]
   },
@@ -102,27 +84,16 @@
     "officialSite": "http://lag-rin.com/",
     "begin": "2012-07-01T13:00:00.000Z",
     "end": "2012-09-23T13:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uOLeXMQqmtg7uSE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjvnpl9",
-        "begin": "2014-04-09T23:06:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:06:33.000Z"
       },
       {
         "site": "bangumi",
@@ -131,22 +102,12 @@
       {
         "site": "nicovideo",
         "id": "lag-rin",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2679",
-        "begin": "2012-06-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -162,18 +123,7 @@
     "officialSite": "http://boku-h.com/",
     "begin": "2012-07-06T02:00:00.000Z",
     "end": "2012-09-25T08:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "66561",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "29650"
@@ -181,12 +131,7 @@
       {
         "site": "nicovideo",
         "id": "boku-h",
-        "begin": "2012-07-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-15T15:00:00.000Z"
       }
     ]
   },
@@ -202,7 +147,6 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_chitose/",
     "begin": "2012-07-01T15:56:00.000Z",
     "end": "2012-12-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -211,22 +155,12 @@
       {
         "site": "nicovideo",
         "id": "getyou",
-        "begin": "2012-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-05T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3352",
-        "begin": "2012-06-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-30T16:00:01.000Z"
       }
     ]
   },
@@ -242,27 +176,16 @@
     "officialSite": "http://www.koichoco.com/",
     "begin": "2012-07-05T16:25:00.000Z",
     "end": "2012-09-27T17:04:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4jwIhu5UxAJl40s",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "t/tozq3ocxm4tnxmp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -271,22 +194,7 @@
       {
         "site": "nicovideo",
         "id": "koichoco",
-        "begin": "2012-07-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "759",
-        "begin": "2012-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-30T16:00:00.000Z"
       }
     ]
   },
@@ -302,7 +210,6 @@
     "officialSite": "http://kichiku.tv/",
     "begin": "2012-07-06T01:30:00.000Z",
     "end": "2012-09-21T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -311,12 +218,7 @@
       {
         "site": "nicovideo",
         "id": "hagure",
-        "begin": "2012-07-26T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-26T15:00:00.000Z"
       }
     ]
   },
@@ -333,27 +235,16 @@
     "officialSite": "http://www.kokoro-connect.com/",
     "begin": "2012-07-07T15:30:00.000Z",
     "end": "2013-04-03T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "t4Ju7FS6KmjLSbE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "78824",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -362,22 +253,12 @@
       {
         "site": "nicovideo",
         "id": "kokoro-connect",
-        "begin": "2012-07-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-13T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "713",
-        "begin": "2012-07-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-06T16:00:00.000Z"
       }
     ]
   },
@@ -396,18 +277,7 @@
     "officialSite": "http://muv-luv-te-anime.com/",
     "begin": "2012-07-01T16:35:00.000Z",
     "end": "2012-12-23T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2592",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "20729"
@@ -415,12 +285,7 @@
       {
         "site": "nicovideo",
         "id": "total-eclipse",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -436,17 +301,11 @@
     "officialSite": "http://www.maql.co.jp/special/jintai/",
     "begin": "2012-07-01T15:00:00.000Z",
     "end": "2012-09-16T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "j/jvjsmfymdpk151d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -455,32 +314,17 @@
       {
         "site": "nicovideo",
         "id": "jintai",
-        "begin": "2012-07-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-05T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "703",
-        "begin": "2012-06-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-30T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "78808",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -499,17 +343,11 @@
     "officialSite": "http://www.swordart-online.net/aincrad/",
     "begin": "2012-07-07T15:00:00.000Z",
     "end": "2012-12-22T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "78569",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -518,22 +356,12 @@
       {
         "site": "nicovideo",
         "id": "swordart-online",
-        "begin": "2012-07-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-09T15:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70302573",
-        "begin": "2017-06-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-01T07:00:00.000Z"
       }
     ]
   },
@@ -549,7 +377,6 @@
     "officialSite": "http://www.binbogamiga.net/",
     "begin": "2012-07-04T16:50:00.000Z",
     "end": "2012-09-26T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -569,7 +396,6 @@
     "officialSite": "http://www.starchild.co.jp/special/joshiraku/",
     "begin": "2012-07-05T17:25:00.000Z",
     "end": "2012-09-27T17:39:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -578,22 +404,7 @@
       {
         "site": "nicovideo",
         "id": "joshiraku",
-        "begin": "2012-07-14T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "757",
-        "begin": "2012-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-14T17:00:00.000Z"
       }
     ]
   },
@@ -609,7 +420,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/nakaimo/",
     "begin": "2012-07-05T16:55:00.000Z",
     "end": "2012-09-27T17:34:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -618,12 +428,7 @@
       {
         "site": "nicovideo",
         "id": "nakaimo",
-        "begin": "2013-03-29T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-29T06:00:00.000Z"
       }
     ]
   },
@@ -639,7 +444,6 @@
     "officialSite": "http://taritari.jp/",
     "begin": "2012-07-01T13:30:00.000Z",
     "end": "2012-09-23T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -648,22 +452,12 @@
       {
         "site": "nicovideo",
         "id": "taritari",
-        "begin": "2012-07-07T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-07T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "752",
-        "begin": "2012-06-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -682,27 +476,16 @@
     "officialSite": "http://arcanafamiglia.com/",
     "begin": "2012-07-01T14:30:00.000Z",
     "end": "2012-09-16T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vN6qKJD2ZqQHhe0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "78810",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -711,22 +494,12 @@
       {
         "site": "nicovideo",
         "id": "arcana",
-        "begin": "2012-07-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-07T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "767",
-        "begin": "2012-06-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -742,37 +515,16 @@
     "officialSite": "http://www.dogdays.tv/2nd/",
     "begin": "2012-07-07T14:30:00.000Z",
     "end": "2012-09-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6jQQjvZczApt61M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "66707",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "78602",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -780,13 +532,8 @@
       },
       {
         "site": "bilibili",
-        "id": "1632",
-        "begin": "2012-07-07T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10292",
+        "begin": "2012-07-07T14:30:00.000Z"
       }
     ]
   },
@@ -802,27 +549,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/driland/",
     "begin": "2012-07-07T14:30:00.000Z",
     "end": "2013-03-30T14:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Qp1n5U2zI2HEQqo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb14f5",
-        "begin": "2015-08-14T17:05:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:05:08.000Z"
       },
       {
         "site": "bangumi",
@@ -845,17 +581,11 @@
     "officialSite": "http://natsuyuki.tv/",
     "begin": "2012-07-05T16:35:00.000Z",
     "end": "2012-09-13T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "78773",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -864,22 +594,12 @@
       {
         "site": "bilibili",
         "id": "760",
-        "begin": "2012-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-04T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "4TsFgibtRwf9ia4Eg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -895,27 +615,16 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/hakuoki/tv/",
     "begin": "2012-07-01T12:25:00.000Z",
     "end": "2012-09-24T18:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icB7qaNA2puRHxS0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "78817",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -924,22 +633,12 @@
       {
         "site": "nicovideo",
         "id": "hakuoki_reimeiroku",
-        "begin": "2012-07-12T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-12T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "763",
-        "begin": "2012-07-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-08T16:00:00.000Z"
       }
     ]
   },
@@ -955,7 +654,6 @@
     "officialSite": "http://kamosuzo2.tv/",
     "begin": "2012-07-05T16:05:00.000Z",
     "end": "2012-09-13T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -964,12 +662,7 @@
       {
         "site": "bilibili",
         "id": "1687",
-        "begin": "2012-07-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -985,18 +678,7 @@
     "officialSite": "http://www.anime-utakoi.jp/",
     "begin": "2012-07-02T16:30:00.000Z",
     "end": "2012-09-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "66701",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "37138"
@@ -1004,12 +686,7 @@
       {
         "site": "nicovideo",
         "id": "utakoi",
-        "begin": "2012-07-24T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-24T14:30:00.000Z"
       }
     ]
   },
@@ -1026,37 +703,21 @@
     "officialSite": "http://genesis-horizon.net/",
     "begin": "2012-07-07T17:28:00.000Z",
     "end": "2012-09-29T17:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8SsVkicth0Q9y8Fg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjvnh4p",
-        "begin": "2014-09-12T06:24:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:24:04.000Z"
       },
       {
         "site": "letv",
         "id": "78766",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1065,12 +726,7 @@
       {
         "site": "bilibili",
         "id": "2677",
-        "begin": "2012-07-07T17:28:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-07T17:28:00.000Z"
       }
     ]
   },
@@ -1086,17 +742,11 @@
     "officialSite": "http://ebiten.jp/",
     "begin": "2012-07-14T14:30:00.000Z",
     "end": "2012-09-15T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "G0RAviaaMicDqdG4M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1105,22 +755,7 @@
       {
         "site": "nicovideo",
         "id": "ch60325",
-        "begin": "2013-04-06T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "774",
-        "begin": "2012-07-13T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-06T13:00:00.000Z"
       }
     ]
   },
@@ -1136,17 +771,11 @@
     "officialSite": "http://www.moe-ribbon.com/",
     "begin": "2012-07-31T01:25:00.000Z",
     "end": "2012-11-15T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uuXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1155,12 +784,7 @@
       {
         "site": "nicovideo",
         "id": "ribbon",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1176,27 +800,16 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2012-07-14T16:00:00.000Z",
     "end": "2012-07-14T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "bangumi",
@@ -1205,22 +818,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "6413",
-        "begin": "2012-07-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-13T16:00:00.000Z"
       }
     ]
   },
@@ -1236,7 +839,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2012-07-14T17:10:00.000Z",
     "end": "2012-07-14T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1256,7 +858,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2012-07-14T17:10:00.000Z",
     "end": "2012-07-14T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1276,17 +877,11 @@
     "officialSite": "",
     "begin": "2012-07-07T16:00:00.000Z",
     "end": "2012-07-07T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xK2HBW3TQ4HkYso",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1295,12 +890,7 @@
       {
         "site": "bilibili",
         "id": "4451",
-        "begin": "2012-07-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-06T16:00:01.000Z"
       }
     ]
   },
@@ -1316,17 +906,11 @@
     "officialSite": "",
     "begin": "2012-07-26T16:00:00.000Z",
     "end": "2012-07-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FkZCwCiaOicjyfHYU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1335,12 +919,7 @@
       {
         "site": "bilibili",
         "id": "3781",
-        "begin": "2012-07-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-07-25T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2012/08.json
+++ b/data/items/2012/08.json
@@ -12,31 +12,15 @@
     "officialSite": "http://kyonoasukashow.com/",
     "begin": "2012-08-03T14:25:00.000Z",
     "end": "2013-01-04T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vd6qKJD2ZqQHhe0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "46079"
-      },
-      {
-        "site": "bilibili",
-        "id": "1678",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
       }
     ]
   },
@@ -52,17 +36,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/onep/campaign/nami_sp/",
     "begin": "2012-08-25T16:00:00.000Z",
     "end": "2012-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "url": "http://www.iqiyi.com/v_19rro4guhk.html",
-        "exist": null
+        "url": "http://www.iqiyi.com/v_19rro4guhk.html"
       },
       {
         "site": "bangumi",
@@ -82,17 +60,11 @@
     "officialSite": "http://milky-holmes.com/anime/series/",
     "begin": "2012-08-25T16:00:00.000Z",
     "end": "2012-08-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tOTgXsYsnNo9uyM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,12 +73,7 @@
       {
         "site": "nicovideo",
         "id": "milky-holmes_alt",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -122,17 +89,11 @@
     "officialSite": "http://b.bngi-channel.jp/lag-rin",
     "begin": "2012-08-23T16:00:00.000Z",
     "end": "2012-08-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "81606",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -141,12 +102,7 @@
       {
         "site": "bilibili",
         "id": "3812",
-        "begin": "2012-08-22T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-22T16:00:01.000Z"
       }
     ]
   },
@@ -162,27 +118,16 @@
     "officialSite": "http://www.geass.jp/akito/",
     "begin": "2012-08-04T16:00:00.000Z",
     "end": "2012-08-04T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "otmjIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "82177",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -202,17 +147,11 @@
     "officialSite": "http://www.kyousogiga.com/",
     "begin": "2012-08-31T16:00:00.000Z",
     "end": "2012-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WISAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -221,12 +160,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4oit",
-        "begin": "2015-09-23T08:10:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-23T08:10:24.000Z"
       }
     ]
   },
@@ -242,17 +176,11 @@
     "officialSite": "",
     "begin": "2012-08-11T16:00:00.000Z",
     "end": "2012-08-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "G0M9uyOJibTeaGIA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -261,12 +189,7 @@
       {
         "site": "bilibili",
         "id": "3521",
-        "begin": "2012-08-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-10T16:00:01.000Z"
       }
     ]
   },
@@ -282,7 +205,6 @@
     "officialSite": "http://fairytail-movie.com/",
     "begin": "2012-08-18T16:00:00.000Z",
     "end": "2012-08-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -291,22 +213,12 @@
       {
         "site": "nicovideo",
         "id": "fairytail_houounomiko",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "4498",
-        "begin": "2012-08-17T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "57752",
+        "begin": "2012-08-17T16:00:01.000Z"
       }
     ]
   },
@@ -322,7 +234,6 @@
     "officialSite": "",
     "begin": "2012-08-08T16:00:00.000Z",
     "end": "2014-09-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -331,12 +242,7 @@
       {
         "site": "nicovideo",
         "id": "ikamusume-ova-01",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -352,7 +258,6 @@
     "officialSite": "http://www.jpet-movie.com/",
     "begin": "2012-08-11T16:00:00.000Z",
     "end": "2012-08-11T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -361,22 +266,12 @@
       {
         "site": "pptv",
         "id": "P9G7OaEHd7UYlv4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4508",
-        "begin": "2012-08-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-08-10T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2012/09.json
+++ b/data/items/2012/09.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.nagoyatv.com/battlespirits_sword/",
     "begin": "2012-09-08T22:00:00.000Z",
     "end": "2013-09-07T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icnVf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -44,37 +38,21 @@
     "officialSite": "http://www.tv-asahi.co.jp/shinsekaiyori/",
     "begin": "2012-09-28T15:30:00.000Z",
     "end": "2013-03-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yzAMiavJYyAZp508",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjqp109",
-        "begin": "2014-09-12T06:41:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:41:31.000Z"
       },
       {
         "site": "letv",
         "id": "81938",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -83,22 +61,12 @@
       {
         "site": "nicovideo",
         "id": "shinsekaiyori",
-        "begin": "2012-10-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-04T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1598",
-        "begin": "2012-09-27T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-27T16:00:00.000Z"
       }
     ]
   },
@@ -114,7 +82,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tamagotchi/",
     "begin": "2012-09-10T10:00:00.000Z",
     "end": "2013-08-29T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -134,27 +101,16 @@
     "officialSite": "http://www.hiironokakera.tv/",
     "begin": "2012-09-30T13:00:00.000Z",
     "end": "2012-12-23T13:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4RbycNgibruxPzTU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "81939",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -163,12 +119,7 @@
       {
         "site": "bilibili",
         "id": "743",
-        "begin": "2012-09-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-29T16:00:00.000Z"
       }
     ]
   },
@@ -184,41 +135,20 @@
     "officialSite": "http://accel-world-game.channel.or.jp/",
     "begin": "2012-09-13T16:00:00.000Z",
     "end": "2012-09-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Klslowtx4RibCAGg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "81965",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "48997"
-      },
-      {
-        "site": "bilibili",
-        "id": "3487",
-        "begin": "2012-09-12T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -234,17 +164,11 @@
     "officialSite": "http://asura-movie.com/",
     "begin": "2012-09-29T16:00:00.000Z",
     "end": "2012-09-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "87629",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -253,12 +177,7 @@
       {
         "site": "nicovideo",
         "id": "asura-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -274,17 +193,11 @@
     "officialSite": "",
     "begin": "2012-09-14T16:00:00.000Z",
     "end": "2012-09-14T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TbiaEAmrQQH7hX8c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -293,22 +206,12 @@
       {
         "site": "nicovideo",
         "id": "ch60379",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4473",
-        "begin": "2012-09-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-13T16:00:01.000Z"
       }
     ]
   },
@@ -324,7 +227,6 @@
     "officialSite": "",
     "begin": "2012-09-26T16:00:00.000Z",
     "end": "2012-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2012/10.json
+++ b/data/items/2012/10.json
@@ -11,27 +11,16 @@
     "officialSite": "http://sakurasou.tv/",
     "begin": "2012-10-08T15:30:00.000Z",
     "end": "2013-03-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Cm5a2ECmFlS3NZ0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "687",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -40,22 +29,12 @@
       {
         "site": "nicovideo",
         "id": "sakurasou",
-        "begin": "2012-10-15T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-15T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgimfh9",
-        "begin": "2018-12-27T07:45:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-27T07:45:39.000Z"
       }
     ]
   },
@@ -74,27 +53,16 @@
     "officialSite": "http://www.tbs.co.jp/anime/hidamari/",
     "begin": "2012-10-04T16:25:00.000Z",
     "end": "2012-12-20T17:22:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6Q76eOBGtvRX1T0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "m/movj0t928nc1w8v",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -103,32 +71,17 @@
       {
         "site": "nicovideo",
         "id": "hidamari_04",
-        "begin": "2014-12-25T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-25T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "734",
-        "begin": "2012-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-04T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhg0wud",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -144,17 +97,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/busou/",
     "begin": "2012-10-04T16:55:00.000Z",
     "end": "2012-12-20T17:52:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7hXvbdU7qiblMyjI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -163,12 +110,7 @@
       {
         "site": "bilibili",
         "id": "741",
-        "begin": "2012-10-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -187,7 +129,6 @@
     "officialSite": "http://girls-und-panzer.jp/",
     "begin": "2012-10-08T16:00:00.000Z",
     "end": "2013-03-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -196,22 +137,12 @@
       {
         "site": "nicovideo",
         "id": "girls-und-panzer",
-        "begin": "2017-11-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-10T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2890",
-        "begin": "2012-10-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -227,27 +158,16 @@
     "officialSite": "http://www.zetsuen.net/",
     "begin": "2012-10-04T17:00:00.000Z",
     "end": "2013-03-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjsuavh",
-        "begin": "2012-12-27T07:07:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-27T07:07:50.000Z"
       },
       {
         "site": "bilibili",
         "id": "3786",
-        "begin": "2012-12-27T07:07:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-27T07:07:50.000Z"
       },
       {
         "site": "bangumi",
@@ -256,12 +176,7 @@
       {
         "site": "nicovideo",
         "id": "zetsuen",
-        "begin": "2014-06-02T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-06-02T06:00:00.000Z"
       }
     ]
   },
@@ -277,7 +192,6 @@
     "officialSite": "http://oniai.com/",
     "begin": "2012-10-05T14:00:00.000Z",
     "end": "2012-12-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -286,12 +200,7 @@
       {
         "site": "nicovideo",
         "id": "oniai",
-        "begin": "2012-10-18T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-18T15:00:00.000Z"
       }
     ]
   },
@@ -311,17 +220,11 @@
     "officialSite": "http://litbus-anime.com/lb/",
     "begin": "2012-10-06T13:30:00.000Z",
     "end": "2013-04-06T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9Av1c9tBse9S0Dg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -330,12 +233,7 @@
       {
         "site": "bilibili",
         "id": "3242",
-        "begin": "2012-10-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -351,7 +249,6 @@
     "officialSite": "http://www.j-toloveru.com/",
     "begin": "2012-10-05T16:00:00.000Z",
     "end": "2012-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -360,12 +257,7 @@
       {
         "site": "nicovideo",
         "id": "to-love-ru3",
-        "begin": "2012-10-17T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-17T06:00:00.000Z"
       }
     ]
   },
@@ -384,7 +276,6 @@
     "officialSite": "http://www.anime-chu-2.com/tv/",
     "begin": "2012-10-03T15:30:00.000Z",
     "end": "2013-12-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -393,22 +284,12 @@
       {
         "site": "nicovideo",
         "id": "chu-2",
-        "begin": "2018-01-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-05T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4340",
-        "begin": "2012-10-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-02T16:00:01.000Z"
       }
     ]
   },
@@ -424,7 +305,6 @@
     "officialSite": "http://medakabox.jp/",
     "begin": "2012-10-10T16:35:00.000Z",
     "end": "2012-12-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -433,12 +313,7 @@
       {
         "site": "nicovideo",
         "id": "medakabox2",
-        "begin": "2012-10-13T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-13T16:30:00.000Z"
       }
     ]
   },
@@ -454,27 +329,16 @@
     "officialSite": "http://www.mikagesha.com/",
     "begin": "2012-10-01T17:05:00.000Z",
     "end": "2012-12-24T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3yQgngZs3Bp9ib2M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifubx4",
-        "begin": "2014-09-12T06:24:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:24:03.000Z"
       },
       {
         "site": "bangumi",
@@ -483,12 +347,7 @@
       {
         "site": "nicovideo",
         "id": "mikagesha",
-        "begin": "2014-09-26T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-26T06:00:00.000Z"
       }
     ]
   },
@@ -504,18 +363,7 @@
     "officialSite": "http://roboticsnotes.tv/",
     "begin": "2012-10-11T16:20:00.000Z",
     "end": "2013-03-21T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2717",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "37673"
@@ -535,37 +383,21 @@
     "officialSite": "http://k-project.jpn.com/",
     "begin": "2012-10-04T16:30:00.000Z",
     "end": "2012-12-27T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6hHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgib6st",
-        "begin": "2014-03-24T08:12:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-24T08:12:03.000Z"
       },
       {
         "site": "qq",
         "id": "u/ucr8ih2v86a22yt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -574,32 +406,17 @@
       {
         "site": "nicovideo",
         "id": "k-project",
-        "begin": "2012-10-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-13T16:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80040118",
-        "begin": "2016-12-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-01T08:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "685",
-        "begin": "2012-10-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-03T16:00:00.000Z"
       }
     ]
   },
@@ -615,7 +432,6 @@
     "officialSite": "http://www.btooom.com/",
     "begin": "2012-10-04T14:00:00.000Z",
     "end": "2012-12-20T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -624,12 +440,7 @@
       {
         "site": "nicovideo",
         "id": "btooom",
-        "begin": "2012-10-08T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-08T13:30:00.000Z"
       }
     ]
   },
@@ -646,17 +457,11 @@
     "officialSite": "http://www.hayate-project.com/",
     "begin": "2012-10-03T17:05:00.000Z",
     "end": "2012-12-19T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb0zhx",
-        "begin": "2015-03-30T08:49:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-30T08:49:08.000Z"
       },
       {
         "site": "bangumi",
@@ -665,12 +470,7 @@
       {
         "site": "bilibili",
         "id": "4341",
-        "begin": "2012-10-02T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-02T16:00:01.000Z"
       }
     ]
   },
@@ -687,17 +487,11 @@
     "officialSite": "http://www.aikatsu.net/",
     "begin": "2012-10-08T10:30:00.000Z",
     "end": "2013-09-26T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg551kx",
-        "begin": "2014-09-12T06:34:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:34:47.000Z"
       },
       {
         "site": "bangumi",
@@ -717,7 +511,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yugioh-zexal/",
     "begin": "2012-10-07T08:30:00.000Z",
     "end": "2014-03-23T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -738,27 +531,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/gyrozetter/",
     "begin": "2012-10-02T09:00:00.000Z",
     "end": "2013-09-24T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "B3tFwyuRATibiaIIg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb2l3l",
-        "begin": "2015-05-06T09:10:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-06T09:10:10.000Z"
       },
       {
         "site": "bangumi",
@@ -778,17 +560,11 @@
     "officialSite": "http://www.starchild.co.jp/special/sukinayo/",
     "begin": "2012-10-06T16:00:00.000Z",
     "end": "2012-12-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8wj0ctpAsO5Rzzc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -797,32 +573,17 @@
       {
         "site": "nicovideo",
         "id": "sukinayo",
-        "begin": "2012-10-12T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-12T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "81850",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "735",
-        "begin": "2012-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -840,37 +601,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/monsuno/",
     "begin": "2012-10-03T09:00:00.000Z",
     "end": "2013-09-25T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Rb2HBW3TQ4HkYso",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc35gx",
-        "begin": "2014-12-03T01:29:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-03T01:29:09.000Z"
       },
       {
         "site": "qq",
         "id": "d/d5px5k9ofmck6hf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -890,7 +635,6 @@
     "officialSite": "http://ixion-saga-anime.jp/",
     "begin": "2012-10-07T16:05:00.000Z",
     "end": "2013-03-31T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -899,12 +643,7 @@
       {
         "site": "nicovideo",
         "id": "ixion-saga",
-        "begin": "2012-10-15T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-15T14:30:00.000Z"
       }
     ]
   },
@@ -920,17 +659,11 @@
     "officialSite": "http://www.code-breaker.jp/",
     "begin": "2012-10-06T17:58:00.000Z",
     "end": "2012-12-26T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9Qr2dNxCsvBT0Tk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -953,7 +686,6 @@
     "officialSite": "http://jojo-animation.com/fb_bt/",
     "begin": "2012-10-05T15:30:00.000Z",
     "end": "2013-04-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -974,17 +706,11 @@
     "officialSite": "http://www.jormungand.tv/",
     "begin": "2012-10-09T15:30:00.000Z",
     "end": "2012-12-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "81956",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -993,12 +719,7 @@
       {
         "site": "nicovideo",
         "id": "jormungand2",
-        "begin": "2012-10-19T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-19T17:00:00.000Z"
       }
     ]
   },
@@ -1014,7 +735,6 @@
     "officialSite": "http://psycho-pass.com/",
     "begin": "2012-10-11T15:50:00.000Z",
     "end": "2013-03-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1034,37 +754,21 @@
     "officialSite": "http://www.tk-anime.info/",
     "begin": "2012-10-01T16:35:00.000Z",
     "end": "2012-12-24T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4Bfxb9c9retOzDQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifubvi",
-        "begin": "2014-04-09T23:07:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:07:15.000Z"
       },
       {
         "site": "letv",
         "id": "92037",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1073,22 +777,12 @@
       {
         "site": "nicovideo",
         "id": "tk-anime",
-        "begin": "2012-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-05T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "688",
-        "begin": "2012-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -1107,7 +801,6 @@
     "officialSite": "http://www.spaceshowertv.com/bis/",
     "begin": "2012-10-10T15:45:00.000Z",
     "end": "2012-11-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1116,12 +809,7 @@
       {
         "site": "nicovideo",
         "id": "bis",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1140,17 +828,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/oshiri/1st/",
     "begin": "2012-10-06T22:55:00.000Z",
     "end": "2013-02-23T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HWVf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1159,12 +841,7 @@
       {
         "site": "bilibili",
         "id": "5887",
-        "begin": "2012-10-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-06T16:00:01.000Z"
       }
     ]
   },
@@ -1180,17 +857,11 @@
     "officialSite": "http://www.b-daman.tv/eS/",
     "begin": "2012-10-06T23:45:00.000Z",
     "end": "2013-09-28T23:44:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lHVf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1214,17 +885,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/bakuman/",
     "begin": "2012-10-06T08:30:00.000Z",
     "end": "2013-03-30T08:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2013/smz3",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1233,22 +898,12 @@
       {
         "site": "nicovideo",
         "id": "bakuman3",
-        "begin": "2012-10-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-20T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "729",
-        "begin": "2012-10-06T08:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-06T08:30:00.000Z"
       }
     ]
   },
@@ -1264,17 +919,11 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2012-10-07T13:27:00.000Z",
     "end": "2012-12-23T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "n7OdG4PpWZf6eOA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1283,12 +932,7 @@
       {
         "site": "nicovideo",
         "id": "te-kyu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1307,17 +951,11 @@
     "officialSite": "http://wooser.tv/",
     "begin": "2012-10-02T16:35:00.000Z",
     "end": "2012-12-18T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BX1HxS2TA0GkIoo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1326,12 +964,7 @@
       {
         "site": "nicovideo",
         "id": "wooser",
-        "begin": "2012-09-25T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-25T03:00:00.000Z"
       }
     ]
   },
@@ -1347,17 +980,11 @@
     "officialSite": "http://litchi-hikari-club.com/",
     "begin": "2012-10-01T18:30:00.000Z",
     "end": "2012-11-19T18:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FGxY1j6kFFK1M5s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1366,12 +993,7 @@
       {
         "site": "bilibili",
         "id": "1685",
-        "begin": "2012-09-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-30T16:00:00.000Z"
       }
     ]
   },
@@ -1387,17 +1009,11 @@
     "officialSite": "http://seitokai-no-ichizon.com/",
     "begin": "2012-10-13T14:30:00.000Z",
     "end": "2012-12-15T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "I1cxrxd97SuODHQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1406,12 +1022,7 @@
       {
         "site": "nicovideo",
         "id": "seitokai2",
-        "begin": "2013-11-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-11-28T15:00:00.000Z"
       }
     ]
   },
@@ -1427,17 +1038,11 @@
     "officialSite": "http://hai-tai.jp/",
     "begin": "2012-10-06T21:55:00.000Z",
     "end": "2012-12-29T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hGtFwyuRATibiaIIg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1457,7 +1062,6 @@
     "officialSite": "http://www.j-gintama.com/",
     "begin": "2012-10-04T09:00:00.000Z",
     "end": "2013-03-28T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1466,12 +1070,7 @@
       {
         "site": "nicovideo",
         "id": "gintama-enchousen",
-        "begin": "2015-04-17T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-17T06:00:00.000Z"
       }
     ]
   },
@@ -1491,37 +1090,16 @@
     "officialSite": "http://www.project-magi.com/",
     "begin": "2012-10-07T08:00:00.000Z",
     "end": "2013-03-31T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icAP9eibNJufda2EA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "81852",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2707",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1530,22 +1108,12 @@
       {
         "site": "netflix",
         "id": "80009097",
-        "begin": "2017-11-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-01T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "470",
-        "begin": "2012-10-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -1561,27 +1129,16 @@
     "officialSite": "http://fuse-anime.com/",
     "begin": "2012-10-20T16:00:00.000Z",
     "end": "2012-10-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "2/264viwbl9bwu5q9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "109722",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1590,12 +1147,7 @@
       {
         "site": "bilibili",
         "id": "4303",
-        "begin": "2012-10-19T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-19T16:00:01.000Z"
       }
     ]
   },
@@ -1611,7 +1163,6 @@
     "officialSite": "http://www.yamato2199.net/",
     "begin": "2012-10-13T16:00:00.000Z",
     "end": "2012-10-13T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1631,17 +1182,11 @@
     "officialSite": "http://www.biohazardcg2.com/",
     "begin": "2012-10-27T16:00:00.000Z",
     "end": "2012-10-27T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "72pGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1661,17 +1206,11 @@
     "officialSite": "",
     "begin": "2012-10-25T16:00:00.000Z",
     "end": "2012-10-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "q8ib5N58FdbMWlPw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1680,12 +1219,7 @@
       {
         "site": "bilibili",
         "id": "4455",
-        "begin": "2012-10-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-24T16:00:01.000Z"
       }
     ]
   },
@@ -1701,17 +1235,11 @@
     "officialSite": "",
     "begin": "2012-10-05T16:00:00.000Z",
     "end": "2015-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uYhk4kqwIF7BP6c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1720,12 +1248,7 @@
       {
         "site": "bilibili",
         "id": "4333",
-        "begin": "2012-10-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-04T16:00:01.000Z"
       }
     ]
   },
@@ -1742,17 +1265,11 @@
     "officialSite": "http://mini-oyaji.com/",
     "begin": "2012-10-01T16:00:00.000Z",
     "end": "2014-04-25T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HGRg3kasHFq9O6M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1761,12 +1278,7 @@
       {
         "site": "nicovideo",
         "id": "mini-oyaji",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1782,17 +1294,11 @@
     "officialSite": "http://youngjump.jp/info/usogui_ova/",
     "begin": "2012-10-19T16:00:00.000Z",
     "end": "2012-10-19T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "60wopg505CKFA2s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1801,12 +1307,7 @@
       {
         "site": "bilibili",
         "id": "4305",
-        "begin": "2012-10-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-18T16:00:01.000Z"
       }
     ]
   },
@@ -1822,7 +1323,6 @@
     "officialSite": "http://aoisekai.net/anime.html",
     "begin": "2012-10-20T16:00:00.000Z",
     "end": "2013-04-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1831,12 +1331,7 @@
       {
         "site": "nicovideo",
         "id": "aoisekai-anime",
-        "begin": "2013-03-21T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-21T03:00:00.000Z"
       }
     ]
   },
@@ -1855,7 +1350,6 @@
     "officialSite": "http://www.madoka-magica.com/zenkouhen/",
     "begin": "2012-10-06T16:00:00.000Z",
     "end": "2012-10-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1864,22 +1358,12 @@
       {
         "site": "nicovideo",
         "id": "madoka-magica-movie1",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80041086",
-        "begin": "2015-06-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-01T07:00:00.000Z"
       }
     ]
   },
@@ -1895,7 +1379,6 @@
     "officialSite": "http://www.madoka-magica.com/zenkouhen/",
     "begin": "2012-10-13T16:00:00.000Z",
     "end": "2012-10-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1904,22 +1387,12 @@
       {
         "site": "nicovideo",
         "id": "madoka-magica-movie2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80041087",
-        "begin": "2015-06-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-01T07:00:00.000Z"
       }
     ]
   },
@@ -1935,7 +1408,6 @@
     "officialSite": "http://www.ph9.jp/",
     "begin": "2012-10-27T16:00:00.000Z",
     "end": "2012-10-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1944,22 +1416,12 @@
       {
         "site": "nicovideo",
         "id": "PH9",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4285",
-        "begin": "2012-10-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-10-26T16:00:01.000Z"
       }
     ]
   },
@@ -1975,7 +1437,6 @@
     "officialSite": "http://kc.kodansha.co.jp/minami/",
     "begin": "2012-10-05T16:00:00.000Z",
     "end": "2012-10-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1984,12 +1445,7 @@
       {
         "site": "pptv",
         "id": "F2tV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2005,7 +1461,6 @@
     "officialSite": "http://www.precure-movie.com/",
     "begin": "2012-10-27T16:00:00.000Z",
     "end": "2012-10-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2014,12 +1469,7 @@
       {
         "site": "letv",
         "id": "89803",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2012/11.json
+++ b/data/items/2012/11.json
@@ -11,7 +11,6 @@
     "officialSite": "http://lupin-3rd.net/sakuhin_tvsp.html",
     "begin": "2012-11-02T16:00:00.000Z",
     "end": "2012-11-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "bilibili",
         "id": "3955",
-        "begin": "2012-11-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-01T16:00:01.000Z"
       }
     ]
   },
@@ -41,17 +35,11 @@
     "officialSite": "http://www.neragaku.com/",
     "begin": "2012-11-10T16:00:00.000Z",
     "end": "2012-11-10T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vLyYFn7kVJL1c9s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "bilibili",
         "id": "2804",
-        "begin": "2012-11-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-09T16:00:00.000Z"
       }
     ]
   },
@@ -81,17 +64,11 @@
     "officialSite": "http://www.perfectchoice-pr.com/initial-d",
     "begin": "2012-11-09T16:00:00.000Z",
     "end": "2013-05-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cxXicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "211",
-        "begin": "2012-11-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-08T16:00:00.000Z"
       }
     ]
   },
@@ -121,17 +93,11 @@
     "officialSite": "http://www.mediafactory.co.jp/comic-alive/yumekuri/",
     "begin": "2012-11-28T16:00:00.000Z",
     "end": "2012-11-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eRP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -140,22 +106,12 @@
       {
         "site": "letv",
         "id": "86931",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4312",
-        "begin": "2012-11-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-11-27T16:00:01.000Z"
       }
     ]
   },
@@ -171,17 +127,11 @@
     "officialSite": "http://anime-oneoff.info/index.html",
     "begin": "2012-11-28T16:00:00.000Z",
     "end": "2012-10-13T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibSIenARq2hh7ibWE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -190,12 +140,7 @@
       {
         "site": "bilibili",
         "id": "3268",
-        "begin": "2012-09-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-09-30T16:00:01.000Z"
       }
     ]
   },
@@ -211,7 +156,6 @@
     "officialSite": "http://www.evangelion.co.jp/",
     "begin": "2012-11-17T16:00:00.000Z",
     "end": "2012-11-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -220,12 +164,7 @@
       {
         "site": "qq",
         "id": "3/32s44m851ltsbnu",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2012/12.json
+++ b/data/items/2012/12.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.imouto-okan.jp/",
     "begin": "2012-12-21T16:55:00.000Z",
     "end": "2013-03-15T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CibDMSrIYiaMYppw8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,22 +24,12 @@
       {
         "site": "nicovideo",
         "id": "imouto-okan",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "645",
-        "begin": "2012-12-21T16:55:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-21T16:55:00.000Z"
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "http://gdgdfairy.com/",
     "begin": "2012-12-27T18:00:00.000Z",
     "end": "2013-03-27T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "nicovideo",
         "id": "gdgd2",
-        "begin": "2014-08-18T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-18T06:00:00.000Z"
       }
     ]
   },
@@ -94,17 +72,11 @@
     "officialSite": "http://puchimas.com/1st/",
     "begin": "2012-12-31T15:00:00.000Z",
     "end": "2013-03-28T15:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TiaUPjfVbywls6lI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -113,22 +85,12 @@
       {
         "site": "nicovideo",
         "id": "petit-idolmaster",
-        "begin": "2013-03-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-11T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "106",
-        "begin": "2012-12-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-31T16:00:00.000Z"
       }
     ]
   },
@@ -144,7 +106,6 @@
     "officialSite": "http://www.nekomonogatarikuro-anime.com/",
     "begin": "2012-12-31T16:30:00.000Z",
     "end": "2012-12-31T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -153,22 +114,12 @@
       {
         "site": "nicovideo",
         "id": "nekomonogatari",
-        "begin": "2013-10-22T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-22T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "723",
-        "begin": "2012-12-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-30T16:00:00.000Z"
       }
     ]
   },
@@ -184,17 +135,11 @@
     "officialSite": "http://milky-holmes.com/anime/series/",
     "begin": "2012-12-31T16:00:00.000Z",
     "end": "2012-12-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tOTgXsYsnNo9uyM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -203,12 +148,7 @@
       {
         "site": "nicovideo",
         "id": "milky-holmes_alt2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -224,7 +164,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/onep/campaign/ruffi_sp/index.html",
     "begin": "2012-12-15T16:00:00.000Z",
     "end": "2012-12-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -244,7 +183,6 @@
     "officialSite": "",
     "begin": "2012-12-15T16:00:00.000Z",
     "end": "2012-12-15T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -265,27 +203,16 @@
     "officialSite": "http://www.mtvjapan.com/usavich/",
     "begin": "2012-12-16T16:00:00.000Z",
     "end": "2013-07-12T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aicnTUbkfj80wrhY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha7rrd",
-        "begin": "2017-04-21T06:13:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-21T06:13:24.000Z"
       },
       {
         "site": "bangumi",
@@ -305,17 +232,11 @@
     "officialSite": "http://www.saint023.com/",
     "begin": "2012-12-03T16:00:00.000Z",
     "end": "2013-08-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Mdia0MpoAcK4Rjicc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -324,22 +245,12 @@
       {
         "site": "letv",
         "id": "84341",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4309",
-        "begin": "2012-12-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-02T16:00:01.000Z"
       }
     ]
   },
@@ -355,17 +266,11 @@
     "officialSite": "http://www.inazuma-movie.jp/",
     "begin": "2012-12-01T16:00:00.000Z",
     "end": "2012-12-01T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Q8SwLpb8bKoNiaicM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -385,17 +290,11 @@
     "officialSite": "http://www.hanayaka-anime.com/",
     "begin": "2012-12-21T16:00:00.000Z",
     "end": "2013-03-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kHlT0TmfD02wLpY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -415,17 +314,11 @@
     "officialSite": "",
     "begin": "2012-12-04T16:00:00.000Z",
     "end": "2012-12-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DOPNS7MZiaccqqBA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -445,7 +338,6 @@
     "officialSite": "https://youtube.com/animebancho",
     "begin": "2012-12-25T16:00:00.000Z",
     "end": "2013-03-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -454,12 +346,7 @@
       {
         "site": "nicovideo",
         "id": "infernocop",
-        "begin": "2015-06-11T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-11T06:00:00.000Z"
       }
     ]
   },
@@ -471,7 +358,6 @@
     "officialSite": "",
     "begin": "2012-12-23T16:00:00.000Z",
     "end": "2013-06-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -480,12 +366,7 @@
       {
         "site": "nicovideo",
         "id": "suraj",
-        "begin": "2013-08-02T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-02T11:00:00.000Z"
       }
     ]
   },
@@ -501,7 +382,6 @@
     "officialSite": "http://www.ao-ex.com/",
     "begin": "2012-12-28T16:00:00.000Z",
     "end": "2012-12-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -510,32 +390,17 @@
       {
         "site": "pptv",
         "id": "21o2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "movie-ao-ex",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3543",
-        "begin": "2012-12-27T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-27T16:00:01.000Z"
       }
     ]
   },
@@ -551,7 +416,6 @@
     "officialSite": "",
     "begin": "2012-12-17T16:00:00.000Z",
     "end": "2013-04-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -560,22 +424,12 @@
       {
         "site": "pptv",
         "id": "yKGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4301",
-        "begin": "2012-12-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2012-12-16T16:00:01.000Z"
       }
     ]
   },
@@ -591,7 +445,6 @@
     "officialSite": "",
     "begin": "2012-12-17T16:00:00.000Z",
     "end": "2013-03-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -600,22 +453,7 @@
       {
         "site": "pptv",
         "id": "nnRg3kasHFq9O6M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4304",
-        "begin": "2012-12-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2013/01.json
+++ b/data/items/2013/01.json
@@ -15,47 +15,21 @@
     "officialSite": "http://cf-vanguard.com/",
     "begin": "2013-01-13T01:00:00.000Z",
     "end": "2014-03-02T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8Y1n5U2zI2HEQqo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "88433",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "8pqD3-i9Be4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "7df70b7a692611e29013",
-        "begin": "2013-01-13T05:23:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-13T05:23:34.000Z"
       },
       {
         "site": "bangumi",
@@ -64,12 +38,7 @@
       {
         "site": "nicovideo",
         "id": "vanguard-lj",
-        "begin": "2013-01-15T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-15T10:30:00.000Z"
       }
     ]
   },
@@ -81,67 +50,31 @@
     "officialSite": "http://ac.qq.com/event/sxdh/index.shtml",
     "begin": "2013-01-11T12:00:00.000Z",
     "end": "2015-03-06T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470016",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "662",
-        "begin": "2013-04-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-11T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "5Xdh30etHVuibPKQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "r/r5a970dy4d7boqj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrjsk2ph",
-        "begin": "2014-09-12T06:27:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:27:34.000Z"
       },
       {
         "site": "sohu",
         "id": "s2013/shixiong",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -161,17 +94,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_aimaimi/",
     "begin": "2013-01-03T14:00:00.000Z",
     "end": "2013-03-26T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hWpGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -180,32 +107,17 @@
       {
         "site": "nicovideo",
         "id": "aimaimi",
-        "begin": "2013-01-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-03T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "84774",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "7",
-        "begin": "2013-01-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-02T16:00:00.000Z"
       }
     ]
   },
@@ -221,17 +133,11 @@
     "officialSite": "http://senran.tv/",
     "begin": "2013-01-06T11:30:00.000Z",
     "end": "2013-03-24T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjt5ou5",
-        "begin": "2016-08-17T08:35:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-17T08:35:44.000Z"
       },
       {
         "site": "bangumi",
@@ -240,12 +146,7 @@
       {
         "site": "nicovideo",
         "id": "senran",
-        "begin": "2013-01-10T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-10T16:30:00.000Z"
       }
     ]
   },
@@ -261,27 +162,16 @@
     "officialSite": "http://mondaiji.tv/",
     "begin": "2013-01-11T16:30:00.000Z",
     "end": "2013-03-15T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8plz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "84786",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -290,12 +180,7 @@
       {
         "site": "bilibili",
         "id": "439",
-        "begin": "2013-01-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-10T16:00:00.000Z"
       }
     ]
   },
@@ -311,17 +196,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/haganai/",
     "begin": "2013-01-10T16:55:00.000Z",
     "end": "2013-03-28T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4YZy8FiaibLmzPTbU",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -330,12 +209,7 @@
       {
         "site": "nicovideo",
         "id": "haganai2",
-        "begin": "2013-07-25T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-25T15:00:00.000Z"
       }
     ]
   },
@@ -351,27 +225,16 @@
     "officialSite": "http://www.tbs.co.jp/anime/sasami/",
     "begin": "2013-01-10T16:25:00.000Z",
     "end": "2013-03-28T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5o1n5U2zI2HEQqo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "e/e3h18m27lxftpyo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -380,12 +243,7 @@
       {
         "site": "nicovideo",
         "id": "sasamisan",
-        "begin": "2013-04-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-01T15:00:00.000Z"
       }
     ]
   },
@@ -401,27 +259,16 @@
     "officialSite": "http://www.oreshura.net/",
     "begin": "2013-01-05T15:00:00.000Z",
     "end": "2013-03-30T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QiakDgelPvic1g3kY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "84811",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -430,22 +277,12 @@
       {
         "site": "nicovideo",
         "id": "oreshura",
-        "begin": "2013-01-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-10T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2667",
-        "begin": "2013-01-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -462,17 +299,11 @@
     "officialSite": "http://www.starchild.co.jp/special/minami-ke/4/",
     "begin": "2013-01-05T16:00:00.000Z",
     "end": "2013-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjt0ail",
-        "begin": "2014-09-12T06:42:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:42:16.000Z"
       },
       {
         "site": "bangumi",
@@ -481,22 +312,12 @@
       {
         "site": "nicovideo",
         "id": "minami-ke4",
-        "begin": "2017-09-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-14T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "623",
-        "begin": "2013-01-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-04T16:00:00.000Z"
       }
     ]
   },
@@ -512,27 +333,16 @@
     "officialSite": "http://www.cdinaba.com/",
     "begin": "2013-01-04T14:30:00.000Z",
     "end": "2013-03-22T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lXpW1DyiaElCzMZk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgi9sa9",
-        "begin": "2014-09-12T06:35:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:35:09.000Z"
       },
       {
         "site": "bangumi",
@@ -541,22 +351,12 @@
       {
         "site": "nicovideo",
         "id": "cdinaba",
-        "begin": "2013-01-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-11T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "628",
-        "begin": "2013-01-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-03T16:00:00.000Z"
       }
     ]
   },
@@ -572,7 +372,6 @@
     "officialSite": "http://tamakomarket.com/",
     "begin": "2013-01-09T15:30:00.000Z",
     "end": "2013-03-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -580,13 +379,8 @@
       },
       {
         "site": "bilibili",
-        "id": "4262",
-        "begin": "2013-01-08T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "116772",
+        "begin": "2013-01-08T16:00:01.000Z"
       }
     ]
   },
@@ -602,17 +396,11 @@
     "officialSite": "http://www.kotourasan.com/",
     "begin": "2013-01-10T17:00:00.000Z",
     "end": "2013-03-28T17:33:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9p139V3DM3HUUro",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -621,22 +409,12 @@
       {
         "site": "nicovideo",
         "id": "kotourasan",
-        "begin": "2013-01-12T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-12T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "417",
-        "begin": "2013-01-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -655,17 +433,11 @@
     "officialSite": "http://www.vividred.net/",
     "begin": "2013-01-10T16:30:00.000Z",
     "end": "2013-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "84777",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -674,22 +446,12 @@
       {
         "site": "nicovideo",
         "id": "vividred",
-        "begin": "2013-01-13T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-13T13:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "1731",
-        "begin": "2013-01-09T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "35992",
+        "begin": "2013-01-09T16:00:01.000Z"
       }
     ]
   },
@@ -705,17 +467,11 @@
     "officialSite": "http://roman-anime.com/",
     "begin": "2013-01-07T17:05:00.000Z",
     "end": "2013-03-25T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "waaSEHjeTozvbdU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -735,17 +491,11 @@
     "officialSite": "http://www.hatsunejima.com/",
     "begin": "2013-01-05T13:00:00.000Z",
     "end": "2013-03-30T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hm1HxS2TA0GkIoo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -754,22 +504,7 @@
       {
         "site": "nicovideo",
         "id": "dc3",
-        "begin": "2013-01-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "659",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-07T15:00:00.000Z"
       }
     ]
   },
@@ -785,17 +520,11 @@
     "officialSite": "http://maoyu.jp/",
     "begin": "2013-01-04T16:00:00.000Z",
     "end": "2013-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ln1X1T2jE1G0Mpo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -804,22 +533,12 @@
       {
         "site": "nicovideo",
         "id": "maoyu",
-        "begin": "2013-01-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-11T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "444",
-        "begin": "2013-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-03T16:00:00.000Z"
       }
     ]
   },
@@ -831,17 +550,11 @@
     "officialSite": "http://akb0048.jp/",
     "begin": "2013-01-05T16:00:00.000Z",
     "end": "2013-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3LKeHITqWpj7eeE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -864,17 +577,11 @@
     "officialSite": "http://mangirl.jp/",
     "begin": "2013-01-02T16:35:00.000Z",
     "end": "2013-05-24T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gmlDwSmPicz2gHoY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -883,22 +590,12 @@
       {
         "site": "nicovideo",
         "id": "mangirl",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "646",
-        "begin": "2013-01-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-01T16:00:00.000Z"
       }
     ]
   },
@@ -917,7 +614,6 @@
     "officialSite": "http://www.lovelive-anime.jp/otonokizaka/",
     "begin": "2013-01-06T13:00:00.000Z",
     "end": "2013-03-31T13:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -926,22 +622,12 @@
       {
         "site": "nicovideo",
         "id": "lovelive",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3068",
-        "begin": "2013-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -960,7 +646,6 @@
     "officialSite": "http://www.yamanosusume.com/1st",
     "begin": "2013-01-02T16:30:00.000Z",
     "end": "2013-05-24T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -969,12 +654,7 @@
       {
         "site": "nicovideo",
         "id": "yamanosusume",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -990,17 +670,11 @@
     "officialSite": "http://senyu.tv/",
     "begin": "2013-01-08T17:05:00.000Z",
     "end": "2013-04-02T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xq2HBW3TQ4HkYso",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1009,12 +683,7 @@
       {
         "site": "nicovideo",
         "id": "senyu",
-        "begin": "2013-01-08T17:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-08T17:10:00.000Z"
       }
     ]
   },
@@ -1031,17 +700,11 @@
     "officialSite": "http://hakken-den.com/",
     "begin": "2013-01-05T17:43:00.000Z",
     "end": "2013-03-30T18:43:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjrryhx",
-        "begin": "2013-01-31T04:15:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-31T04:15:14.000Z"
       },
       {
         "site": "bangumi",
@@ -1061,7 +724,6 @@
     "officialSite": "http://unlimited-zc.jp/index.html",
     "begin": "2013-01-07T16:35:00.000Z",
     "end": "2013-03-25T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1070,12 +732,7 @@
       {
         "site": "nicovideo",
         "id": "unlimited",
-        "begin": "2013-01-12T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-12T14:00:00.000Z"
       }
     ]
   },
@@ -1091,18 +748,7 @@
     "officialSite": "http://www.anime-amnesia.com/",
     "begin": "2013-01-07T14:30:00.000Z",
     "end": "2013-03-25T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "841",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "46452"
@@ -1110,22 +756,12 @@
       {
         "site": "nicovideo",
         "id": "amnesia",
-        "begin": "2013-01-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-09T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "638",
-        "begin": "2013-01-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -1141,7 +777,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/lululolo/",
     "begin": "2013-01-16T22:40:00.000Z",
     "end": "2013-02-20T22:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1164,27 +799,11 @@
     "officialSite": "http://www.ntv.co.jp/chihayafuru2/",
     "begin": "2013-01-11T16:53:00.000Z",
     "end": "2015-07-19T04:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjt938x",
-        "begin": "2013-01-12T03:40:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "246",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-12T03:40:32.000Z"
       },
       {
         "site": "bangumi",
@@ -1193,12 +812,7 @@
       {
         "site": "nicovideo",
         "id": "chihayafuru2",
-        "begin": "2014-04-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-01T06:00:00.000Z"
       }
     ]
   },
@@ -1217,37 +831,21 @@
     "officialSite": "http://www.ntv.co.jp/gj/series/",
     "begin": "2013-01-09T16:29:00.000Z",
     "end": "2013-03-27T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0baiaIIjuXpzicfeU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrifty6p",
-        "begin": "2014-09-12T06:30:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:30:33.000Z"
       },
       {
         "site": "bilibili",
         "id": "637",
-        "begin": "2014-09-12T06:30:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:30:33.000Z"
       },
       {
         "site": "bangumi",
@@ -1256,12 +854,7 @@
       {
         "site": "nicovideo",
         "id": "gj_anime",
-        "begin": "2014-05-16T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-16T06:00:00.000Z"
       }
     ]
   },
@@ -1281,27 +874,16 @@
     "officialSite": "http://www.beastsaga.tv/",
     "begin": "2013-01-12T23:44:00.000Z",
     "end": "2013-09-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pEwopg505CKFA2s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgiej79",
-        "begin": "2014-06-24T07:52:30.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-06-24T07:52:30.000Z"
       },
       {
         "site": "bangumi",
@@ -1321,17 +903,11 @@
     "officialSite": "http://www.yte.co.jp/program/ishiasa/",
     "begin": "2013-01-06T13:27:00.000Z",
     "end": "2013-03-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sVZCwCiaOicjyfHYU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1340,22 +916,7 @@
       {
         "site": "nicovideo",
         "id": "ishidatoasakura",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "650",
-        "begin": "2013-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1371,7 +932,6 @@
     "officialSite": "http://line-anime.net/",
     "begin": "2013-01-07T16:30:00.000Z",
     "end": "2013-09-30T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1391,17 +951,11 @@
     "officialSite": "http://hetalia.com/bw/top.html",
     "begin": "2013-01-25T16:00:00.000Z",
     "end": "2013-06-07T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ew7qaNA2puRHxS0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1410,12 +964,7 @@
       {
         "site": "nicovideo",
         "id": "hetalia-thebeautifulworld",
-        "begin": "2013-01-28T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-28T12:00:00.000Z"
       }
     ]
   },
@@ -1431,7 +980,6 @@
     "officialSite": "http://fight-odenkun.com/",
     "begin": "2013-01-12T16:00:00.000Z",
     "end": "2014-12-27T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1451,27 +999,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_bw/index2.html",
     "begin": "2013-01-17T16:00:00.000Z",
     "end": "2013-04-08T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icFdBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hibacbz0801byjb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1491,17 +1028,11 @@
     "officialSite": "http://doukoku.com/",
     "begin": "2013-01-25T16:00:00.000Z",
     "end": "2014-11-25T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qKyIBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1521,17 +1052,11 @@
     "officialSite": "http://jigokuyouchien.com/",
     "begin": "2013-01-08T16:00:00.000Z",
     "end": "2013-03-26T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4olj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1540,22 +1065,12 @@
       {
         "site": "nicovideo",
         "id": "jigokuyouchien",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "684",
-        "begin": "2013-01-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-10T16:00:00.000Z"
       }
     ]
   },
@@ -1571,7 +1086,6 @@
     "officialSite": "",
     "begin": "2013-01-12T16:00:00.000Z",
     "end": "2013-01-12T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1591,17 +1105,11 @@
     "officialSite": "http://accel-world-game.channel.or.jp/kasoku/",
     "begin": "2013-01-31T16:00:00.000Z",
     "end": "2013-01-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Klslowtx4RibCAGg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1610,12 +1118,7 @@
       {
         "site": "bilibili",
         "id": "3488",
-        "begin": "2013-01-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-01-30T16:00:01.000Z"
       }
     ]
   },
@@ -1631,7 +1134,6 @@
     "officialSite": "http://www.aniplex.co.jp/gintama/1st/dvd/dvd_yorinuki.html",
     "begin": "2013-01-23T16:00:00.000Z",
     "end": "2013-02-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1640,12 +1142,7 @@
       {
         "site": "nicovideo",
         "id": "yorinuki-gintama",
-        "begin": "2015-04-08T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-08T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/2013/02.json
+++ b/data/items/2013/02.json
@@ -16,27 +16,16 @@
     "officialSite": "http://asahi.co.jp/dokidoki_precure/",
     "begin": "2013-02-02T23:30:00.000Z",
     "end": "2014-01-26T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "sFkzsRlic7y2QDnY",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha85ld",
-        "begin": "2016-12-12T08:25:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-12T08:25:10.000Z"
       },
       {
         "site": "bangumi",
@@ -45,22 +34,7 @@
       {
         "site": "netflix",
         "id": "80175619",
-        "begin": "2017-08-18T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1710",
-        "begin": "2013-02-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-18T07:00:00.000Z"
       }
     ]
   },
@@ -76,17 +50,11 @@
     "officialSite": "http://www.robotanime.jp/",
     "begin": "2013-02-05T16:30:00.000Z",
     "end": "2013-04-23T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "w7WfHYXrW5n8euI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -95,22 +63,12 @@
       {
         "site": "nicovideo",
         "id": "robotanime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "642",
-        "begin": "2013-02-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-02-05T16:00:00.000Z"
       }
     ]
   },
@@ -127,27 +85,16 @@
     "officialSite": "http://www.project-index.net/",
     "begin": "2013-02-23T16:00:00.000Z",
     "end": "2013-02-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhatfkd",
-        "begin": "2016-08-15T01:30:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-15T01:30:14.000Z"
       },
       {
         "site": "letv",
         "id": "91233",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -156,12 +103,7 @@
       {
         "site": "bilibili",
         "id": "965",
-        "begin": "2013-02-22T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-02-22T16:00:00.000Z"
       }
     ]
   },
@@ -178,17 +120,11 @@
     "officialSite": "http://www.stardriver-movie.net/",
     "begin": "2013-02-09T16:00:00.000Z",
     "end": "2013-02-09T18:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc0nwl",
-        "begin": "2014-09-05T08:25:20.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-05T08:25:20.000Z"
       },
       {
         "site": "bangumi",
@@ -197,22 +133,12 @@
       {
         "site": "nicovideo",
         "id": "stardriver-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "5mlDwSmPicz2gHoY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -228,17 +154,11 @@
     "officialSite": "",
     "begin": "2013-02-28T16:00:00.000Z",
     "end": "2013-03-28T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KtWicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -258,17 +178,11 @@
     "officialSite": "",
     "begin": "2013-02-10T16:00:00.000Z",
     "end": "2013-02-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3p56ibGDGNnTXVb0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -291,7 +205,6 @@
     "officialSite": "http://www.berserkfilm.com/",
     "begin": "2013-02-01T16:00:00.000Z",
     "end": "2013-02-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -300,22 +213,12 @@
       {
         "site": "nicovideo",
         "id": "berserkfilm",
-        "begin": "2017-03-03T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-03T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80063025",
-        "begin": "2017-09-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-01T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2013/03.json
+++ b/data/items/2013/03.json
@@ -14,17 +14,11 @@
     "officialSite": "http://date-a-live-anime.com/",
     "begin": "2013-03-30T15:00:00.000Z",
     "end": "2013-06-15T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjucztp",
-        "begin": "2015-04-10T08:30:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T08:30:11.000Z"
       },
       {
         "site": "bangumi",
@@ -33,12 +27,7 @@
       {
         "site": "nicovideo",
         "id": "date-a-live",
-        "begin": "2014-01-19T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-19T15:00:00.000Z"
       }
     ]
   },
@@ -57,7 +46,6 @@
     "officialSite": "http://rdg-anime.jp/",
     "begin": "2013-03-16T14:30:00.000Z",
     "end": "2013-06-01T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -66,12 +54,7 @@
       {
         "site": "nicovideo",
         "id": "rdg",
-        "begin": "2014-01-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-05T15:00:00.000Z"
       }
     ]
   },
@@ -87,17 +70,11 @@
     "officialSite": "http://www.animemirai.jp/c1.php",
     "begin": "2013-03-02T16:00:00.000Z",
     "end": "2013-03-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6OFibicGTKOnjbWcE",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -120,17 +97,11 @@
     "officialSite": "http://www.animemirai.jp/c2.php",
     "begin": "2013-03-02T16:00:00.000Z",
     "end": "2013-03-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "87725",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -139,22 +110,12 @@
       {
         "site": "netflix",
         "id": "80079082",
-        "begin": "2015-10-09T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2547",
-        "begin": "2013-03-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-01T16:00:00.000Z"
       }
     ]
   },
@@ -170,17 +131,11 @@
     "officialSite": "http://animemirai.jp/c3.php",
     "begin": "2013-03-02T16:00:00.000Z",
     "end": "2013-03-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Qy0Hhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -200,41 +155,20 @@
     "officialSite": "http://www.animemirai.jp/c4.php",
     "begin": "2013-03-02T16:00:00.000Z",
     "end": "2013-03-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eKoIhu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "v_19rrnvepuo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "54734"
-      },
-      {
-        "site": "bilibili",
-        "id": "4271",
-        "begin": "2013-03-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -250,27 +184,16 @@
     "officialSite": "http://youngjump.jp/info/saipuu/",
     "begin": "2013-03-12T16:00:00.000Z",
     "end": "2013-05-30T16:02:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LtG7OaEHd7UYlv4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "87178",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -279,22 +202,7 @@
       {
         "site": "nicovideo",
         "id": "saipuu",
-        "begin": "2013-04-18T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "682",
-        "begin": "2013-03-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-18T04:00:00.000Z"
       }
     ]
   },
@@ -310,27 +218,16 @@
     "officialSite": "http://www.sanrio.co.jp/character/gudetama/",
     "begin": "2013-03-31T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "tI9p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "k/knvmsc7suct7q0l",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -350,27 +247,16 @@
     "officialSite": "http://doraeiga.com/2013/",
     "begin": "2013-03-09T16:00:00.000Z",
     "end": "2013-03-09T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "R9O9O6MJebcamAA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "92438",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -379,32 +265,17 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mmih",
-        "begin": "2018-05-31T16:11:29.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:11:29.000Z"
       },
       {
         "site": "bilibili",
         "id": "3898",
-        "begin": "2013-03-08T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-08T16:00:01.000Z"
       }
     ]
   },
@@ -420,17 +291,11 @@
     "officialSite": "http://www.nhk.or.jp/bs/joshianime/",
     "begin": "2013-03-10T16:00:00.000Z",
     "end": "2013-03-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CfXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -450,17 +315,11 @@
     "officialSite": "http://www.nhk.or.jp/bs/joshianime/",
     "begin": "2013-03-17T16:00:00.000Z",
     "end": "2013-03-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CfXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -480,31 +339,15 @@
     "officialSite": "http://www.nhk.or.jp/bs/joshianime/",
     "begin": "2013-03-24T16:00:00.000Z",
     "end": "2013-03-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CfXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "67452"
-      },
-      {
-        "site": "bilibili",
-        "id": "5580",
-        "begin": "2013-03-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -520,17 +363,11 @@
     "officialSite": "http://www.nuramago.jp/",
     "begin": "2013-03-04T16:00:00.000Z",
     "end": "2013-03-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DOPNS7MZiaccqqBA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -539,12 +376,7 @@
       {
         "site": "bilibili",
         "id": "3798",
-        "begin": "2013-03-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-03-03T16:00:01.000Z"
       }
     ]
   },
@@ -560,7 +392,6 @@
     "officialSite": "http://www.dragonball2013.com/",
     "begin": "2013-03-30T16:00:00.000Z",
     "end": "2013-03-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -569,12 +400,7 @@
       {
         "site": "nicovideo",
         "id": "dragonball2013",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -590,7 +416,6 @@
     "officialSite": "http://www.hanasakuiroha.jp/",
     "begin": "2013-03-09T16:00:00.000Z",
     "end": "2013-03-09T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -599,12 +424,7 @@
       {
         "site": "pptv",
         "id": "jmBMyjKYCEapJ48",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2013/04.json
+++ b/data/items/2013/04.json
@@ -11,27 +11,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/prettyrhythm/",
     "begin": "2013-04-06T01:00:00.000Z",
     "end": "2014-03-29T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "033b8b22863111e2b16f",
-        "begin": "2013-04-09T00:15:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "1RQejV8BX3E",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-04-09T00:15:26.000Z"
       },
       {
         "site": "bangumi",
@@ -40,12 +24,7 @@
       {
         "site": "nicovideo",
         "id": "prettyrhythm_rl",
-        "begin": "2013-04-19T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-19T10:30:00.000Z"
       }
     ]
   },
@@ -62,45 +41,20 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/driland2/",
     "begin": "2013-04-06T01:30:00.000Z",
     "end": "2014-03-29T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Dib7KSLAWhsQnpQ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "fe815c40309111e3b8b7",
-        "begin": "2013-10-09T04:04:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "yTcP6SgWAJI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-09T04:04:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "66409"
-      },
-      {
-        "site": "saraba1st",
-        "id": "823763"
       }
     ]
   },
@@ -116,27 +70,16 @@
     "officialSite": "http://www.tbs.co.jp/anime/oregairu/1st/",
     "begin": "2013-04-04T16:33:00.000Z",
     "end": "2013-06-27T16:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "06uFA2vRQXiciaYMg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb343l",
-        "begin": "2015-04-23T08:07:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-23T08:07:00.000Z"
       },
       {
         "site": "bangumi",
@@ -145,32 +88,17 @@
       {
         "site": "nicovideo",
         "id": "oregairu",
-        "begin": "2013-04-14T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-14T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1539",
-        "begin": "2013-04-04T16:33:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-04T16:33:00.000Z"
       },
       {
         "site": "qq",
         "id": "5/5wiuorx70i3vdqb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -189,17 +117,11 @@
     "officialSite": "http://karneval-anime.com/",
     "begin": "2013-04-03T17:43:00.000Z",
     "end": "2013-06-26T18:14:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "m2NNyzOZCUeqKJA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -219,17 +141,11 @@
     "officialSite": "http://www.oreimo-anime.com/",
     "begin": "2013-04-06T15:00:00.000Z",
     "end": "2013-08-18T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "87894",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -238,22 +154,12 @@
       {
         "site": "nicovideo",
         "id": "oreimo2",
-        "begin": "2013-04-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-11T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2661",
-        "begin": "2013-04-06T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-06T15:00:00.000Z"
       }
     ]
   },
@@ -269,18 +175,7 @@
     "officialSite": "http://mjp-anime.jp/",
     "begin": "2013-04-04T13:30:00.000Z",
     "end": "2013-09-19T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "2700",
-        "begin": "2013-04-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "50535"
@@ -288,12 +183,7 @@
       {
         "site": "nicovideo",
         "id": "mjp",
-        "begin": "2013-04-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-08T14:30:00.000Z"
       }
     ]
   },
@@ -309,7 +199,6 @@
     "officialSite": "http://nyaruko.com/",
     "begin": "2013-04-07T16:05:00.000Z",
     "end": "2013-06-30T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -318,12 +207,7 @@
       {
         "site": "nicovideo",
         "id": "nyaruko-w",
-        "begin": "2013-04-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-09T15:30:00.000Z"
       }
     ]
   },
@@ -339,27 +223,11 @@
     "officialSite": "http://maousama.jp/",
     "begin": "2013-04-04T13:00:00.000Z",
     "end": "2013-06-27T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjx97w1",
-        "begin": "2013-04-04T22:58:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2410",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-04T22:58:45.000Z"
       },
       {
         "site": "bangumi",
@@ -368,32 +236,17 @@
       {
         "site": "nicovideo",
         "id": "maousama",
-        "begin": "2013-04-12T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-12T14:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80006149",
-        "begin": "2017-01-31T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-31T08:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2932",
-        "begin": "2013-04-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -412,17 +265,11 @@
     "officialSite": "http://www.henneko.jp",
     "begin": "2013-04-13T13:30:00.000Z",
     "end": "2013-06-29T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NsexL5f9basOjPQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -431,12 +278,7 @@
       {
         "site": "bilibili",
         "id": "413",
-        "begin": "2013-04-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-12T16:00:00.000Z"
       }
     ]
   },
@@ -452,7 +294,6 @@
     "officialSite": "http://www.hayate-project.com/",
     "begin": "2013-04-08T16:35:00.000Z",
     "end": "2013-06-26T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -461,12 +302,7 @@
       {
         "site": "bilibili",
         "id": "4435",
-        "begin": "2013-04-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-07T16:00:01.000Z"
       }
     ]
   },
@@ -482,17 +318,11 @@
     "officialSite": "http://akunohana-anime.jp/",
     "begin": "2013-04-05T13:00:00.000Z",
     "end": "2013-06-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjwznfd",
-        "begin": "2013-04-19T05:35:51.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-19T05:35:51.000Z"
       },
       {
         "site": "bangumi",
@@ -501,12 +331,7 @@
       {
         "site": "nicovideo",
         "id": "akunohana",
-        "begin": "2013-04-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-09T16:00:00.000Z"
       }
     ]
   },
@@ -522,7 +347,6 @@
     "officialSite": "http://www.hyakka-ryoran.tv/",
     "begin": "2013-04-05T13:30:00.000Z",
     "end": "2013-06-21T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -531,12 +355,7 @@
       {
         "site": "nicovideo",
         "id": "hyakka-ryoran2",
-        "begin": "2013-04-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -552,7 +371,6 @@
     "officialSite": "http://kc.kodansha.co.jp/azazel/",
     "begin": "2013-04-06T16:00:00.000Z",
     "end": "2013-06-29T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -561,22 +379,12 @@
       {
         "site": "nicovideo",
         "id": "azazel_z",
-        "begin": "2013-04-12T15:45:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-12T15:45:00.000Z"
       },
       {
         "site": "letv",
         "id": "87895",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -592,17 +400,11 @@
     "officialSite": "http://arata-anime.com/",
     "begin": "2013-04-08T17:05:00.000Z",
     "end": "2013-07-01T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ic5SAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -622,17 +424,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/photokano/",
     "begin": "2013-04-04T17:03:00.000Z",
     "end": "2013-06-27T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0a2HBW3TQ4HkYso",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -641,22 +437,12 @@
       {
         "site": "nicovideo",
         "id": "photokano",
-        "begin": "2013-04-22T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-22T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "580",
-        "begin": "2013-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-03T16:00:00.000Z"
       }
     ]
   },
@@ -675,7 +461,6 @@
     "officialSite": "http://shingeki.tv/",
     "begin": "2013-04-06T16:58:00.000Z",
     "end": "2013-09-28T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -684,22 +469,12 @@
       {
         "site": "nicovideo",
         "id": "shingeki",
-        "begin": "2013-04-10T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-10T13:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70299043",
-        "begin": "2017-01-10T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T08:00:00.000Z"
       }
     ]
   },
@@ -718,37 +493,16 @@
     "officialSite": "http://www.valvrave.com/",
     "begin": "2013-04-11T16:35:00.000Z",
     "end": "2013-12-26T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjxrb1d",
-        "begin": "2013-04-11T20:36:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-11T20:36:59.000Z"
       },
       {
         "site": "bilibili",
         "id": "3307",
-        "begin": "2013-04-11T20:36:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2453",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-11T20:36:59.000Z"
       },
       {
         "site": "bangumi",
@@ -757,12 +511,7 @@
       {
         "site": "nicovideo",
         "id": "valvrave",
-        "begin": "2013-04-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-13T16:00:00.000Z"
       }
     ]
   },
@@ -779,37 +528,16 @@
     "officialSite": "http://www.project-railgun.net/index.html",
     "begin": "2013-04-12T14:30:00.000Z",
     "end": "2013-09-27T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjwiwi1",
-        "begin": "2013-04-13T02:08:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-13T02:08:44.000Z"
       },
       {
         "site": "letv",
         "id": "87896",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2454",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -818,22 +546,12 @@
       {
         "site": "nicovideo",
         "id": "railgun-s",
-        "begin": "2013-04-19T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-19T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "427",
-        "begin": "2013-04-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -850,27 +568,16 @@
     "officialSite": "http://crimeedge.com/",
     "begin": "2013-04-03T15:30:00.000Z",
     "end": "2013-06-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BibvFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "87839",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -879,22 +586,7 @@
       {
         "site": "nicovideo",
         "id": "crimeedge",
-        "begin": "2013-04-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4442",
-        "begin": "2013-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-10T14:00:00.000Z"
       }
     ]
   },
@@ -910,7 +602,6 @@
     "officialSite": "http://mushibugyo.jp/",
     "begin": "2013-04-08T09:00:00.000Z",
     "end": "2013-09-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -919,12 +610,7 @@
       {
         "site": "nicovideo",
         "id": "mushibugyo",
-        "begin": "2013-04-14T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-14T16:30:00.000Z"
       }
     ]
   },
@@ -940,17 +626,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_sparrows/",
     "begin": "2013-04-09T11:25:00.000Z",
     "end": "2013-06-25T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zbGbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -959,22 +639,7 @@
       {
         "site": "nicovideo",
         "id": "sparrows",
-        "begin": "2013-04-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "601",
-        "begin": "2013-04-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-11T16:00:00.000Z"
       }
     ]
   },
@@ -990,17 +655,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/aiura/",
     "begin": "2013-04-09T16:35:00.000Z",
     "end": "2013-06-25T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EuvFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1009,22 +668,12 @@
       {
         "site": "nicovideo",
         "id": "aiura",
-        "begin": "2013-04-09T16:40:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-09T16:40:00.000Z"
       },
       {
         "site": "letv",
         "id": "87897",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1041,17 +690,11 @@
     "officialSite": "http://www.yuyushiki.net/",
     "begin": "2013-04-09T15:30:00.000Z",
     "end": "2013-06-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjxlrwx",
-        "begin": "2013-04-09T19:30:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-09T19:30:48.000Z"
       },
       {
         "site": "bangumi",
@@ -1060,12 +703,7 @@
       {
         "site": "nicovideo",
         "id": "yuyushiki",
-        "begin": "2013-04-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-11T15:30:00.000Z"
       }
     ]
   },
@@ -1081,27 +719,16 @@
     "officialSite": "http://www.starchild.co.jp/special/muromisan/",
     "begin": "2013-04-06T16:15:00.000Z",
     "end": "2013-06-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1KiaEAmrQQH7hX8c",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "87898",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1110,22 +737,7 @@
       {
         "site": "nicovideo",
         "id": "muromisan",
-        "begin": "2013-04-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "570",
-        "begin": "2013-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-12T16:00:00.000Z"
       }
     ]
   },
@@ -1142,27 +754,11 @@
     "officialSite": "http://ds2a.jp/",
     "begin": "2013-04-04T17:05:00.000Z",
     "end": "2013-06-27T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjx99mx",
-        "begin": "2014-04-09T23:07:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2413",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:07:47.000Z"
       },
       {
         "site": "bangumi",
@@ -1171,12 +767,7 @@
       {
         "site": "nicovideo",
         "id": "ds2",
-        "begin": "2013-04-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-14T15:00:00.000Z"
       }
     ]
   },
@@ -1195,17 +786,11 @@
     "officialSite": "http://gargantia.jp/",
     "begin": "2013-04-07T13:00:00.000Z",
     "end": "2013-10-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PzMdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1214,32 +799,17 @@
       {
         "site": "nicovideo",
         "id": "gargantia",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80039789",
-        "begin": "2016-12-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-01T08:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "445",
-        "begin": "2013-04-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1255,18 +825,7 @@
     "officialSite": "http://archive2000.utapri.tv/",
     "begin": "2013-04-03T17:05:00.000Z",
     "end": "2013-06-26T17:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2408",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "31416"
@@ -1274,32 +833,17 @@
       {
         "site": "nicovideo",
         "id": "utapri2",
-        "begin": "2013-04-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-06T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1msxx",
-        "begin": "2017-11-01T11:12:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-01T11:12:08.000Z"
       },
       {
         "site": "bilibili",
         "id": "1562",
-        "begin": "2013-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -1316,31 +860,15 @@
     "officialSite": "http://www9.nhk.or.jp/anime/tomoo/",
     "begin": "2013-04-06T00:30:00.000Z",
     "end": "2015-02-07T00:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ISELiafFXxwVo5k4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "61118"
-      },
-      {
-        "site": "bilibili",
-        "id": "1730",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
       }
     ]
   },
@@ -1359,17 +887,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mylittle-pony/",
     "begin": "2013-04-01T22:30:00.000Z",
     "end": "2014-03-24T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "87914",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1378,12 +900,7 @@
       {
         "site": "nicovideo",
         "id": "mylittle-pony_n",
-        "begin": "2013-04-19T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-19T11:00:00.000Z"
       }
     ]
   },
@@ -1399,7 +916,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/trainheroes/",
     "begin": "2013-04-02T08:30:00.000Z",
     "end": "2013-09-24T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1419,7 +935,6 @@
     "officialSite": "http://www.ddhokuto.com/",
     "begin": "2013-04-02T16:40:00.000Z",
     "end": "2013-06-25T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1439,17 +954,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/jp-happiness/",
     "begin": "2013-04-05T22:00:00.000Z",
     "end": "2014-03-29T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EezIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1470,27 +979,16 @@
     "officialSite": "http://leviathan-anime.net/",
     "begin": "2013-04-06T14:30:00.000Z",
     "end": "2013-06-29T14:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "s103tR2D8zGUEno",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0ovh",
-        "begin": "2014-09-04T05:33:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-04T05:33:03.000Z"
       },
       {
         "site": "bangumi",
@@ -1499,22 +997,12 @@
       {
         "site": "nicovideo",
         "id": "leviathan",
-        "begin": "2013-04-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-08T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2656",
-        "begin": "2013-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -1530,17 +1018,11 @@
     "officialSite": "http://www.rironsha.co.jp/ousama_anime/",
     "begin": "2013-04-06T00:30:00.000Z",
     "end": "2013-06-22T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mph08lrAMG7RT7c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1549,12 +1031,7 @@
       {
         "site": "bilibili",
         "id": "599",
-        "begin": "2013-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1570,17 +1047,11 @@
     "officialSite": "http://www.ahiru-anime.com/",
     "begin": "2013-04-06T23:00:00.000Z",
     "end": "2013-04-06T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EO3HRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1589,12 +1060,7 @@
       {
         "site": "bilibili",
         "id": "676",
-        "begin": "2013-04-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -1610,17 +1076,11 @@
     "officialSite": "http://garasunokamendesuga.ponycanyon.co.jp/",
     "begin": "2013-04-07T12:54:00.000Z",
     "end": "2013-04-21T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GeTQTrYcjMotqxM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1629,22 +1089,12 @@
       {
         "site": "nicovideo",
         "id": "garasunokamendesuga",
-        "begin": "2013-06-14T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-14T09:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1764",
-        "begin": "2013-04-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-07T16:00:00.000Z"
       }
     ]
   },
@@ -1660,17 +1110,11 @@
     "officialSite": "http://ketsuekigatakun.com/",
     "begin": "2013-04-07T13:27:00.000Z",
     "end": "2013-06-23T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "y/yjbdd0x0yl48w89",
-        "begin": "2013-04-10T03:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-10T03:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1679,12 +1123,7 @@
       {
         "site": "nicovideo",
         "id": "ketsuekigata-kun",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1700,17 +1139,11 @@
     "officialSite": "http://line-anime.net/",
     "begin": "2013-04-03T09:30:00.000Z",
     "end": "2014-03-26T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mJaCAGjOPnzfXcU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1730,17 +1163,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/lbxwars/",
     "begin": "2013-04-03T10:27:00.000Z",
     "end": "2013-12-25T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VyYSkPhezgxv7VU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1760,17 +1187,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/gakkatsu/",
     "begin": "2013-04-03T14:25:00.000Z",
     "end": "2013-09-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "AP3XVb0jk9E0sho",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1779,12 +1200,7 @@
       {
         "site": "bilibili",
         "id": "586",
-        "begin": "2013-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-02T16:00:00.000Z"
       }
     ]
   },
@@ -1796,7 +1212,6 @@
     "officialSite": "http://xn--u9j429qiq1a.jp/",
     "begin": "2013-04-05T09:20:00.000Z",
     "end": "2014-02-21T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1805,12 +1220,7 @@
       {
         "site": "nicovideo",
         "id": "takanotsume_max",
-        "begin": "2013-04-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-07T15:00:00.000Z"
       }
     ]
   },
@@ -1826,7 +1236,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/duelmastersv/",
     "begin": "2013-04-05T23:30:00.000Z",
     "end": "2014-03-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1846,7 +1255,6 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/gao/",
     "begin": "2013-04-05T19:52:00.000Z",
     "end": "2016-03-25T20:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1866,17 +1274,11 @@
     "officialSite": "http://miyakawahungry.com/",
     "begin": "2013-04-29T12:00:00.000Z",
     "end": "2013-07-01T12:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hYhk4kqwIF7BP6c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1885,12 +1287,7 @@
       {
         "site": "bilibili",
         "id": "678",
-        "begin": "2013-04-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-28T16:00:00.000Z"
       }
     ]
   },
@@ -1906,7 +1303,6 @@
     "officialSite": "http://hai-tai.jp/",
     "begin": "2013-04-06T09:25:00.000Z",
     "end": "2013-06-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1915,12 +1311,7 @@
       {
         "site": "bilibili",
         "id": "1680",
-        "begin": "2013-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -1936,47 +1327,26 @@
     "officialSite": "http://steinsgate-movie.jp/",
     "begin": "2013-04-20T16:00:00.000Z",
     "end": "2013-04-20T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BwbycNgibruxPzTU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "y/yvhxapls0zblr3s",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10009242",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "291731",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1985,12 +1355,7 @@
       {
         "site": "bilibili",
         "id": "3467",
-        "begin": "2013-04-19T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-19T16:00:01.000Z"
       }
     ]
   },
@@ -2006,27 +1371,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_bw/index2.html",
     "begin": "2013-04-25T16:00:00.000Z",
     "end": "2013-09-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "icFdBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hibacbz0801byjb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2047,17 +1401,11 @@
     "officialSite": "http://hai-tai.jp/",
     "begin": "2013-04-07T16:00:00.000Z",
     "end": "2014-03-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrjyur41",
-        "begin": "2017-03-02T09:22:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-02T09:22:01.000Z"
       },
       {
         "site": "bangumi",
@@ -2066,12 +1414,7 @@
       {
         "site": "bilibili",
         "id": "499",
-        "begin": "2013-04-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-06T16:00:01.000Z"
       }
     ]
   },
@@ -2087,27 +1430,16 @@
     "officialSite": "http://shinchan-movie.com/",
     "begin": "2013-04-20T16:00:00.000Z",
     "end": "2013-04-20T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhwlloo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2116,22 +1448,12 @@
       {
         "site": "qq",
         "id": "b/bymafsjpccgo4bw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3895",
-        "begin": "2013-04-19T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "15072",
+        "begin": "2013-04-19T16:00:01.000Z"
       }
     ]
   },
@@ -2147,17 +1469,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2013-04-20T16:00:00.000Z",
     "end": "2013-04-20T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -2166,22 +1482,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2197,7 +1503,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2013-04-01T08:35:00.000Z",
     "end": "2013-07-12T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2217,17 +1522,11 @@
     "officialSite": "http://www.yamato2199.net/",
     "begin": "2013-04-07T16:00:00.000Z",
     "end": "2013-09-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Rjchnwdt3RtibicGQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2247,17 +1546,11 @@
     "officialSite": "http://youngjump.jp/info/policemen/",
     "begin": "2013-04-11T16:00:00.000Z",
     "end": "2013-05-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UNC8OqIIeLYZlic8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2266,22 +1559,7 @@
       {
         "site": "nicovideo",
         "id": "policemen",
-        "begin": "2013-04-18T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "683",
-        "begin": "2013-04-10T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-18T04:00:00.000Z"
       }
     ]
   },
@@ -2297,17 +1575,11 @@
     "officialSite": "http://ribon.shueisha.co.jp/ohasta/index.html",
     "begin": "2013-04-30T16:00:00.000Z",
     "end": "2013-04-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CgnjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2316,12 +1588,7 @@
       {
         "site": "bilibili",
         "id": "4432",
-        "begin": "2013-04-29T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-29T16:00:01.000Z"
       }
     ]
   },
@@ -2337,17 +1604,11 @@
     "officialSite": "http://www.koitabi-nanto.jp/",
     "begin": "2013-04-28T16:00:00.000Z",
     "end": "2013-04-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FOnDQakPf70gngY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2356,12 +1617,7 @@
       {
         "site": "bilibili",
         "id": "4440",
-        "begin": "2013-04-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-04-27T16:00:01.000Z"
       }
     ]
   },
@@ -2377,17 +1633,11 @@
     "officialSite": "http://www.yamato2199.net/",
     "begin": "2013-04-13T16:00:00.000Z",
     "end": "2013-04-13T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DPHbWcEnl9U4th4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2407,7 +1657,6 @@
     "officialSite": "",
     "begin": "2013-04-13T16:00:00.000Z",
     "end": "2013-04-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2416,12 +1665,7 @@
       {
         "site": "nicovideo",
         "id": "ch2583350",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2013/05.json
+++ b/data/items/2013/05.json
@@ -7,7 +7,6 @@
     "officialSite": "http://www.nhk.or.jp/asianleaders/",
     "begin": "2013-05-09T15:00:00.000Z",
     "end": "2013-10-03T15:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -27,17 +26,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/inazumago/",
     "begin": "2013-05-08T10:00:00.000Z",
     "end": "2014-03-19T10:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TsqmJIzyYqADgek",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,7 +53,6 @@
     "officialSite": "http://comic-meteor.jp/sp/tendoro/",
     "begin": "2013-05-12T16:00:00.000Z",
     "end": "2013-05-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -69,22 +61,12 @@
       {
         "site": "letv",
         "id": "89672",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "602",
-        "begin": "2013-05-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-05-11T16:00:00.000Z"
       }
     ]
   },
@@ -100,17 +82,11 @@
     "officialSite": "http://www.kotonohanoniwa.jp",
     "begin": "2013-05-31T16:00:00.000Z",
     "end": "2013-05-31T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "87682",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -119,22 +95,12 @@
       {
         "site": "nicovideo",
         "id": "kotonohanoniwa",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2546",
-        "begin": "2013-05-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-05-30T16:00:00.000Z"
       }
     ]
   },
@@ -150,7 +116,6 @@
     "officialSite": "http://www.saint023.com/",
     "begin": "2013-05-10T16:00:00.000Z",
     "end": "2013-05-10T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -159,32 +124,17 @@
       {
         "site": "nicovideo",
         "id": "saint023",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "W9fBP6cNfbsenAQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3230",
-        "begin": "2013-05-09T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-05-09T16:00:01.000Z"
       }
     ]
   },
@@ -200,17 +150,11 @@
     "officialSite": "",
     "begin": "2013-05-21T16:00:00.000Z",
     "end": "2013-06-28T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "aibfRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -219,12 +163,7 @@
       {
         "site": "bilibili",
         "id": "679",
-        "begin": "2013-05-20T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-05-20T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2013/06.json
+++ b/data/items/2013/06.json
@@ -15,27 +15,16 @@
     "officialSite": "http://www9.nhk.or.jp/anime/kingdom2/",
     "begin": "2013-06-08T14:45:00.000Z",
     "end": "2014-03-01T15:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrifq03u",
-        "begin": "2013-08-22T08:07:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-22T08:07:35.000Z"
       },
       {
         "site": "bilibili",
         "id": "583",
-        "begin": "2013-06-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-07T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -44,12 +33,7 @@
       {
         "site": "nicovideo",
         "id": "kingdom2",
-        "begin": "2016-01-24T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-24T15:00:00.000Z"
       }
     ]
   },
@@ -65,17 +49,11 @@
     "officialSite": "http://garasunokamendesuga.ponycanyon.co.jp/movie/",
     "begin": "2013-06-22T16:00:00.000Z",
     "end": "2013-06-22T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YfLeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -84,12 +62,7 @@
       {
         "site": "bilibili",
         "id": "4046",
-        "begin": "2013-06-21T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-21T16:00:01.000Z"
       }
     ]
   },
@@ -105,7 +78,6 @@
     "officialSite": "",
     "begin": "2013-06-15T16:00:00.000Z",
     "end": "2013-06-15T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -125,17 +97,11 @@
     "officialSite": "http://d-game.dengeki.com/RO-KYU-BU/index.html",
     "begin": "2013-06-22T16:00:00.000Z",
     "end": "2013-06-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SzIenARq2hh7ibWE",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -155,7 +121,6 @@
     "officialSite": "http://donyatsu.jp",
     "begin": "2013-06-01T16:00:00.000Z",
     "end": "2013-06-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -164,12 +129,7 @@
       {
         "site": "nicovideo",
         "id": "donyatsu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -188,7 +148,6 @@
     "officialSite": "http://kokaku-a.jp/arise/",
     "begin": "2013-06-21T16:00:00.000Z",
     "end": "2013-06-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -197,12 +156,7 @@
       {
         "site": "netflix",
         "id": "80002073",
-        "begin": "2017-01-31T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-31T08:00:00.000Z"
       }
     ]
   }

--- a/data/items/2013/07.json
+++ b/data/items/2013/07.json
@@ -11,28 +11,12 @@
     "officialSite": "http://www.monogatari-series.com/2ndseason/",
     "begin": "2013-07-06T15:00:00.000Z",
     "end": "2013-12-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "url": "http://comic.le.com/zt/wuyu/index.shtml",
         "site": "letv",
         "id": "91561",
-        "begin": "2013-07-11T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "118",
-        "begin": "2013-07-11T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-11T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -41,12 +25,7 @@
       {
         "site": "nicovideo",
         "id": "monogatari-series-2nd",
-        "begin": "2013-07-11T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-11T14:00:00.000Z"
       }
     ]
   },
@@ -62,57 +41,26 @@
     "officialSite": "http://kakusen-kun.com/",
     "begin": "2013-07-08T16:59:00.000Z",
     "end": "2013-12-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Zib3HRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "91812",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "3e50f242de5111e2b356",
-        "begin": "2013-07-11T10:55:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "GJnth25qxqo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-07-11T10:55:32.000Z"
       },
       {
         "site": "bilibili",
         "id": "1571",
-        "begin": "2013-07-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-07T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -121,12 +69,7 @@
       {
         "site": "nicovideo",
         "id": "kakusen-kun",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -142,7 +85,6 @@
     "officialSite": "http://symphogear-g.com/",
     "begin": "2013-07-04T17:35:00.000Z",
     "end": "2013-09-26T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -151,32 +93,17 @@
       {
         "site": "nicovideo",
         "id": "symphogear-g",
-        "begin": "2013-07-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-07T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcmifx",
-        "begin": "2017-10-31T16:01:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-31T16:01:38.000Z"
       },
       {
         "site": "bilibili",
         "id": "527",
-        "begin": "2013-07-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -192,17 +119,11 @@
     "officialSite": "http://www.nep-anime.tv/",
     "begin": "2013-07-12T13:00:00.000Z",
     "end": "2014-10-16T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "t/txfzw2twpsablfe",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -211,22 +132,12 @@
       {
         "site": "nicovideo",
         "id": "nep-anime",
-        "begin": "2013-07-19T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-19T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "530",
-        "begin": "2013-07-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-11T16:00:00.000Z"
       }
     ]
   },
@@ -245,17 +156,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/rozen/",
     "begin": "2013-07-04T16:59:00.000Z",
     "end": "2013-09-26T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NTUfnQVr2xl8ibmI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -264,32 +169,17 @@
       {
         "site": "nicovideo",
         "id": "rozen3",
-        "begin": "2013-07-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-16T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "525",
-        "begin": "2013-07-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-03T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhgch9h",
-        "begin": "2018-11-22T04:23:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-22T04:23:04.000Z"
       }
     ]
   },
@@ -305,18 +195,7 @@
     "officialSite": "http://www.servantservice.org/",
     "begin": "2013-07-04T18:09:00.000Z",
     "end": "2013-09-26T18:39:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2466",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "69944"
@@ -324,22 +203,12 @@
       {
         "site": "nicovideo",
         "id": "servantservice",
-        "begin": "2013-07-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-09T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "516",
-        "begin": "2013-07-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -355,18 +224,7 @@
     "officialSite": "http://genshiken-2daime.com/",
     "begin": "2013-07-06T16:00:00.000Z",
     "end": "2013-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2470",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "71802"
@@ -374,22 +232,12 @@
       {
         "site": "nicovideo",
         "id": "genshiken-2daime",
-        "begin": "2013-07-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-13T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "519",
-        "begin": "2013-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -405,7 +253,6 @@
     "officialSite": "http://inuhasa.jp/",
     "begin": "2013-07-01T16:00:00.000Z",
     "end": "2013-09-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -414,22 +261,12 @@
       {
         "site": "nicovideo",
         "id": "inuhasa",
-        "begin": "2013-07-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-04T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2783",
-        "begin": "2013-06-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -448,7 +285,6 @@
     "officialSite": "http://tamayura.info/moreggressive/",
     "begin": "2013-07-03T12:30:00.000Z",
     "end": "2013-09-18T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -457,32 +293,17 @@
       {
         "site": "nicovideo",
         "id": "tamayura-tv2",
-        "begin": "2013-09-30T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-09-30T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjb3o5",
-        "begin": "2013-10-29T09:17:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-29T09:17:48.000Z"
       },
       {
         "site": "bilibili",
         "id": "515",
-        "begin": "2013-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-02T16:00:00.000Z"
       }
     ]
   },
@@ -498,18 +319,7 @@
     "officialSite": "http://www.kinmosa.com/",
     "begin": "2013-07-06T11:30:00.000Z",
     "end": "2013-09-21T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "72784",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "57978"
@@ -517,22 +327,12 @@
       {
         "site": "nicovideo",
         "id": "kinmosa",
-        "begin": "2013-07-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-11T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "443",
-        "begin": "2013-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -548,7 +348,6 @@
     "officialSite": "http://www.kiminoirumachi.com/",
     "begin": "2013-07-13T14:30:00.000Z",
     "end": "2013-09-28T14:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -557,22 +356,12 @@
       {
         "site": "nicovideo",
         "id": "kiminoirumachi",
-        "begin": "2013-07-14T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-14T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2714",
-        "begin": "2013-07-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-12T16:00:00.000Z"
       }
     ]
   },
@@ -588,17 +377,11 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2013-07-07T13:27:00.000Z",
     "end": "2013-09-22T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oYlj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -607,12 +390,7 @@
       {
         "site": "nicovideo",
         "id": "te-kyu2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -628,17 +406,11 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_rikoran_mi/",
     "begin": "2013-07-08T13:25:00.000Z",
     "end": "2013-09-23T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0lM9uyOJibTeaGIA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -647,32 +419,17 @@
       {
         "site": "nicovideo",
         "id": "rikoran3",
-        "begin": "2013-07-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-11T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "91472",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1675",
-        "begin": "2013-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-06-30T16:00:00.000Z"
       }
     ]
   },
@@ -688,7 +445,6 @@
     "officialSite": "http://kaminomi.jp/",
     "begin": "2013-07-08T16:35:00.000Z",
     "end": "2013-09-23T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -697,12 +453,7 @@
       {
         "site": "nicovideo",
         "id": "kaminomi3",
-        "begin": "2013-07-13T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-13T14:30:00.000Z"
       }
     ]
   },
@@ -718,27 +469,16 @@
     "officialSite": "http://www.watamote.jp/",
     "begin": "2013-07-08T17:05:00.000Z",
     "end": "2013-09-23T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cvXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "p/pz9nim110g6rdfy",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -747,12 +487,7 @@
       {
         "site": "nicovideo",
         "id": "watamote",
-        "begin": "2013-07-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-13T16:00:00.000Z"
       }
     ]
   },
@@ -768,27 +503,11 @@
     "officialSite": "http://uchoten-anime.com/",
     "begin": "2013-07-07T13:00:00.000Z",
     "end": "2013-09-29T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "de7KSLAWhsQnpQ0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2473",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -796,13 +515,8 @@
       },
       {
         "site": "bilibili",
-        "id": "507",
-        "begin": "2013-07-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "113132",
+        "begin": "2013-07-06T16:00:01.000Z"
       }
     ]
   },
@@ -821,27 +535,11 @@
     "officialSite": "http://www.fantasistadoll.com/",
     "begin": "2013-07-06T18:28:00.000Z",
     "end": "2013-09-28T18:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg4hygp",
-        "begin": "2014-09-12T06:36:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2471",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:36:50.000Z"
       },
       {
         "site": "bangumi",
@@ -850,12 +548,7 @@
       {
         "site": "nicovideo",
         "id": "fantasistadoll",
-        "begin": "2013-07-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-07T15:30:00.000Z"
       }
     ]
   },
@@ -874,18 +567,7 @@
     "officialSite": "http://1st.iwatobi-sc.com/",
     "begin": "2013-07-03T15:30:00.000Z",
     "end": "2013-09-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2646",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "72109"
@@ -893,22 +575,12 @@
       {
         "site": "nicovideo",
         "id": "iwatobi-sc",
-        "begin": "2013-07-08T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-08T13:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "4394",
-        "begin": "2013-07-02T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "120712",
+        "begin": "2013-07-02T16:00:01.000Z"
       }
     ]
   },
@@ -928,27 +600,11 @@
     "officialSite": "http://anime.prisma-illya.jp/1st/",
     "begin": "2013-07-06T14:30:00.000Z",
     "end": "2013-09-07T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg4dwet",
-        "begin": "2013-07-06T18:25:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2480",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-06T18:25:17.000Z"
       },
       {
         "site": "bangumi",
@@ -957,12 +613,7 @@
       {
         "site": "nicovideo",
         "id": "prisma-illya",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -978,7 +629,6 @@
     "officialSite": "http://bloodlad.jp/",
     "begin": "2013-07-07T15:30:00.000Z",
     "end": "2013-09-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -987,12 +637,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh835od",
-        "begin": "2017-06-30T16:02:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:45.000Z"
       }
     ]
   },
@@ -1011,7 +656,6 @@
     "officialSite": "http://www.geneitaiyo.com/",
     "begin": "2013-07-06T14:30:00.000Z",
     "end": "2013-11-16T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1020,22 +664,12 @@
       {
         "site": "nicovideo",
         "id": "geneitaiyo",
-        "begin": "2013-07-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-12T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "594",
-        "begin": "2013-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -1051,7 +685,6 @@
     "officialSite": "http://www.haremking.tv/season2/",
     "begin": "2013-07-07T11:30:00.000Z",
     "end": "2013-09-22T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1060,12 +693,7 @@
       {
         "site": "nicovideo",
         "id": "haremking2",
-        "begin": "2013-07-11T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-11T16:30:00.000Z"
       }
     ]
   },
@@ -1081,17 +709,11 @@
     "officialSite": "http://kami-nai.com/",
     "begin": "2013-07-06T16:30:00.000Z",
     "end": "2014-03-27T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "s/s04twr7jsk59twc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1100,22 +722,12 @@
       {
         "site": "nicovideo",
         "id": "kami-nai",
-        "begin": "2013-07-26T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-26T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3145",
-        "begin": "2013-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-05T16:00:00.000Z"
       }
     ]
   },
@@ -1135,27 +747,11 @@
     "officialSite": "http://www.ro-kyu-bu.com/",
     "begin": "2013-07-05T13:30:00.000Z",
     "end": "2013-09-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg4hqkl",
-        "begin": "2013-07-07T22:12:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2467",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-07T22:12:47.000Z"
       },
       {
         "site": "bangumi",
@@ -1164,22 +760,12 @@
       {
         "site": "nicovideo",
         "id": "ro-kyu-bu-ss",
-        "begin": "2013-07-15T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-15T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2683",
-        "begin": "2013-07-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-04T16:00:00.000Z"
       }
     ]
   },
@@ -1195,27 +781,16 @@
     "officialSite": "http://www.tbs.co.jp/anime/stella/",
     "begin": "2013-07-04T16:29:00.000Z",
     "end": "2013-09-26T16:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zLCcGoLoWJb5d98",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "i/iteevv3orfr22it",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1224,22 +799,12 @@
       {
         "site": "nicovideo",
         "id": "stella-c3bu",
-        "begin": "2013-07-16T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-16T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "548",
-        "begin": "2013-07-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -1255,17 +820,11 @@
     "officialSite": "http://www.love-lab.tv/",
     "begin": "2013-07-04T17:05:00.000Z",
     "end": "2013-09-26T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lJJibicGTKOnjbWcE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1274,22 +833,12 @@
       {
         "site": "nicovideo",
         "id": "love-lab",
-        "begin": "2013-07-14T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-14T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "451",
-        "begin": "2013-07-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -1305,17 +854,11 @@
     "officialSite": "http://www.geneonuniversal.jp/rondorobe/anime/danganronpa/",
     "begin": "2013-07-04T16:35:00.000Z",
     "end": "2013-09-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZibDMSrIYiaMYppw8",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1324,32 +867,17 @@
       {
         "site": "nicovideo",
         "id": "danganronpa-anime",
-        "begin": "2013-07-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-06T16:30:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2013/dwlp",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4400",
-        "begin": "2013-07-03T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-03T16:00:01.000Z"
       }
     ]
   },
@@ -1365,17 +893,11 @@
     "officialSite": "http://milky-holmes.com/anime/futari/",
     "begin": "2013-07-13T13:00:00.000Z",
     "end": "2013-09-28T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fvTgXsYsnNo9uyM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1384,22 +906,12 @@
       {
         "site": "nicovideo",
         "id": "milky-holmes-futari",
-        "begin": "2013-07-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-15T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1693",
-        "begin": "2013-07-12T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-12T16:00:00.000Z"
       }
     ]
   },
@@ -1415,7 +927,6 @@
     "officialSite": "http://www.ntv.co.jp/kitakubu/",
     "begin": "2013-07-04T17:54:00.000Z",
     "end": "2013-10-10T18:19:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1424,22 +935,12 @@
       {
         "site": "nicovideo",
         "id": "kitakubu",
-        "begin": "2014-05-22T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-22T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3135",
-        "begin": "2013-07-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-03T16:00:00.000Z"
       }
     ]
   },
@@ -1455,18 +956,7 @@
     "officialSite": "http://www.ginsaji-anime.com/",
     "begin": "2013-07-11T16:10:00.000Z",
     "end": "2013-09-19T16:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2477",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "59664"
@@ -1488,18 +978,7 @@
     "officialSite": "http://www.ntv.co.jp/GATCHAMAN_Crowds/",
     "begin": "2013-07-12T17:33:00.000Z",
     "end": "2013-09-27T17:28:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2481",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "69494"
@@ -1507,32 +986,17 @@
       {
         "site": "nicovideo",
         "id": "gatchaman-crowds",
-        "begin": "2015-06-28T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-28T15:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80041161",
-        "begin": "2015-08-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-01T07:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "520",
-        "begin": "2013-07-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-11T16:00:00.000Z"
       }
     ]
   },
@@ -1548,7 +1012,6 @@
     "officialSite": "http://makai-ouji.com/",
     "begin": "2013-07-07T16:05:00.000Z",
     "end": "2013-09-22T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1557,12 +1020,7 @@
       {
         "site": "nicovideo",
         "id": "makai-ouji",
-        "begin": "2013-07-08T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-08T14:00:00.000Z"
       }
     ]
   },
@@ -1579,27 +1037,11 @@
     "officialSite": "http://hakken-den.com/",
     "begin": "2013-07-07T13:30:00.000Z",
     "end": "2013-09-29T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg4hhzp",
-        "begin": "2014-04-09T23:08:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2474",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T23:08:03.000Z"
       },
       {
         "site": "bangumi",
@@ -1608,12 +1050,7 @@
       {
         "site": "bilibili",
         "id": "529",
-        "begin": "2013-07-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-06T16:00:00.000Z"
       }
     ]
   },
@@ -1630,17 +1067,11 @@
     "officialSite": "http://www.bc-anime.com/",
     "begin": "2013-07-02T10:30:00.000Z",
     "end": "2013-09-17T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrg3waet",
-        "begin": "2014-09-12T06:21:54.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:21:54.000Z"
       },
       {
         "site": "bangumi",
@@ -1649,12 +1080,7 @@
       {
         "site": "nicovideo",
         "id": "bc-anime",
-        "begin": "2013-07-04T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-04T13:30:00.000Z"
       }
     ]
   },
@@ -1670,7 +1096,6 @@
     "officialSite": "http://gifuu.jp/",
     "begin": "2013-07-02T16:40:00.000Z",
     "end": "2013-12-17T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1690,7 +1115,6 @@
     "officialSite": "http://senyu.tv/",
     "begin": "2013-07-02T16:35:00.000Z",
     "end": "2013-09-24T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1710,17 +1134,11 @@
     "officialSite": "http://www.moe-ribbon.com/",
     "begin": "2013-07-05T16:53:00.000Z",
     "end": "2013-09-06T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KB76eOBGtvRX1T0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1740,7 +1158,6 @@
     "officialSite": "http://ani.tv/yamishibai/",
     "begin": "2013-07-14T17:15:00.000Z",
     "end": "2013-09-29T17:41:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1760,17 +1177,11 @@
     "officialSite": "http://kadendanshi.com/",
     "begin": "2013-07-02T14:30:00.000Z",
     "end": "2013-12-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "g4lj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1779,12 +1190,7 @@
       {
         "site": "nicovideo",
         "id": "kadendanshi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1800,37 +1206,21 @@
     "officialSite": "http://kadendanshi.com/",
     "begin": "2013-07-13T16:00:00.000Z",
     "end": "2013-07-13T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "letv",
         "id": "95245",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1839,22 +1229,12 @@
       {
         "site": "qq",
         "id": "e/ejr0xfirssdm33y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5744",
-        "begin": "2013-07-12T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-12T16:00:01.000Z"
       }
     ]
   },
@@ -1870,27 +1250,16 @@
     "officialSite": "http://www.karanokyoukai.com/onair/",
     "begin": "2013-07-05T16:00:00.000Z",
     "end": "2013-09-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KyELiafFXxwVo5k4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "r/rfgkivnu2k0ylyb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1899,12 +1268,7 @@
       {
         "site": "nicovideo",
         "id": "karanokyoukai",
-        "begin": "2013-07-05T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-05T15:30:00.000Z"
       }
     ]
   },
@@ -1920,27 +1284,16 @@
     "officialSite": "",
     "begin": "2013-07-01T16:00:00.000Z",
     "end": "2014-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MDwYlv5k1BJ181s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaeetp",
-        "begin": "2016-02-04T07:54:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-04T07:54:06.000Z"
       },
       {
         "site": "bangumi",
@@ -1960,27 +1313,16 @@
     "officialSite": "",
     "begin": "2013-07-27T16:00:00.000Z",
     "end": "2013-07-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "paqGBGzSQoDjYck",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rro3s6vk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2000,17 +1342,11 @@
     "officialSite": "http://wwws.warnerbros.co.jp/gintama/",
     "begin": "2013-07-06T16:00:00.000Z",
     "end": "2013-07-06T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrmkaxq8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2030,7 +1366,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2013-07-13T17:10:00.000Z",
     "end": "2013-07-13T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2050,17 +1385,11 @@
     "officialSite": "http://hakusai-anime.shtair.net/",
     "begin": "2013-07-15T16:00:00.000Z",
     "end": "2014-12-29T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PTUfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2080,17 +1409,11 @@
     "officialSite": "http://www.kazetachinu.jp/",
     "begin": "2013-07-20T16:00:00.000Z",
     "end": "2013-07-20T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "p6yIBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2110,17 +1433,11 @@
     "officialSite": "http://www.gundam-age.net/memory_of_eden/index.html",
     "begin": "2013-07-26T16:00:00.000Z",
     "end": "2013-07-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HB33dd1DsicFU0jo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2140,17 +1457,11 @@
     "officialSite": "",
     "begin": "2013-07-21T16:00:00.000Z",
     "end": "2013-07-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "CgHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2159,12 +1470,7 @@
       {
         "site": "bilibili",
         "id": "3490",
-        "begin": "2013-07-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-20T16:00:01.000Z"
       }
     ]
   },
@@ -2180,7 +1486,6 @@
     "officialSite": "",
     "begin": "2013-07-26T16:00:00.000Z",
     "end": "2014-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2189,12 +1494,7 @@
       {
         "site": "pptv",
         "id": "ic29JxyibVBUOmJIw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2210,7 +1510,6 @@
     "officialSite": "",
     "begin": "2013-07-24T16:00:00.000Z",
     "end": "2013-07-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2219,22 +1518,12 @@
       {
         "site": "pptv",
         "id": "KCAMiavJYyAZp508",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3800",
-        "begin": "2013-07-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-07-23T16:00:01.000Z"
       }
     ]
   },
@@ -2250,7 +1539,6 @@
     "officialSite": "",
     "begin": "2013-07-20T16:00:00.000Z",
     "end": "2013-07-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2259,12 +1547,7 @@
       {
         "site": "letv",
         "id": "10002046",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2013/08.json
+++ b/data/items/2013/08.json
@@ -11,17 +11,11 @@
     "officialSite": "",
     "begin": "2013-08-24T16:00:00.000Z",
     "end": "2013-08-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rro4glmc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -41,17 +35,11 @@
     "officialSite": "",
     "begin": "2013-08-04T16:00:00.000Z",
     "end": "2016-05-07T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WibbSULgejswvrRU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "bilibili",
         "id": "5069",
-        "begin": "2016-07-10T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-10T17:35:00.000Z"
       }
     ]
   },
@@ -81,17 +64,11 @@
     "officialSite": "",
     "begin": "2013-08-05T16:00:00.000Z",
     "end": "2013-09-09T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3kslowtx4RibCAGg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -100,12 +77,7 @@
       {
         "site": "bilibili",
         "id": "506",
-        "begin": "2013-08-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-04T16:00:00.000Z"
       }
     ]
   },
@@ -121,7 +93,6 @@
     "officialSite": "",
     "begin": "2013-08-24T16:00:00.000Z",
     "end": "2013-08-24T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -141,17 +112,11 @@
     "officialSite": "",
     "begin": "2013-08-28T16:00:00.000Z",
     "end": "2013-08-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mYlj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -167,7 +132,6 @@
     "officialSite": "http://www.vap.co.jp/ponque/",
     "begin": "2013-08-22T16:00:00.000Z",
     "end": "2014-08-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -176,12 +140,7 @@
       {
         "site": "nicovideo",
         "id": "ponque",
-        "begin": "2016-01-13T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-13T11:00:00.000Z"
       }
     ]
   },
@@ -197,7 +156,6 @@
     "officialSite": "",
     "begin": "2013-08-03T16:00:00.000Z",
     "end": "2013-11-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -206,12 +164,7 @@
       {
         "site": "pptv",
         "id": "9mtFwyuRATibiaIIg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -227,7 +180,6 @@
     "officialSite": "",
     "begin": "2013-08-24T16:00:00.000Z",
     "end": "2013-08-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -236,22 +188,12 @@
       {
         "site": "pptv",
         "id": "T8SwLpb8bKoNiaicM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3833",
-        "begin": "2013-08-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-23T16:00:01.000Z"
       }
     ]
   },
@@ -267,7 +209,6 @@
     "officialSite": "http://www.anohana.jp/",
     "begin": "2013-08-31T16:00:00.000Z",
     "end": "2013-08-31T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -276,12 +217,7 @@
       {
         "site": "pptv",
         "id": "ZiczYVr4klNI1sxs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -297,7 +233,6 @@
     "officialSite": "http://www.hanayume.com/kamisama/",
     "begin": "2013-08-20T16:00:00.000Z",
     "end": "2013-08-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -306,12 +241,7 @@
       {
         "site": "pptv",
         "id": "HhP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -327,7 +257,6 @@
     "officialSite": "",
     "begin": "2013-08-16T16:00:00.000Z",
     "end": "2013-08-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -336,12 +265,7 @@
       {
         "site": "pptv",
         "id": "EBnzcdkicrib1QzjY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -357,7 +281,6 @@
     "officialSite": "http://www.tk-anime.info/",
     "begin": "2013-08-12T16:00:00.000Z",
     "end": "2013-08-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -366,22 +289,12 @@
       {
         "site": "pptv",
         "id": "QMiakIorwYJ4Bfibc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2857",
-        "begin": "2013-08-11T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-11T16:00:00.000Z"
       }
     ]
   },
@@ -397,7 +310,6 @@
     "officialSite": "",
     "begin": "2013-08-06T16:00:00.000Z",
     "end": "2013-08-06T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -406,22 +318,12 @@
       {
         "site": "pptv",
         "id": "F2tV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4398",
-        "begin": "2013-08-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-08-05T16:00:01.000Z"
       }
     ]
   },
@@ -433,7 +335,6 @@
     "officialSite": "",
     "begin": "2013-08-02T16:00:00.000Z",
     "end": "2013-09-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -442,12 +343,7 @@
       {
         "site": "nicovideo",
         "id": "madboxzombies",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2013/09.json
+++ b/data/items/2013/09.json
@@ -11,65 +11,30 @@
     "officialSite": "http://ssb-love.tv/",
     "begin": "2013-09-13T16:53:00.000Z",
     "end": "2013-12-13T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "50a2ad0a08b311e3b8b7",
-        "begin": "2013-09-13T22:30:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "o3pTET0Lh68",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-09-13T22:30:05.000Z"
       },
       {
         "site": "qq",
         "id": "v/v3qmzely1mvcn9i",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93252",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "V9fBP6cNfbsenAQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "79701"
-      },
-      {
-        "site": "saraba1st",
-        "id": "956573"
       }
     ]
   },
@@ -85,45 +50,20 @@
     "officialSite": "http://anime-dialover.com/",
     "begin": "2013-09-16T14:30:00.000Z",
     "end": "2013-12-09T14:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "p/p5yfnziow4uwunf",
-        "begin": "2013-09-23T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "479",
-        "begin": "2013-09-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-09-23T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "64993"
       },
       {
-        "site": "saraba1st",
-        "id": "955887"
-      },
-      {
         "site": "nicovideo",
         "id": "anime-dialover",
-        "begin": "2013-09-21T16:45:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-09-21T16:45:00.000Z"
       }
     ]
   },
@@ -139,7 +79,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tamagotchi2013/index2.html",
     "begin": "2013-09-05T09:30:00.000Z",
     "end": "2014-03-27T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -159,17 +98,11 @@
     "officialSite": "http://www.sunrise-inc.co.jp/battlespirits6/",
     "begin": "2013-09-21T22:00:00.000Z",
     "end": "2014-09-20T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5GhEwiaqQAD6hH4c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -192,17 +125,11 @@
     "officialSite": "http://www3.nhk.or.jp/anime/oshiri/",
     "begin": "2013-09-30T09:25:00.000Z",
     "end": "2014-03-27T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oayIBm7URILlY8s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -222,37 +149,21 @@
     "officialSite": "http://www.geass.jp/akito/",
     "begin": "2013-09-14T16:00:00.000Z",
     "end": "2013-09-14T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "otmjIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9mhz9",
-        "begin": "2016-08-31T16:02:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:02:16.000Z"
       },
       {
         "site": "letv",
         "id": "82177",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -275,27 +186,16 @@
     "officialSite": "http://harlock-movie.com/",
     "begin": "2013-09-07T16:00:00.000Z",
     "end": "2013-09-07T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zVIibvCSKibjiabGYE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rro3wd2c",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -304,12 +204,7 @@
       {
         "site": "netflix",
         "id": "80000768",
-        "begin": "2014-08-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-01T07:00:00.000Z"
       }
     ]
   },
@@ -325,17 +220,11 @@
     "officialSite": "http://www.daikaijyu.com/rush/",
     "begin": "2013-09-18T16:00:00.000Z",
     "end": "2014-02-05T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ITUfnQVr2xl8ibmI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -344,12 +233,7 @@
       {
         "site": "bilibili",
         "id": "4384",
-        "begin": "2013-09-17T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-09-17T16:00:01.000Z"
       }
     ]
   },
@@ -365,17 +249,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/oregairu/",
     "begin": "2013-09-19T16:00:00.000Z",
     "end": "2013-09-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "W86qKJD2ZqQHhe0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -384,12 +262,7 @@
       {
         "site": "bilibili",
         "id": "3437",
-        "begin": "2013-09-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-09-18T16:00:01.000Z"
       }
     ]
   },
@@ -405,7 +278,6 @@
     "officialSite": "",
     "begin": "2013-09-13T16:00:00.000Z",
     "end": "2013-09-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -414,22 +286,12 @@
       {
         "site": "pptv",
         "id": "OjMdmwNp2Rd6ibGA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3514",
-        "begin": "2013-09-12T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-09-12T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2013/10.json
+++ b/data/items/2013/10.json
@@ -11,35 +11,20 @@
     "officialSite": "http://www.starchild.co.jp/special/coppelion/top.html",
     "begin": "2013-10-02T12:00:00.000Z",
     "end": "2013-12-25T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/ox39rizb1w9cbv1",
-        "begin": "2013-10-02T13:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2013-10-02T13:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "485",
-        "begin": "2013-10-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-01T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "10463"
-      },
-      {
-        "site": "saraba1st",
-        "id": "959518"
       }
     ]
   },
@@ -55,57 +40,26 @@
     "officialSite": "http://anime-kyokai.com/",
     "begin": "2013-10-02T15:30:00.000Z",
     "end": "2013-12-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh92469",
-        "begin": "2017-01-17T01:00:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-17T01:00:16.000Z"
       },
       {
         "site": "letv",
         "id": "93274",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/jjdbf",
-        "begin": "2013-10-02T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "78",
-        "begin": "2013-10-02T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-02T19:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3365",
-        "begin": "2013-10-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-01T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -114,12 +68,7 @@
       {
         "site": "nicovideo",
         "id": "anime-kyokai",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -138,65 +87,30 @@
     "officialSite": "http://gaist-anime.com/",
     "begin": "2013-10-02T09:00:00.000Z",
     "end": "2014-10-01T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "qqONC3PZSYfqaNA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbgwzl",
-        "begin": "2015-12-04T10:03:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-04T10:03:19.000Z"
       },
       {
         "site": "youku",
         "id": "5af840e4fe6811e2a705",
-        "begin": "2013-10-05T03:39:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "F1cq966NDcY",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-05T03:39:47.000Z"
       },
       {
         "site": "letv",
         "id": "93669",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "79873"
-      },
-      {
-        "site": "saraba1st",
-        "id": "948576"
       }
     ]
   },
@@ -215,75 +129,35 @@
     "officialSite": "http://www.starchild.co.jp/special/miss_monochrome_anime/",
     "begin": "2013-10-01T16:35:00.000Z",
     "end": "2013-12-24T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "36d97dec03e811e38b3f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "bh7k-qp7cRk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "n45q6FC2JmTHRa0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93561",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "v/v3ahv9tmgwosl37",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "80778"
       },
       {
-        "site": "saraba1st",
-        "id": "959511"
-      },
-      {
         "site": "nicovideo",
         "id": "miss-monochrome",
-        "begin": "2013-10-01T16:40:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-01T16:40:00.000Z"
       }
     ]
   },
@@ -299,55 +173,25 @@
     "officialSite": "http://www.nagiasu.jp/",
     "begin": "2013-10-03T13:00:00.000Z",
     "end": "2014-04-03T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgjao0x",
-        "begin": "2014-04-09T22:49:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "95",
-        "begin": "2013-10-03T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T22:49:50.000Z"
       },
       {
         "site": "bilibili",
-        "id": "441",
-        "begin": "2013-10-03T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8672",
+        "begin": "2013-10-03T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "47889"
       },
       {
-        "site": "saraba1st",
-        "id": "927657"
-      },
-      {
         "site": "nicovideo",
         "id": "nagiasu",
-        "begin": "2013-10-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T14:30:00.000Z"
       }
     ]
   },
@@ -363,75 +207,35 @@
     "officialSite": "http://www.kyousougiga-tv.com/",
     "begin": "2013-10-09T16:30:00.000Z",
     "end": "2013-12-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "21M9uyOJibTeaGIA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb1465",
-        "begin": "2016-01-04T06:42:53.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-04T06:42:53.000Z"
       },
       {
         "site": "letv",
         "id": "93555",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/jsxh",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "79",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "79114"
       },
       {
-        "site": "saraba1st",
-        "id": "937157"
-      },
-      {
         "site": "nicovideo",
         "id": "kyousougiga-tv",
-        "begin": "2013-10-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T14:00:00.000Z"
       }
     ]
   },
@@ -448,45 +252,20 @@
     "officialSite": "http://www.aikatsu.net/02/index.html",
     "begin": "2013-10-03T10:00:00.000Z",
     "end": "2014-09-25T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "12b8f2e01c4211e3a705",
-        "begin": "2013-10-18T00:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "B9DlhZTCGd0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-18T00:33:52.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhayx3d",
-        "begin": "2015-03-26T03:23:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-26T03:23:12.000Z"
       },
       {
         "site": "bangumi",
         "id": "139317"
-      },
-      {
-        "site": "saraba1st",
-        "id": "930385"
       }
     ]
   },
@@ -505,25 +284,15 @@
     "officialSite": "http://www.strike-the-blood.com/",
     "begin": "2013-10-04T14:30:00.000Z",
     "end": "2014-03-28T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "67826"
       },
       {
-        "site": "saraba1st",
-        "id": "946896"
-      },
-      {
         "site": "nicovideo",
         "id": "strike-the-blood",
-        "begin": "2013-10-10T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-10T14:30:00.000Z"
       }
     ]
   },
@@ -542,35 +311,20 @@
     "officialSite": "http://www.tbs.co.jp/anime/is2/",
     "begin": "2013-10-03T16:58:00.000Z",
     "end": "2013-12-19T17:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "68022"
       },
       {
-        "site": "saraba1st",
-        "id": "959887"
-      },
-      {
         "site": "nicovideo",
         "id": "anime-is2",
-        "begin": "2013-10-14T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-14T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3489",
-        "begin": "2013-10-02T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-02T16:00:01.000Z"
       }
     ]
   },
@@ -589,55 +343,30 @@
     "officialSite": "http://golden-time.jp/",
     "begin": "2013-10-03T17:35:00.000Z",
     "end": "2014-03-27T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "r/rur1k9y16jaqici",
-        "begin": "2013-10-03T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2013-10-03T18:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "468",
-        "begin": "2013-10-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-02T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "68031"
       },
       {
-        "site": "saraba1st",
-        "id": "945381"
-      },
-      {
         "site": "nicovideo",
         "id": "golden-time",
-        "begin": "2013-10-08T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-08T13:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhgk0n1",
-        "begin": "2017-11-07T00:30:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-07T00:30:07.000Z"
       }
     ]
   },
@@ -656,65 +385,30 @@
     "officialSite": "http://www.kill-la-kill.jp/",
     "begin": "2013-10-03T17:05:00.000Z",
     "end": "2014-03-27T17:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "98",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "93029",
-        "begin": "2013-10-03T17:10:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-03T17:10:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "419",
-        "begin": "2013-10-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-02T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "72941"
       },
       {
-        "site": "saraba1st",
-        "id": "915948"
-      },
-      {
         "site": "nicovideo",
         "id": "kill-la-kill",
-        "begin": "2013-10-06T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-06T14:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70305217",
-        "begin": "2017-05-22T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-05-22T07:00:00.000Z"
       }
     ]
   },
@@ -733,25 +427,15 @@
     "officialSite": "http://www.tbs.co.jp/anime/obc/",
     "begin": "2013-10-03T16:28:00.000Z",
     "end": "2013-12-19T17:08:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "78406"
       },
       {
-        "site": "saraba1st",
-        "id": "959899"
-      },
-      {
         "site": "nicovideo",
         "id": "anime-obc",
-        "begin": "2013-10-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-15T15:00:00.000Z"
       }
     ]
   },
@@ -771,75 +455,40 @@
     "officialSite": "http://www9.nhk.or.jp/anime/loghorizon/",
     "begin": "2013-10-05T08:30:00.000Z",
     "end": "2014-03-22T08:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "gotl40uxIVicCQKg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93540",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0xgd",
-        "begin": "2014-12-16T08:07:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-16T08:07:07.000Z"
       },
       {
         "site": "youku",
         "id": "b9229c08e3cb11e29748",
-        "begin": "2013-10-05T18:49:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T18:49:48.000Z"
       },
       {
         "site": "bilibili",
         "id": "289",
-        "begin": "2013-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "64140"
       },
       {
-        "site": "saraba1st",
-        "id": "946364"
-      },
-      {
         "site": "nicovideo",
         "id": "loghorizon",
-        "begin": "2015-05-18T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-18T06:00:00.000Z"
       }
     ]
   },
@@ -858,35 +507,20 @@
     "officialSite": "http://litbus-anime.com/refrain/",
     "begin": "2013-10-05T11:30:00.000Z",
     "end": "2013-12-28T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "69484"
       },
       {
-        "site": "saraba1st",
-        "id": "962291"
-      },
-      {
         "site": "nicovideo",
         "id": "litbus-anime-refrain",
-        "begin": "2013-10-06T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-06T13:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "3570",
-        "begin": "2013-10-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "81292",
+        "begin": "2013-10-04T16:00:01.000Z"
       }
     ]
   },
@@ -903,45 +537,25 @@
     "officialSite": "http://www.yu-sibu.com/",
     "begin": "2013-10-04T16:30:00.000Z",
     "end": "2014-03-31T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GBXicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93136",
-        "begin": "2013-10-04T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-04T18:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4382",
-        "begin": "2013-10-03T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-03T16:00:01.000Z"
       },
       {
         "site": "bangumi",
         "id": "73440"
-      },
-      {
-        "site": "saraba1st",
-        "id": "932750"
       }
     ]
   },
@@ -960,7 +574,6 @@
     "officialSite": "http://freezing.tv/",
     "begin": "2013-10-04T12:30:00.000Z",
     "end": "2013-12-20T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -969,12 +582,7 @@
       {
         "site": "nicovideo",
         "id": "freezing2-tv",
-        "begin": "2013-10-10T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-10T17:00:00.000Z"
       }
     ]
   },
@@ -991,75 +599,35 @@
     "officialSite": "http://www.phibrain.net/",
     "begin": "2013-10-06T08:30:00.000Z",
     "end": "2014-03-23T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhax8kd",
-        "begin": "2015-01-05T06:21:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0ummBD47jvU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-01-05T06:21:18.000Z"
       },
       {
         "site": "youku",
         "id": "0d218d7619ca11e38b3f",
-        "begin": "2013-10-07T02:44:13.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-07T02:44:13.000Z"
       },
       {
         "site": "qq",
         "id": "u/u0ae6bix0kt4lag",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93552",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "489",
-        "begin": "2013-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "49693"
-      },
-      {
-        "site": "saraba1st",
-        "id": "950301"
       }
     ]
   },
@@ -1076,17 +644,11 @@
     "officialSite": "http://whitealbum2.jp/",
     "begin": "2013-10-05T16:30:00.000Z",
     "end": "2013-12-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgjanw9",
-        "begin": "2013-10-05T16:30:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T16:30:12.000Z"
       },
       {
         "site": "bangumi",
@@ -1095,32 +657,17 @@
       {
         "site": "nicovideo",
         "id": "whitealbum2",
-        "begin": "2013-10-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-08T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3516",
-        "begin": "2013-10-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-04T16:00:01.000Z"
       },
       {
         "site": "qq",
         "id": "6/6pbo5sfnjadq2r1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1139,75 +686,35 @@
     "officialSite": "http://yozakura-anime.jp/",
     "begin": "2013-10-06T14:30:00.000Z",
     "end": "2013-12-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jYFr6VG3J2XIRq4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "XhGkrzdXGf8",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "e9c14c84e22611e29748",
-        "begin": "2013-10-07T04:22:08.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-07T04:22:08.000Z"
       },
       {
         "site": "qq",
         "id": "j/jye92pufaaq3fvr",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "473",
-        "begin": "2013-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "71955"
       },
       {
-        "site": "saraba1st",
-        "id": "960569"
-      },
-      {
         "site": "nicovideo",
         "id": "yozakura-anime",
-        "begin": "2013-10-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-09T14:30:00.000Z"
       }
     ]
   },
@@ -1226,55 +733,25 @@
     "officialSite": "http://diaace.com/",
     "begin": "2013-10-05T23:30:00.000Z",
     "end": "2015-03-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgjao65",
-        "begin": "2014-09-12T06:28:32.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "103",
-        "begin": "2013-10-06T02:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:28:32.000Z"
       },
       {
         "site": "bangumi",
         "id": "73083"
       },
       {
-        "site": "saraba1st",
-        "id": "916299"
-      },
-      {
         "site": "nicovideo",
         "id": "diaace",
-        "begin": "2013-10-11T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-11T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4375",
-        "begin": "2013-10-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -1293,75 +770,35 @@
     "officialSite": "http://walroma.com/",
     "begin": "2013-10-06T15:30:00.000Z",
     "end": "2013-12-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "106",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "mgtv",
         "id": "108321",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93450",
-        "begin": "2013-10-06T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-06T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "480",
-        "begin": "2013-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "76210"
       },
       {
-        "site": "saraba1st",
-        "id": "925814"
-      },
-      {
         "site": "nicovideo",
         "id": "walroma",
-        "begin": "2013-10-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-10T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh8353p",
-        "begin": "2017-07-14T06:06:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-14T06:06:16.000Z"
       }
     ]
   },
@@ -1381,27 +818,11 @@
     "officialSite": "http://mgnb.tv/",
     "begin": "2013-10-06T15:00:00.000Z",
     "end": "2013-12-22T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgjanth",
-        "begin": "2013-10-06T16:00:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "91",
-        "begin": "2013-10-06T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-06T16:00:04.000Z"
       },
       {
         "site": "bangumi",
@@ -1410,22 +831,7 @@
       {
         "site": "nicovideo",
         "id": "mgnb-tv",
-        "begin": "2013-10-06T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4380",
-        "begin": "2013-10-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-06T15:30:00.000Z"
       }
     ]
   },
@@ -1444,55 +850,25 @@
     "officialSite": "http://www.project-magi.com/",
     "begin": "2013-10-06T08:00:00.000Z",
     "end": "2014-03-30T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "93028",
-        "begin": "2013-10-06T08:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-06T08:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "471",
-        "begin": "2013-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "107",
-        "begin": "2013-10-06T08:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "77646"
       },
       {
-        "site": "saraba1st",
-        "id": "865547"
-      },
-      {
         "site": "netflix",
         "id": "80028089",
-        "begin": "2017-11-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-01T07:00:00.000Z"
       }
     ]
   },
@@ -1509,87 +885,41 @@
     "officialSite": "http://www.kurobas.com/",
     "begin": "2013-10-05T16:58:00.000Z",
     "end": "2014-03-29T17:43:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "joRw7la8LGrNS7M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "41613",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "e5894f40e3ca11e29748",
-        "begin": "2013-10-06T08:03:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-06T08:03:08.000Z"
       },
       {
         "site": "qq",
         "id": "5/53x6bbyb07ebl3s",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "_nJJMEa6O6I",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgjann1",
-        "begin": "2014-09-12T06:23:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:23:25.000Z"
       },
       {
         "site": "letv",
         "id": "93033",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1625",
-        "begin": "2013-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1613,65 +943,20 @@
     "officialSite": "http://www.sekatsuyo.com/",
     "begin": "2013-10-06T11:30:00.000Z",
     "end": "2013-12-22T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "74027",
-        "begin": "2013-10-06T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "0995377e0da211e1a046",
-        "begin": "2013-10-07T04:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "I8kEXNTYFeA",
-        "begin": "2013-10-06T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "486",
-        "begin": "2013-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-07T04:25:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "78408"
       },
       {
-        "site": "saraba1st",
-        "id": "960556"
-      },
-      {
         "site": "nicovideo",
         "id": "sekatsuyo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1687,25 +972,15 @@
     "officialSite": "http://www.ntv.co.jp/ippo/",
     "begin": "2013-10-05T16:35:00.000Z",
     "end": "2014-03-29T18:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "502",
-        "begin": "2013-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "78798"
-      },
-      {
-        "site": "saraba1st",
-        "id": "935098"
       }
     ]
   },
@@ -1725,67 +1000,26 @@
     "officialSite": "http://www.ntv.co.jp/voicetorm7/",
     "begin": "2013-10-05T17:05:00.000Z",
     "end": "2013-12-28T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QcyoJo70ZKIFgibs",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "8fd33520055d11e3a705",
-        "begin": "2013-10-06T07:48:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "mE4mtF0Jtxk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-06T07:48:34.000Z"
       },
       {
         "site": "qq",
         "id": "n/nvaj06cswye3rv0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "460",
-        "begin": "2013-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "61",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1794,12 +1028,7 @@
       {
         "site": "nicovideo",
         "id": "voicetorm7_anime",
-        "begin": "2013-10-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-11T15:00:00.000Z"
       }
     ]
   },
@@ -1815,65 +1044,30 @@
     "officialSite": "http://www.ntv.co.jp/tesabu/",
     "begin": "2013-10-05T17:20:00.000Z",
     "end": "2015-08-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "h/hspj1p1lk40jmsz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "6236bbae032911e38b3f",
-        "begin": "2013-10-13T09:19:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "T5nFEQ19Yjo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-13T09:19:22.000Z"
       },
       {
         "site": "bilibili",
         "id": "1578",
-        "begin": "2013-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "80442"
       },
       {
-        "site": "saraba1st",
-        "id": "962886"
-      },
-      {
         "site": "nicovideo",
         "id": "tesabu",
-        "begin": "2013-10-05T17:50:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T17:50:00.000Z"
       }
     ]
   },
@@ -1889,55 +1083,30 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2013-10-06T13:25:00.000Z",
     "end": "2013-12-22T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ooZy8FiaibLmzPTbU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93675",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "19",
-        "begin": "2013-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "82079"
       },
       {
-        "site": "saraba1st",
-        "id": "861754"
-      },
-      {
         "site": "nicovideo",
         "id": "te-kyu3",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1956,55 +1125,25 @@
     "officialSite": "http://www.machine-doll.com/",
     "begin": "2013-10-07T11:30:00.000Z",
     "end": "2013-12-23T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgjanhh",
-        "begin": "2013-10-07T12:00:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "89",
-        "begin": "2013-10-07T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-07T12:00:09.000Z"
       },
       {
         "site": "bangumi",
         "id": "61962"
       },
       {
-        "site": "saraba1st",
-        "id": "906849"
-      },
-      {
         "site": "nicovideo",
         "id": "machine-doll",
-        "begin": "2013-10-10T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-10T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4388",
-        "begin": "2013-10-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-06T16:00:01.000Z"
       }
     ]
   },
@@ -2020,45 +1159,20 @@
     "officialSite": "http://gingitsune.net/",
     "begin": "2013-10-06T16:05:00.000Z",
     "end": "2013-12-22T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "0d2fcdb00a1f11e3a705",
-        "begin": "2013-10-05T03:35:38.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ZA5Yw-VdK2s",
-        "begin": "2013-10-06T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-05T03:35:38.000Z"
       },
       {
         "site": "bangumi",
         "id": "70960"
       },
       {
-        "site": "saraba1st",
-        "id": "960486"
-      },
-      {
         "site": "nicovideo",
         "id": "gingitsune",
-        "begin": "2013-10-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-09T15:00:00.000Z"
       }
     ]
   },
@@ -2079,27 +1193,11 @@
     "officialSite": "http://gundam-bf.net/2013/",
     "begin": "2013-10-07T09:00:00.000Z",
     "end": "2014-03-31T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgjaks5",
-        "begin": "2016-08-09T06:51:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "90",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-09T06:51:09.000Z"
       },
       {
         "site": "bangumi",
@@ -2108,12 +1206,7 @@
       {
         "site": "bilibili",
         "id": "4374",
-        "begin": "2013-10-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-06T16:00:01.000Z"
       }
     ]
   },
@@ -2129,27 +1222,11 @@
     "officialSite": "http://yowapeda.com/",
     "begin": "2013-10-07T16:35:00.000Z",
     "end": "2014-06-30T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "88da380a055711e3b8b7",
-        "begin": "2013-10-04T03:32:17.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "iXeFPRjW9ZM",
-        "begin": "2013-10-07T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-04T03:32:17.000Z"
       },
       {
         "site": "bangumi",
@@ -2158,12 +1235,7 @@
       {
         "site": "nicovideo",
         "id": "yowapeda",
-        "begin": "2013-10-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-11T14:30:00.000Z"
       }
     ]
   },
@@ -2182,75 +1254,25 @@
     "officialSite": "http://www.aokihagane.com/index.php",
     "begin": "2013-10-07T17:55:00.000Z",
     "end": "2013-12-23T19:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "3dfc462efe6911e2a705",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "y7w-zWgB64Q",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93453",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "483",
-        "begin": "2013-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "75",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "74663"
       },
       {
-        "site": "saraba1st",
-        "id": "949824"
-      },
-      {
         "site": "nicovideo",
         "id": "aokihagane",
-        "begin": "2013-10-10T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-10T13:30:00.000Z"
       }
     ]
   },
@@ -2266,45 +1288,20 @@
     "officialSite": "http://www.nonnontv.com/top.html",
     "begin": "2013-10-07T17:05:00.000Z",
     "end": "2013-12-23T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "838fc1c8030211e3b8b7",
-        "begin": "2013-10-04T02:44:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ulKOjCIyn9g",
-        "begin": "2013-10-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-04T02:44:26.000Z"
       },
       {
         "site": "bangumi",
         "id": "78405"
       },
       {
-        "site": "saraba1st",
-        "id": "960462"
-      },
-      {
         "site": "nicovideo",
         "id": "nonnontv",
-        "begin": "2013-10-17T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-17T15:30:00.000Z"
       }
     ]
   },
@@ -2323,25 +1320,15 @@
     "officialSite": "http://www.tokyo-ravens.com/",
     "begin": "2013-10-08T15:30:00.000Z",
     "end": "2014-03-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "78542"
       },
       {
-        "site": "saraba1st",
-        "id": "961162"
-      },
-      {
         "site": "nicovideo",
         "id": "tokyo-ravens",
-        "begin": "2013-10-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-16T16:00:00.000Z"
       }
     ]
   },
@@ -2357,55 +1344,30 @@
     "officialSite": "http://blazblue-am.jp/",
     "begin": "2013-10-08T16:30:00.000Z",
     "end": "2013-12-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2013/blazblue1",
-        "begin": "2013-10-08T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-08T20:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "229398e2e3d911e29748",
-        "begin": "2013-10-09T01:54:37.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-09T01:54:37.000Z"
       },
       {
         "site": "bangumi",
         "id": "73825"
       },
       {
-        "site": "saraba1st",
-        "id": "960942"
-      },
-      {
         "site": "nicovideo",
         "id": "blazblue-anime",
-        "begin": "2013-10-11T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-11T13:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "4368",
-        "begin": "2013-10-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "111892",
+        "begin": "2013-10-07T16:00:01.000Z"
       }
     ]
   },
@@ -2424,45 +1386,20 @@
     "officialSite": "http://www.galileidonna.tv/",
     "begin": "2013-10-10T15:50:00.000Z",
     "end": "2013-12-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "99",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "93220",
-        "begin": "2013-10-10T16:50:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-10T16:50:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "475",
-        "begin": "2013-10-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "77471"
-      },
-      {
-        "site": "saraba1st",
-        "id": "968440"
       }
     ]
   },
@@ -2479,45 +1416,25 @@
     "officialSite": "http://noucome.jp/",
     "begin": "2013-10-09T16:00:00.000Z",
     "end": "2013-12-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "9XZia4EiauHlyicPaU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "93138",
-        "begin": "2013-10-09T17:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-09T17:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2673",
-        "begin": "2013-10-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-08T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "77570"
-      },
-      {
-        "site": "saraba1st",
-        "id": "961467"
       }
     ]
   },
@@ -2534,27 +1451,11 @@
     "officialSite": "http://www.valvrave.com/",
     "begin": "2013-10-10T16:35:00.000Z",
     "end": "2013-12-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgjanrd",
-        "begin": "2013-10-10T20:35:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "97",
-        "begin": "2013-10-10T20:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-10T20:35:12.000Z"
       },
       {
         "site": "bangumi",
@@ -2577,45 +1478,20 @@
     "officialSite": "http://www.samumenco.com/",
     "begin": "2013-10-10T16:20:00.000Z",
     "end": "2014-03-27T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "100",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "93129",
-        "begin": "2013-10-10T16:25:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2013-10-10T16:25:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "476",
-        "begin": "2013-10-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "77473"
-      },
-      {
-        "site": "saraba1st",
-        "id": "945059"
       }
     ]
   },
@@ -2634,65 +1510,30 @@
     "officialSite": "http://www.5648.jp/",
     "begin": "2013-10-10T16:00:00.000Z",
     "end": "2013-12-12T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ia4Nt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "s/sil8p038h3hthpd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "27kPM1IBmTA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "8ef6f2500a2011e38b3f",
-        "begin": "2013-10-11T02:37:41.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-11T02:37:41.000Z"
       },
       {
         "site": "bilibili",
         "id": "495",
-        "begin": "2013-10-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "78398"
-      },
-      {
-        "site": "saraba1st",
-        "id": "961958"
       }
     ]
   },
@@ -2712,97 +1553,41 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_xy/",
     "begin": "2013-10-17T10:00:00.000Z",
     "end": "2015-10-22T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "5/5seimij3v9kms9y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2016/jlbkmxy1",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "167671",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhab3gh",
-        "begin": "2016-01-08T10:36:36.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T10:36:36.000Z"
       },
       {
         "site": "pptv",
         "id": "VicbiaYMguntwicvSU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "CIK0mT03n_M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "ca5b9dc41c3f11e3b8b7",
-        "begin": "2015-12-23T17:11:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-23T17:11:17.000Z"
       },
       {
         "site": "letv",
         "id": "93548",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "%E5%AE%A0%E7%89%A9%E5%B0%8F%E7%B2%BE%E7%81%B5XY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2811,12 +1596,7 @@
       {
         "site": "bilibili",
         "id": "5762",
-        "begin": "2013-10-16T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-16T16:00:01.000Z"
       }
     ]
   },
@@ -2832,17 +1612,11 @@
     "officialSite": "http://www.pokemon.co.jp/ex/origin/",
     "begin": "2013-10-02T16:00:00.000Z",
     "end": "2013-10-02T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "93668",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2862,17 +1636,11 @@
     "officialSite": "",
     "begin": "2013-10-25T16:00:00.000Z",
     "end": "2013-10-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6m9JxyibVBUOmJIw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2881,12 +1649,7 @@
       {
         "site": "bilibili",
         "id": "3852",
-        "begin": "2013-10-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-24T16:00:01.000Z"
       }
     ]
   },
@@ -2902,7 +1665,6 @@
     "officialSite": "",
     "begin": "2013-10-09T16:00:00.000Z",
     "end": "2014-11-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2911,22 +1673,12 @@
       {
         "site": "pptv",
         "id": "duTQTrYcjMotqxM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4383",
-        "begin": "2013-10-08T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-08T16:00:01.000Z"
       }
     ]
   },
@@ -2942,7 +1694,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/2013_precure/",
     "begin": "2013-10-26T16:00:00.000Z",
     "end": "2013-10-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2951,12 +1702,7 @@
       {
         "site": "pptv",
         "id": "n4Nt61O5KWfKSLA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2972,7 +1718,6 @@
     "officialSite": "",
     "begin": "2013-10-16T16:00:00.000Z",
     "end": "2013-10-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2981,12 +1726,7 @@
       {
         "site": "pptv",
         "id": "dOLOTLQaiasgrqRE",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3005,7 +1745,6 @@
     "officialSite": "http://www.madoka-magica.com/",
     "begin": "2013-10-25T16:00:00.000Z",
     "end": "2013-10-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3014,12 +1753,7 @@
       {
         "site": "netflix",
         "id": "70296750",
-        "begin": "2015-06-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-01T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2013/11.json
+++ b/data/items/2013/11.json
@@ -7,77 +7,36 @@
     "officialSite": "",
     "begin": "2013-11-15T02:30:00.000Z",
     "end": "2015-02-27T04:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470017",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "Wb6aGIDmVpT3dd0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hpxk7hpq715lw3o",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgj8yuh",
-        "begin": "2014-04-09T22:50:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T22:50:16.000Z"
       },
       {
         "site": "letv",
         "id": "94506",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2013/csyx",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "100159",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -97,17 +56,11 @@
     "officialSite": "http://www.ntv.co.jp/kinro/lineup/20131129/",
     "begin": "2013-11-15T16:00:00.000Z",
     "end": "2013-11-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "n4tl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -127,17 +80,11 @@
     "officialSite": "http://www.shashinkan-aoshigure.com/aoshigure/",
     "begin": "2013-11-09T16:00:00.000Z",
     "end": "2013-11-09T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10008182",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -146,12 +93,7 @@
       {
         "site": "bilibili",
         "id": "2820",
-        "begin": "2013-11-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-11-08T16:00:00.000Z"
       }
     ]
   },
@@ -167,17 +109,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/hidamari/",
     "begin": "2013-11-27T16:00:00.000Z",
     "end": "2013-11-27T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jIBs6lK4KGbJR68",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -186,22 +122,12 @@
       {
         "site": "bilibili",
         "id": "3823",
-        "begin": "2013-11-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-11-26T16:00:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh7jfkl",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -217,7 +143,6 @@
     "officialSite": "http://ch.nicovideo.jp/nya/",
     "begin": "2013-11-05T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -226,12 +151,7 @@
       {
         "site": "nicovideo",
         "id": "nya",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -247,7 +167,6 @@
     "officialSite": "http://www.p3m.jp/",
     "begin": "2013-11-23T16:00:00.000Z",
     "end": "2013-11-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -256,22 +175,12 @@
       {
         "site": "nicovideo",
         "id": "p3m",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2845",
-        "begin": "2013-11-22T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-11-22T16:00:00.000Z"
       }
     ]
   },
@@ -287,7 +196,6 @@
     "officialSite": "http://patema.jp/",
     "begin": "2013-11-09T16:00:00.000Z",
     "end": "2013-11-09T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -296,22 +204,12 @@
       {
         "site": "nicovideo",
         "id": "patema",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3668",
-        "begin": "2013-11-08T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-11-08T16:00:01.000Z"
       }
     ]
   },
@@ -327,7 +225,6 @@
     "officialSite": "http://www.bayonetta-movie.com/",
     "begin": "2013-11-23T16:00:00.000Z",
     "end": "2013-11-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -336,12 +233,7 @@
       {
         "site": "pptv",
         "id": "ZfXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -360,7 +252,6 @@
     "officialSite": "http://kokaku-a.jp/arise/",
     "begin": "2013-11-29T16:00:00.000Z",
     "end": "2013-11-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -369,12 +260,7 @@
       {
         "site": "netflix",
         "id": "80002074",
-        "begin": "2017-01-31T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-31T08:00:00.000Z"
       }
     ]
   }

--- a/data/items/2013/12.json
+++ b/data/items/2013/12.json
@@ -11,57 +11,26 @@
     "officialSite": "http://pupipo.tv/",
     "begin": "2013-12-20T16:53:00.000Z",
     "end": "2014-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JC4KiaPBWxgRn5U0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "NBUkfZHMX0g",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "0546d626525811e3a705",
-        "begin": "2013-12-28T02:22:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-28T02:22:57.000Z"
       },
       {
         "site": "qq",
         "id": "1/1nx4dcrhqgqjibp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "95038",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -84,27 +53,16 @@
     "officialSite": "http://doublecircle.toshiba-smartcommunity.com/",
     "begin": "2013-12-19T16:00:00.000Z",
     "end": "2014-09-25T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NiaAMiavJYyAZp508",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/98o6m42is63etn3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -113,12 +71,7 @@
       {
         "site": "bilibili",
         "id": "216",
-        "begin": "2013-12-18T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-18T16:00:00.000Z"
       }
     ]
   },
@@ -137,27 +90,16 @@
     "officialSite": "http://bushiroad-anime.com/",
     "begin": "2013-12-31T16:00:00.000Z",
     "end": "2013-12-31T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "20YysBhib7iayPDXU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "6/6xn8j1a5ee9j0ev",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -166,12 +108,7 @@
       {
         "site": "bilibili",
         "id": "1653",
-        "begin": "2013-12-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-30T16:00:00.000Z"
       }
     ]
   },
@@ -187,57 +124,26 @@
     "officialSite": "http://lupicona-movie.com/",
     "begin": "2013-12-07T16:00:00.000Z",
     "end": "2013-12-07T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5Hdh30etHVuibPKQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rri0uklo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "75035",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10016100",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/lbss",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -259,17 +165,11 @@
     "officialSite": "http://king-cr.jp/special/majocco/",
     "begin": "2013-12-28T16:00:00.000Z",
     "end": "2013-12-28T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NCgEgupQwP5h30c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -289,17 +189,11 @@
     "officialSite": "http://amazing-twins.com/",
     "begin": "2013-12-29T16:00:00.000Z",
     "end": "2014-02-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8HtV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -308,12 +202,7 @@
       {
         "site": "bilibili",
         "id": "214",
-        "begin": "2014-02-25T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-02-25T16:00:00.000Z"
       }
     ]
   },
@@ -329,17 +218,11 @@
     "officialSite": "http://www.aniplex.co.jp/natsume",
     "begin": "2013-12-15T16:00:00.000Z",
     "end": "2013-12-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Dhnzcdkicrib1QzjY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -348,12 +231,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh9i375",
-        "begin": "2017-04-12T06:05:36.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T06:05:36.000Z"
       }
     ]
   },
@@ -369,17 +247,11 @@
     "officialSite": "http://bloodlad.jp",
     "begin": "2013-12-04T16:00:00.000Z",
     "end": "2013-12-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ttu1M5sBca8SkPg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",

--- a/data/items/2014/01.json
+++ b/data/items/2014/01.json
@@ -15,77 +15,31 @@
     "officialSite": "http://www.tv-aichi.co.jp/fc-buddyfight/",
     "begin": "2014-01-03T23:00:00.000Z",
     "end": "2015-04-03T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Q9WicPaULe7kcmgI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "95313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "222",
-        "begin": "2014-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-03T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "0a14b8a862d411e3a705",
-        "begin": "2014-01-11T10:01:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0yYeCeFSZDo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-11T10:01:38.000Z"
       },
       {
         "site": "qq",
         "id": "g/gkvdkxuaepreo2m",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "219",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -109,45 +63,20 @@
     "officialSite": "http://imocyo-anime.com/",
     "begin": "2014-01-04T13:30:00.000Z",
     "end": "2014-03-22T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgje7wd",
-        "begin": "2014-01-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "183",
-        "begin": "2014-01-04T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-04T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "55703"
       },
       {
-        "site": "saraba1st",
-        "id": "987191"
-      },
-      {
         "site": "nicovideo",
         "id": "imocyo-anime",
-        "begin": "2014-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-10T03:00:00.000Z"
       }
     ]
   },
@@ -166,55 +95,25 @@
     "officialSite": "http://www.vap.co.jp/nobunagun/",
     "begin": "2014-01-05T13:00:00.000Z",
     "end": "2014-03-30T13:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "d/dob058ixul6vbw4",
-        "begin": "2014-01-05T16:35:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-05T16:35:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "223",
-        "begin": "2014-01-05T16:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "188",
-        "begin": "2014-01-05T16:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-05T16:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "79802"
       },
       {
-        "site": "saraba1st",
-        "id": "990314"
-      },
-      {
         "site": "nicovideo",
         "id": "nobunagun",
-        "begin": "2014-01-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-07T03:00:00.000Z"
       }
     ]
   },
@@ -234,45 +133,20 @@
     "officialSite": "http://space-dandy.com/",
     "begin": "2014-01-05T14:00:00.000Z",
     "end": "2014-03-30T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgje7xx",
-        "begin": "2014-01-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "185",
-        "begin": "2014-01-05T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-05T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "80864"
       },
       {
-        "site": "saraba1st",
-        "id": "961085"
-      },
-      {
         "site": "nicovideo",
         "id": "space-dandy",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -291,75 +165,36 @@
     "officialSite": "http://noragami-anime.net/1/",
     "begin": "2014-01-05T14:30:00.000Z",
     "end": "2014-03-23T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgje7tl",
-        "begin": "2014-01-05T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-01-05T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2731",
-        "begin": "2014-01-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "186",
-        "begin": "2014-01-05T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-05T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "82572"
       },
       {
-        "site": "saraba1st",
-        "id": "964386"
-      },
-      {
         "site": "nicovideo",
         "id": "noragami-anime",
-        "begin": "2014-01-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T15:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80006397",
         "begin": "2017-12-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
         "comment": "港区可见"
       },
       {
         "site": "sohu",
         "id": "s2013/llsc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -375,95 +210,40 @@
     "officialSite": "http://www.fal-gaku.com/",
     "begin": "2014-01-05T13:25:00.000Z",
     "end": "2014-03-30T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "U8WvLZX7a6kMiavI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "33455b5a6dcf11e3a705",
-        "begin": "2014-01-06T01:55:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "VyjqLWiyiSU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-06T01:55:57.000Z"
       },
       {
         "site": "qq",
         "id": "d/do9n7u9ssryk2t4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "95331",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1489",
-        "begin": "2014-01-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "187",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "84493"
       },
       {
-        "site": "saraba1st",
-        "id": "958301"
-      },
-      {
         "site": "nicovideo",
         "id": "falgaku-anime",
-        "begin": "2016-10-04T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T06:00:00.000Z"
       }
     ]
   },
@@ -483,27 +263,11 @@
     "officialSite": "http://www.starchild.co.jp/special/seitokai2/",
     "begin": "2014-01-04T11:30:00.000Z",
     "end": "2014-03-29T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgje85d",
-        "begin": "2014-01-04T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "182",
-        "begin": "2014-01-04T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-04T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -512,12 +276,7 @@
       {
         "site": "nicovideo",
         "id": "seitokai02",
-        "begin": "2014-01-13T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-13T14:00:00.000Z"
       }
     ]
   },
@@ -536,85 +295,35 @@
     "officialSite": "http://www.witch-cw-anime.jp/",
     "begin": "2014-01-05T13:30:00.000Z",
     "end": "2014-03-23T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "95345",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "0/013o2kb95j423ab",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "0fa22c4c452911e3b8b7",
-        "begin": "2014-01-01T07:38:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "3CzwLK6v9Gc",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-01T07:38:58.000Z"
       },
       {
         "site": "pptv",
         "id": "1EUvrRV76ymMCnI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "176",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "87113"
       },
       {
-        "site": "saraba1st",
-        "id": "968599"
-      },
-      {
         "site": "nicovideo",
         "id": "witch-cw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -630,77 +339,26 @@
     "officialSite": "http://www.buddy-complex.jp/",
     "begin": "2014-01-05T15:00:00.000Z",
     "end": "2014-03-30T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "fAbbteIVqLA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "6e1724d65b3511e3a705",
-        "begin": "2014-01-02T00:31:38.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-02T00:31:38.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgje7o1",
-        "begin": "2014-04-09T22:48:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "75159",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-09T22:48:52.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/buddycomplex",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1722",
-        "begin": "2014-01-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "199",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -720,37 +378,11 @@
     "officialSite": "http://www.saki-anime.com/",
     "begin": "2014-01-05T17:05:00.000Z",
     "end": "2014-04-06T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "33ea967a5ca311e3b8b7",
-        "begin": "2014-01-05T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "JzB40TpDmPE",
-        "begin": "2014-01-05T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "190",
-        "begin": "2014-01-05T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-05T17:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -759,12 +391,7 @@
       {
         "site": "nicovideo",
         "id": "saki-zenkokuhen",
-        "begin": "2014-01-11T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-11T14:00:00.000Z"
       }
     ]
   },
@@ -781,37 +408,11 @@
     "officialSite": "http://www.t-sekikun.jp/",
     "begin": "2014-01-05T17:35:00.000Z",
     "end": "2014-06-01T15:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "b302b478144711e38b3f",
-        "begin": "2014-01-05T21:15:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "V48zjBLR5PA",
-        "begin": "2014-01-05T21:15:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "189",
-        "begin": "2014-01-05T21:15:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-05T21:15:00.000Z"
       },
       {
         "site": "bangumi",
@@ -820,12 +421,7 @@
       {
         "site": "nicovideo",
         "id": "t-sekikun",
-        "begin": "2014-01-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-12T15:00:00.000Z"
       }
     ]
   },
@@ -841,55 +437,25 @@
     "officialSite": "http://koiuta.tv/",
     "begin": "2014-01-06T13:00:00.000Z",
     "end": "2014-03-31T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "95021",
-        "begin": "2014-01-06T13:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-06T13:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "233",
-        "begin": "2014-01-06T13:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "192",
-        "begin": "2014-01-06T13:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-06T13:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "73828"
       },
       {
-        "site": "saraba1st",
-        "id": "978861"
-      },
-      {
         "site": "nicovideo",
         "id": "koiuta-tv",
-        "begin": "2014-01-06T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-06T13:30:00.000Z"
       }
     ]
   },
@@ -908,55 +474,20 @@
     "officialSite": "http://soniani.jp/",
     "begin": "2014-01-06T11:30:00.000Z",
     "end": "2014-03-24T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "8/8afffvyby5ga318",
-        "begin": "2014-01-06T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "232",
-        "begin": "2014-01-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "193",
-        "begin": "2014-01-06T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-06T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "84081"
       },
       {
-        "site": "saraba1st",
-        "id": "956552"
-      },
-      {
         "site": "nicovideo",
         "id": "soniani",
-        "begin": "2014-01-07T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-07T14:30:00.000Z"
       }
     ]
   },
@@ -975,45 +506,20 @@
     "officialSite": "http://www.nobunaga.tv/",
     "begin": "2014-01-05T16:35:00.000Z",
     "end": "2014-06-22T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "8581ce084a9811e3b8b7",
-        "begin": "2014-01-05T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "zw8cGAwSDJM",
-        "begin": "2014-01-05T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-05T16:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "87625"
       },
       {
-        "site": "saraba1st",
-        "id": "970632"
-      },
-      {
         "site": "nicovideo",
         "id": "nobunaga",
-        "begin": "2014-01-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-10T15:30:00.000Z"
       }
     ]
   },
@@ -1032,55 +538,20 @@
     "officialSite": "http://www.d-fragments.net/",
     "begin": "2014-01-06T17:05:00.000Z",
     "end": "2014-03-24T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "867b29c0058411e3a705",
-        "begin": "2014-01-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "OpofdZOE_mI",
-        "begin": "2014-01-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "198",
-        "begin": "2014-01-06T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-06T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "80548"
       },
       {
-        "site": "saraba1st",
-        "id": "987886"
-      },
-      {
         "site": "nicovideo",
         "id": "d-frag",
-        "begin": "2014-01-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-16T16:00:00.000Z"
       }
     ]
   },
@@ -1096,7 +567,6 @@
     "officialSite": "http://s.mxtv.jp/kokakua_nyumon/",
     "begin": "2014-01-06T16:00:00.000Z",
     "end": "2014-06-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1119,75 +589,30 @@
     "officialSite": "http://www.anime-chu-2.com/",
     "begin": "2014-01-08T15:30:00.000Z",
     "end": "2014-03-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2013/zeb2",
-        "begin": "2014-01-08T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-08T18:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "1be4027c66b811e3a705",
-        "begin": "2014-01-08T18:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ZL7up76Yeik",
-        "begin": "2014-01-08T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-08T18:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4349",
-        "begin": "2014-01-08T18:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "202",
-        "begin": "2014-01-08T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-08T18:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "72942"
       },
       {
-        "site": "saraba1st",
-        "id": "984504"
-      },
-      {
         "site": "nicovideo",
         "id": "chu-2-ren",
-        "begin": "2018-01-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-06T03:00:00.000Z"
       }
     ]
   },
@@ -1206,75 +631,41 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/youkai-watch/",
     "begin": "2014-01-08T10:00:00.000Z",
     "end": "2018-03-30T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Oy0Hhe1TwwFk4ko",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "h/hbccdwvo9t21w4i",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "83124"
       },
       {
-        "site": "saraba1st",
-        "id": "988026"
-      },
-      {
         "site": "nicovideo",
         "id": "youkai-watch",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80087629",
         "begin": "2016-07-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
         "comment": "港区可见"
       },
       {
         "site": "mgtv",
         "id": "328216",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgibl0h",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1294,55 +685,20 @@
     "officialSite": "http://hamatorapj.com/animation.html",
     "begin": "2014-01-07T16:40:00.000Z",
     "end": "2014-03-25T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "9997364a5ca811e3b8b7",
-        "begin": "2014-01-07T17:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "eUPF1XG11cs",
-        "begin": "2014-01-07T17:10:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "203",
-        "begin": "2014-01-07T17:10:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-07T17:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "87718"
       },
       {
-        "site": "saraba1st",
-        "id": "965704"
-      },
-      {
         "site": "nicovideo",
         "id": "hamatorapj",
-        "begin": "2013-12-30T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-12-30T03:00:00.000Z"
       }
     ]
   },
@@ -1358,55 +714,25 @@
     "officialSite": "http://www.ginsaji-anime.com/",
     "begin": "2014-01-09T15:50:00.000Z",
     "end": "2014-03-27T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "95033",
-        "begin": "2014-01-09T15:55:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-09T15:55:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "240",
-        "begin": "2014-01-09T15:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "207",
-        "begin": "2014-01-09T15:55:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T15:55:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "77480"
       },
       {
-        "site": "saraba1st",
-        "id": "988689"
-      },
-      {
         "site": "netflix",
         "id": "80041161",
-        "begin": "2015-08-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-01T07:00:00.000Z"
       }
     ]
   },
@@ -1425,65 +751,25 @@
     "officialSite": "http://mikakunin.jp/",
     "begin": "2014-01-08T17:13:00.000Z",
     "end": "2014-03-26T17:43:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "yldBvyeNicTueHIQ",
-        "begin": "2014-01-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-10T14:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "2aa61d0a235511e3b8b7",
-        "begin": "2014-01-10T14:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "242",
-        "begin": "2014-01-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "206",
-        "begin": "2014-01-10T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-10T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "83869"
       },
       {
-        "site": "saraba1st",
-        "id": "988504"
-      },
-      {
         "site": "nicovideo",
         "id": "mikakunin",
-        "begin": "2014-01-12T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-12T13:30:00.000Z"
       }
     ]
   },
@@ -1499,55 +785,20 @@
     "officialSite": "http://zxignition.tv/",
     "begin": "2014-01-09T17:20:00.000Z",
     "end": "2014-04-03T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "58f9fa065ca711e3a705",
-        "begin": "2014-01-09T17:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "empzLT6BOj4",
-        "begin": "2014-01-09T17:20:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "218",
-        "begin": "2014-01-09T17:20:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T17:20:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "59035"
       },
       {
-        "site": "saraba1st",
-        "id": "965956"
-      },
-      {
         "site": "nicovideo",
         "id": "zxignition",
-        "begin": "2014-01-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-12T03:00:00.000Z"
       }
     ]
   },
@@ -1563,57 +814,16 @@
     "officialSite": "http://www.pupa-anime.com/",
     "begin": "2014-01-09T17:30:00.000Z",
     "end": "2014-03-27T17:34:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "02dba6f41c3f11e3a705",
-        "begin": "2014-01-10T01:04:51.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "YK2bP-HVmSE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-10T01:04:51.000Z"
       },
       {
         "site": "qq",
         "id": "f/fifserh0g9lpnvc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "247",
-        "begin": "2014-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "211",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1633,85 +843,35 @@
     "officialSite": "http://hozukino-reitetsu.com/",
     "begin": "2014-01-09T16:50:00.000Z",
     "end": "2014-04-03T17:13:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbdhzd",
-        "begin": "2016-08-03T02:39:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-03T02:39:07.000Z"
       },
       {
         "site": "sohu",
         "id": "s2013/gddlc",
-        "begin": "2014-01-09T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T19:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "05650f98030111e3a705",
-        "begin": "2014-01-09T19:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "jDJLFxCWxBI",
-        "begin": "2014-01-09T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-09T19:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3440",
-        "begin": "2014-01-09T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "208",
-        "begin": "2014-01-09T19:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T19:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "77188"
       },
       {
-        "site": "saraba1st",
-        "id": "988855"
-      },
-      {
         "site": "nicovideo",
         "id": "hozukino-reitetsu",
-        "begin": "2014-01-13T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-13T14:30:00.000Z"
       }
     ]
   },
@@ -1730,65 +890,30 @@
     "officialSite": "http://www.tbs.co.jp/anime/mahosen/",
     "begin": "2014-01-09T17:13:00.000Z",
     "end": "2014-03-27T18:11:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbd2bd",
-        "begin": "2016-08-05T07:17:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-05T07:17:28.000Z"
       },
       {
         "site": "sohu",
         "id": "s2013/mfzz",
-        "begin": "2014-01-09T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T20:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4367",
-        "begin": "2014-01-09T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "209",
-        "begin": "2014-01-09T20:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T20:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "79228"
       },
       {
-        "site": "saraba1st",
-        "id": "963378"
-      },
-      {
         "site": "nicovideo",
         "id": "mahosen",
-        "begin": "2014-01-26T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-26T15:00:00.000Z"
       }
     ]
   },
@@ -1804,75 +929,25 @@
     "officialSite": "http://www.tbs.co.jp/anime/sakura/",
     "begin": "2014-01-09T17:43:00.000Z",
     "end": "2014-03-27T18:41:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2013/trick",
-        "begin": "2014-01-09T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "F_Kpy6LCzCs",
-        "begin": "2014-01-09T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-09T20:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "6e3c74d250ba11e3b8b7",
-        "begin": "2014-01-09T20:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3547",
-        "begin": "2014-01-09T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "214",
-        "begin": "2014-01-09T20:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T20:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "80838"
       },
       {
-        "site": "saraba1st",
-        "id": "985396"
-      },
-      {
         "site": "nicovideo",
         "id": "sakuratrick",
-        "begin": "2014-01-21T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-21T15:00:00.000Z"
       }
     ]
   },
@@ -1891,85 +966,30 @@
     "officialSite": "http://www.dreamcreation.co.jp/stpl/",
     "begin": "2014-01-09T16:00:00.000Z",
     "end": "2014-03-27T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BhD8euJIuPZZ1z8",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "agOIIdO0Heg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "db819ff85bc911e38b3f",
-        "begin": "2014-01-10T00:56:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-10T00:56:02.000Z"
       },
       {
         "site": "qq",
         "id": "7/75ly4e6byzt3jdk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "212",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "24",
-        "begin": "2014-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "86804"
       },
       {
-        "site": "saraba1st",
-        "id": "989343"
-      },
-      {
         "site": "nicovideo",
         "id": "stpl",
-        "begin": "2014-01-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-07T15:00:00.000Z"
       }
     ]
   },
@@ -1988,37 +1008,11 @@
     "officialSite": "http://wakeupgirls.jp/",
     "begin": "2014-01-10T16:23:00.000Z",
     "end": "2014-03-28T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "afa35b76032a11e38b3f",
-        "begin": "2014-01-10T16:53:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "7LMph51n7d8",
-        "begin": "2014-01-10T16:53:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "215",
-        "begin": "2014-01-10T16:53:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-10T16:53:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2027,12 +1021,7 @@
       {
         "site": "nicovideo",
         "id": "wakeupgirls",
-        "begin": "2014-01-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-13T15:30:00.000Z"
       }
     ]
   },
@@ -2051,75 +1040,30 @@
     "officialSite": "http://www.no-rin.tv/",
     "begin": "2014-01-10T16:00:00.000Z",
     "end": "2014-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "s/sscgn2qjxk1fc2i",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0HLSH-kZAxA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "717eef92031411e38b3f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "249",
-        "begin": "2014-01-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "217",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "68756"
       },
       {
-        "site": "saraba1st",
-        "id": "907036"
-      },
-      {
         "site": "nicovideo",
         "id": "no-rin",
-        "begin": "2014-01-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-12T03:00:00.000Z"
       }
     ]
   },
@@ -2135,55 +1079,20 @@
     "officialSite": "http://www.nisekoi.jp/1st/",
     "begin": "2014-01-11T14:30:00.000Z",
     "end": "2014-05-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "95078",
-        "begin": "2014-01-11T14:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1573",
-        "begin": "2014-01-11T14:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "221",
-        "begin": "2014-01-11T14:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-11T14:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "74628"
       },
       {
-        "site": "saraba1st",
-        "id": "989359"
-      },
-      {
         "site": "nicovideo",
         "id": "nisekoi",
-        "begin": "2014-01-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-13T15:00:00.000Z"
       }
     ]
   },
@@ -2199,65 +1108,30 @@
     "officialSite": "http://www.sekaiseifuku-zzz.com/",
     "begin": "2014-01-11T15:00:00.000Z",
     "end": "2016-07-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "95268",
-        "begin": "2014-01-16T20:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-16T20:30:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2013/sjzf",
-        "begin": "2014-01-16T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "222",
-        "begin": "2014-01-16T20:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-16T20:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "86072"
       },
       {
-        "site": "saraba1st",
-        "id": "979254"
-      },
-      {
         "site": "nicovideo",
         "id": "sekaiseifuku-zzz",
-        "begin": "2014-01-15T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-15T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "253",
-        "begin": "2014-01-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-10T16:00:00.000Z"
       }
     ]
   },
@@ -2277,55 +1151,25 @@
     "officialSite": "http://wizardbarristers.com/",
     "begin": "2014-01-12T15:30:00.000Z",
     "end": "2014-03-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2013/wizardbarristers",
-        "begin": "2014-01-12T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "224",
-        "begin": "2014-01-12T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-12T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "80787"
       },
       {
-        "site": "saraba1st",
-        "id": "945394"
-      },
-      {
         "site": "nicovideo",
         "id": "wizardbarristers",
-        "begin": "2014-01-24T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-24T15:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "4232",
-        "begin": "2014-01-11T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "75452",
+        "begin": "2014-01-11T16:00:01.000Z"
       }
     ]
   },
@@ -2342,67 +1186,26 @@
     "officialSite": "http://www.ntv.co.jp/tesabu/",
     "begin": "2014-01-11T19:00:00.000Z",
     "end": "2014-03-29T19:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VsGrKZH3Z6UIhu4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "a/ah9btl2q75qm71m",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "d8ac33ca711211e3b8b7",
-        "begin": "2014-01-13T02:28:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "IEeRScWf3H8",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-13T02:28:05.000Z"
       },
       {
         "site": "bilibili",
         "id": "1579",
-        "begin": "2014-01-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "223",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-10T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2411,12 +1214,7 @@
       {
         "site": "nicovideo",
         "id": "tesabu",
-        "begin": "2013-10-05T17:50:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T17:50:00.000Z"
       }
     ]
   },
@@ -2433,45 +1231,20 @@
     "officialSite": "http://inarikonkon.jp/",
     "begin": "2014-01-15T16:00:00.000Z",
     "end": "2014-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "95081",
-        "begin": "2014-01-15T17:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-15T17:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "257",
-        "begin": "2014-01-15T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "226",
-        "begin": "2014-01-15T17:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-15T17:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "56116"
-      },
-      {
-        "site": "saraba1st",
-        "id": "990480"
       }
     ]
   },
@@ -2491,28 +1264,12 @@
     "officialSite": "http://maken-ki-two.com/",
     "begin": "2014-01-15T16:30:00.000Z",
     "end": "2014-03-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "url": "http://comic.le.com/zt/mjj2/index.shtml",
         "site": "letv",
         "id": "96258",
-        "begin": "2014-01-15T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "227",
-        "begin": "2014-01-15T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-01-15T18:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2532,67 +1289,26 @@
     "officialSite": "http://gogo575.sega.jp/",
     "begin": "2014-01-09T16:25:00.000Z",
     "end": "2014-01-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PScRjicddzQtu7FQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "7gCdfLVzEac",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "4d14916662e111e3b8b7",
-        "begin": "2014-01-10T00:49:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-10T00:49:31.000Z"
       },
       {
         "site": "qq",
         "id": "l/lek65108jsrrl4p",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "241",
-        "begin": "2014-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "210",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-08T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2601,12 +1317,7 @@
       {
         "site": "nicovideo",
         "id": "gogo575",
-        "begin": "2014-01-12T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-12T16:05:00.000Z"
       }
     ]
   },
@@ -2625,27 +1336,16 @@
     "officialSite": "http://wooser.tv/",
     "begin": "2014-01-07T16:35:00.000Z",
     "end": "2014-03-25T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QNKibPKQKergbmQE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "v/v78mvhukcdb4m6d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2654,12 +1354,7 @@
       {
         "site": "nicovideo",
         "id": "wooser-tv-kakuse",
-        "begin": "2014-01-07T16:40:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-07T16:40:00.000Z"
       }
     ]
   },
@@ -2675,27 +1370,16 @@
     "officialSite": "http://www.takeshobo.co.jp/sp/tv_oneechan/",
     "begin": "2014-01-08T18:00:00.000Z",
     "end": "2014-03-26T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "BQicpZ881peNGxCw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/9d2wr6l2d1o7d5z",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2704,22 +1388,12 @@
       {
         "site": "nicovideo",
         "id": "tv-oneechan",
-        "begin": "2014-01-09T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-09T16:35:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "238",
-        "begin": "2014-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -2731,7 +1405,6 @@
     "officialSite": "http://www.araiguma-rascal.com/meitantei/",
     "begin": "2014-01-08T23:55:00.000Z",
     "end": "2014-03-27T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2751,7 +1424,6 @@
     "officialSite": "http://web.music-ru.com/akaechan/",
     "begin": "2014-01-06T16:21:00.000Z",
     "end": "2014-03-31T16:51:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2760,12 +1432,7 @@
       {
         "site": "bilibili",
         "id": "3132",
-        "begin": "2014-01-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-05T16:00:00.000Z"
       }
     ]
   },
@@ -2781,7 +1448,6 @@
     "officialSite": "http://www.ntv.co.jp/inuneko/dog/",
     "begin": "2014-01-11T18:45:00.000Z",
     "end": "2014-03-29T18:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2801,7 +1467,6 @@
     "officialSite": "http://www.ntv.co.jp/inuneko/cat/",
     "begin": "2014-01-11T18:45:00.000Z",
     "end": "2014-03-29T18:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2824,37 +1489,16 @@
     "officialSite": "http://www.robot-girlsz.com/",
     "begin": "2014-01-04T15:50:00.000Z",
     "end": "2015-02-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MyQQjvZczApt61M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "92150",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "200",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2863,22 +1507,12 @@
       {
         "site": "nicovideo",
         "id": "robot-girlsz",
-        "begin": "2014-02-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-02-01T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "218",
-        "begin": "2014-01-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-03T16:00:00.000Z"
       }
     ]
   },
@@ -2895,17 +1529,11 @@
     "officialSite": "http://www.litbus-anime.com/ex/index.html",
     "begin": "2014-01-29T16:00:00.000Z",
     "end": "2014-07-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mo1n5U2zI2HEQqo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2914,12 +1542,7 @@
       {
         "site": "bilibili",
         "id": "3571",
-        "begin": "2014-01-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-28T16:00:01.000Z"
       }
     ]
   },
@@ -2938,7 +1561,6 @@
     "officialSite": "http://www.mushishi-anime.com/hihamukage/",
     "begin": "2014-01-04T16:00:00.000Z",
     "end": "2014-01-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2947,32 +1569,17 @@
       {
         "site": "nicovideo",
         "id": "mushishi-tokubetsuhen01",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "70205008",
-        "begin": "2015-08-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-01T07:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgje811",
-        "begin": "2014-01-04T19:15:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-04T19:15:09.000Z"
       }
     ]
   },
@@ -2988,7 +1595,6 @@
     "officialSite": "http://zeushi-kun.jp/",
     "begin": "2014-01-06T16:00:00.000Z",
     "end": "2014-03-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2997,12 +1603,7 @@
       {
         "site": "nicovideo",
         "id": "zeushi-kun",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3018,7 +1619,6 @@
     "officialSite": "http://cmt-ch5-5.tv/pc/",
     "begin": "2014-01-28T16:00:00.000Z",
     "end": "2014-03-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3027,12 +1627,7 @@
       {
         "site": "nicovideo",
         "id": "5-5",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3048,7 +1643,6 @@
     "officialSite": "http://www.idolmaster-anime.jp/",
     "begin": "2014-01-25T16:00:00.000Z",
     "end": "2014-01-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3057,22 +1651,12 @@
       {
         "site": "pptv",
         "id": "QtC8OqIIeLYZlic8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2685",
-        "begin": "2014-01-24T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-24T16:00:00.000Z"
       }
     ]
   },
@@ -3088,7 +1672,6 @@
     "officialSite": "",
     "begin": "2014-01-04T16:00:00.000Z",
     "end": "2014-01-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3097,22 +1680,12 @@
       {
         "site": "pptv",
         "id": "eibzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4230",
-        "begin": "2014-01-03T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-03T16:00:01.000Z"
       }
     ]
   },
@@ -3128,7 +1701,6 @@
     "officialSite": "http://honeyworks.jp/release/01.html",
     "begin": "2014-01-29T16:00:00.000Z",
     "end": "2014-01-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3137,12 +1709,7 @@
       {
         "site": "bilibili",
         "id": "4355",
-        "begin": "2014-01-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-28T16:00:01.000Z"
       }
     ]
   },
@@ -3158,7 +1725,6 @@
     "officialSite": "http://kc.kodansha.co.jp/kimino/index.html",
     "begin": "2014-01-17T16:00:00.000Z",
     "end": "2014-03-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3167,12 +1733,7 @@
       {
         "site": "nicovideo",
         "id": "kiminoirumachi_OAD",
-        "begin": "2018-10-18T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-18T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2014/02.json
+++ b/data/items/2014/02.json
@@ -15,55 +15,25 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/happinesscharge_precure/",
     "begin": "2014-02-01T23:30:00.000Z",
     "end": "2015-01-25T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "m4xo5k60JGLFQ6s",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9v2tp",
-        "begin": "2016-12-05T09:36:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-05T09:36:28.000Z"
       },
       {
         "site": "letv",
         "id": "95301",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1711",
-        "begin": "2014-02-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "88348"
-      },
-      {
-        "site": "saraba1st",
-        "id": "995323"
       }
     ]
   },
@@ -75,87 +45,36 @@
     "officialSite": "http://ac.qq.com/event/zgjqdh.html",
     "begin": "2014-02-28T12:00:00.000Z",
     "end": "2016-05-17T12:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470011",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "358",
-        "begin": "2014-02-27T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "usAppg505CKFA88",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "k/kb68t18k7mu5a2b",
-        "begin": "2014-03-04T12:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-04T12:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgi7t01",
-        "begin": "2014-09-12T06:33:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-12T06:33:05.000Z"
       },
       {
         "site": "letv",
         "id": "96073",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/zgjqxs",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "100144",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -175,17 +94,11 @@
     "officialSite": "http://www.buddha-anime.com/",
     "begin": "2014-02-08T16:00:00.000Z",
     "end": "2014-02-08T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vpt181vBMWicSULg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -194,12 +107,7 @@
       {
         "site": "bilibili",
         "id": "5476",
-        "begin": "2014-02-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-02-07T16:00:01.000Z"
       }
     ]
   },
@@ -215,17 +123,11 @@
     "officialSite": "http://mahouka.jp/",
     "begin": "2014-02-22T16:00:00.000Z",
     "end": "2015-02-25T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HAPta9M5qedKyDA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -248,17 +150,11 @@
     "officialSite": "http://wondermomo.jp/",
     "begin": "2014-02-06T16:00:00.000Z",
     "end": "2014-03-06T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Vs2nJY3zY6EEguo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -267,12 +163,7 @@
       {
         "site": "nicovideo",
         "id": "wondermomo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -288,7 +179,6 @@
     "officialSite": "",
     "begin": "2014-02-05T16:00:00.000Z",
     "end": "2014-02-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -297,22 +187,12 @@
       {
         "site": "nicovideo",
         "id": "natsume-yuki",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9hxl1",
-        "begin": "2017-04-12T06:06:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T06:06:47.000Z"
       }
     ]
   },
@@ -328,7 +208,6 @@
     "officialSite": "http://xmaiden.jp",
     "begin": "2014-02-28T16:00:00.000Z",
     "end": "2014-06-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -337,12 +216,7 @@
       {
         "site": "nicovideo",
         "id": "xmaiden",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -358,7 +232,6 @@
     "officialSite": "",
     "begin": "2014-02-13T16:00:00.000Z",
     "end": "2014-07-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -367,22 +240,12 @@
       {
         "site": "pptv",
         "id": "aicvVU7shkc8ysBg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3419",
-        "begin": "2014-02-12T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-02-12T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2014/03.json
+++ b/data/items/2014/03.json
@@ -14,37 +14,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cf-vanguard-lm/",
     "begin": "2014-03-09T01:00:00.000Z",
     "end": "2014-10-19T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RibfRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "decc9d30adb711e38b3f",
-        "begin": "2014-03-09T12:16:29.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "idxgUQ7qnCA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-03-09T12:16:29.000Z"
       },
       {
         "site": "bangumi",
@@ -53,12 +32,7 @@
       {
         "site": "nicovideo",
         "id": "vanguard-lm",
-        "begin": "2014-03-18T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-18T10:30:00.000Z"
       }
     ]
   },
@@ -70,7 +44,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/velonica/",
     "begin": "2014-03-10T09:10:00.000Z",
     "end": "2014-03-21T09:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -86,7 +59,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/wasimo/",
     "begin": "2014-03-10T09:00:00.000Z",
     "end": "2014-03-21T09:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -109,7 +81,6 @@
     "officialSite": "http://www.keroro.com/flashanime/",
     "begin": "2014-03-22T10:00:00.000Z",
     "end": "2014-09-06T10:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -129,37 +100,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/sengokumusou/",
     "begin": "2014-03-21T16:00:00.000Z",
     "end": "2014-03-21T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "obmTEXnfT43wbtY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrnwb0ik",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/zfvxl2ox1962zjg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -168,12 +123,7 @@
       {
         "site": "bilibili",
         "id": "1494",
-        "begin": "2014-03-20T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-20T16:00:00.000Z"
       }
     ]
   },
@@ -189,27 +139,16 @@
     "officialSite": "http://sekai-ichi-movie.jp/",
     "begin": "2014-03-15T16:00:00.000Z",
     "end": "2014-03-15T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cOTQTrYcjMotqxM",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/uosqtsn16jsdu1b",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -229,17 +168,11 @@
     "officialSite": "",
     "begin": "2014-03-15T16:00:00.000Z",
     "end": "2014-03-15T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrkvlb40",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -259,17 +192,11 @@
     "officialSite": "http://doraeiga.com/2014/",
     "begin": "2014-03-08T16:00:00.000Z",
     "end": "2014-03-08T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10003862",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -278,32 +205,17 @@
       {
         "site": "qq",
         "id": "z/z8alyhrvkd3jp2y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6mm3p",
-        "begin": "2018-05-31T16:13:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T16:13:18.000Z"
       },
       {
         "site": "bilibili",
         "id": "3901",
-        "begin": "2014-03-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-07T16:00:01.000Z"
       }
     ]
   },
@@ -319,17 +231,11 @@
     "officialSite": "http://animemirai.jp/2014/",
     "begin": "2014-03-01T16:00:00.000Z",
     "end": "2014-03-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xlo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -349,17 +255,11 @@
     "officialSite": "http://animemirai.jp/2014/",
     "begin": "2014-03-01T16:00:00.000Z",
     "end": "2014-03-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xlo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -379,17 +279,11 @@
     "officialSite": "http://animemirai.jp/2014/",
     "begin": "2014-03-01T16:00:00.000Z",
     "end": "2014-03-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xlo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -398,12 +292,7 @@
       {
         "site": "bilibili",
         "id": "3673",
-        "begin": "2014-02-28T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-02-28T16:00:01.000Z"
       }
     ]
   },
@@ -419,17 +308,11 @@
     "officialSite": "http://animemirai.jp/2014/",
     "begin": "2014-03-01T16:00:00.000Z",
     "end": "2014-03-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xlo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -450,17 +333,11 @@
     "officialSite": "http://www.starchild.co.jp/special/mitsuwano/",
     "begin": "2014-03-12T16:00:00.000Z",
     "end": "2014-03-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DygEgupQwP5h30c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -480,17 +357,11 @@
     "officialSite": "",
     "begin": "2014-03-16T16:00:00.000Z",
     "end": "2014-03-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "n4Fr6VG3J2XIRq4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -510,17 +381,11 @@
     "officialSite": "http://mikakunin.jp/goods.html",
     "begin": "2014-03-19T16:00:00.000Z",
     "end": "2014-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mH5a2ECmFlS3NZ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -529,12 +394,7 @@
       {
         "site": "bilibili",
         "id": "3507",
-        "begin": "2014-03-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-18T16:00:01.000Z"
       }
     ]
   },
@@ -550,17 +410,11 @@
     "officialSite": "",
     "begin": "2014-03-28T16:00:00.000Z",
     "end": "2014-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mH5a2ECmFlS3NZ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -569,12 +423,7 @@
       {
         "site": "bilibili",
         "id": "3797",
-        "begin": "2014-03-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-27T16:00:01.000Z"
       }
     ]
   },
@@ -590,7 +439,6 @@
     "officialSite": "http://wild-adapter.com/",
     "begin": "2014-03-26T16:00:00.000Z",
     "end": "2015-09-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -599,12 +447,7 @@
       {
         "site": "nicovideo",
         "id": "wild-adapter",
-        "begin": "2017-04-07T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T06:00:00.000Z"
       }
     ]
   },
@@ -620,7 +463,6 @@
     "officialSite": "",
     "begin": "2014-03-08T16:00:00.000Z",
     "end": "2014-03-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -629,22 +471,12 @@
       {
         "site": "pptv",
         "id": "HgXvbdU7qiblMyjI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3832",
-        "begin": "2014-03-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-07T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2014/04.json
+++ b/data/items/2014/04.json
@@ -14,35 +14,20 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/majinbone/",
     "begin": "2014-04-01T09:30:00.000Z",
     "end": "2015-03-31T09:57:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb26ut",
-        "begin": "2015-09-02T05:50:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-02T05:50:24.000Z"
       },
       {
         "site": "bangumi",
         "id": "91135"
       },
       {
-        "site": "saraba1st",
-        "id": "996417"
-      },
-      {
         "site": "nicovideo",
         "id": "majinbone",
-        "begin": "2014-04-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-04T03:00:00.000Z"
       }
     ]
   },
@@ -62,47 +47,16 @@
     "officialSite": "http://www.disney.co.jp/diskwars/",
     "begin": "2014-04-02T09:30:00.000Z",
     "end": "2015-03-25T09:57:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc2yph",
-        "begin": "2014-04-02T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-02T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "daf240e092e911e38b3f",
-        "begin": "2014-04-02T15:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "8O6LrFIHhfc",
-        "begin": "2014-04-02T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1241",
-        "begin": "2014-04-02T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-02T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -125,7 +79,6 @@
     "officialSite": "http://www.nickjapan.com/character/tmnt/",
     "begin": "2014-04-03T22:30:00.000Z",
     "end": "2014-09-25T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -148,37 +101,16 @@
     "officialSite": "http://akuma-riddle.com/",
     "begin": "2014-04-03T17:13:00.000Z",
     "end": "2014-06-19T17:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/emzm",
-        "begin": "2014-04-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-04T19:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4205",
-        "begin": "2014-04-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "exist": null
-      },
-      {
-        "site": "acfun",
-        "id": "1132",
-        "begin": "2014-04-04T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-04T19:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -187,12 +119,7 @@
       {
         "site": "nicovideo",
         "id": "akuma-riddle",
-        "begin": "2014-04-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-07T03:00:00.000Z"
       }
     ]
   },
@@ -212,37 +139,16 @@
     "officialSite": "http://jojo-animation.com/sc/",
     "begin": "2014-04-04T15:30:00.000Z",
     "end": "2014-09-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "631X1T2jE1G0Mpo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4yxl",
-        "begin": "2015-08-05T06:49:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "954",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-05T06:49:50.000Z"
       },
       {
         "site": "bangumi",
@@ -262,95 +168,40 @@
     "officialSite": "http://www.tbs.co.jp/anime/kawaisou/",
     "begin": "2014-04-03T17:16:00.000Z",
     "end": "2015-06-25T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ijchnwdt3RtibicGQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10000889",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/9lmz99xuczth7ry",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "bea97028909811e3a705",
-        "begin": "2014-04-04T09:16:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ufo-aT912FA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-04T09:16:59.000Z"
       },
       {
         "site": "bilibili",
         "id": "113",
-        "begin": "2014-04-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1110",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-02T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "89216"
       },
       {
-        "site": "saraba1st",
-        "id": "1012475"
-      },
-      {
         "site": "nicovideo",
         "id": "kawaisou",
-        "begin": "2014-04-19T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-19T14:00:00.000Z"
       }
     ]
   },
@@ -366,65 +217,25 @@
     "officialSite": "http://www.mushishi-anime.com/",
     "begin": "2014-04-04T15:00:00.000Z",
     "end": "2014-06-13T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/csxz",
-        "begin": "2014-04-04T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "gzcFORsqmzM",
-        "begin": "2014-04-04T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-04T20:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "3b94454c75d511e3a705",
-        "begin": "2014-04-04T20:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "184",
-        "begin": "2014-04-04T20:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-04T20:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "92705"
       },
       {
-        "site": "saraba1st",
-        "id": "1010630"
-      },
-      {
         "site": "nicovideo",
         "id": "mushishi02",
-        "begin": "2014-04-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T15:00:00.000Z"
       }
     ]
   },
@@ -440,35 +251,15 @@
     "officialSite": "http://selector-wixoss.com/",
     "begin": "2014-04-03T17:43:00.000Z",
     "end": "2014-06-19T18:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi91g9",
-        "begin": "2014-04-03T18:49:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1114",
-        "begin": "2014-04-03T18:49:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-03T18:49:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "95095"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1009195"
       }
     ]
   },
@@ -488,55 +279,25 @@
     "officialSite": "http://www.tbs.co.jp/anime/blade/",
     "begin": "2014-04-03T16:46:00.000Z",
     "end": "2014-06-26T18:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "g/g9bv0pqsa2sr71o",
-        "begin": "2014-04-03T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-03T18:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "111",
-        "begin": "2014-04-03T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1138",
-        "begin": "2014-04-03T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-03T18:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "95825"
       },
       {
-        "site": "saraba1st",
-        "id": "1012318"
-      },
-      {
         "site": "nicovideo",
         "id": "blade-anime",
-        "begin": "2014-04-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-15T15:00:00.000Z"
       }
     ]
   },
@@ -555,75 +316,30 @@
     "officialSite": "http://www.fuyukitodoki.com/",
     "begin": "2014-04-03T17:25:00.000Z",
     "end": "2014-07-03T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4HlT0TmfD02wLpY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "K0hA1H3g-uM",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "cdde049cb01311e3b8b7",
-        "begin": "2014-04-04T10:37:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-04T10:37:18.000Z"
       },
       {
         "site": "qq",
         "id": "4/4239zjr5qfeimdv",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10000898",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1200",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "98217"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1012723"
       }
     ]
   },
@@ -639,55 +355,20 @@
     "officialSite": "http://www.seikokutv.com/",
     "begin": "2014-04-05T11:30:00.000Z",
     "end": "2014-06-21T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "4dd5df8e6b7d11e3b8b7",
-        "begin": "2014-04-05T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Nk7t-NLMlJw",
-        "begin": "2014-04-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1112",
-        "begin": "2014-04-05T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "79225"
       },
       {
-        "site": "saraba1st",
-        "id": "1012956"
-      },
-      {
         "site": "nicovideo",
         "id": "seikokutv",
-        "begin": "2014-04-17T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-17T16:00:00.000Z"
       }
     ]
   },
@@ -706,45 +387,20 @@
     "officialSite": "http://tenkaiknight.jp/",
     "begin": "2014-04-05T00:00:00.000Z",
     "end": "2015-03-28T00:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470050",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhbz3g5",
-        "begin": "2014-12-16T09:51:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-16T09:51:43.000Z"
       },
       {
         "site": "bangumi",
         "id": "80736"
       },
       {
-        "site": "saraba1st",
-        "id": "1000629"
-      },
-      {
         "site": "bilibili",
-        "id": "128",
-        "begin": "2014-04-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "117712",
+        "begin": "2014-04-05T16:00:01.000Z"
       }
     ]
   },
@@ -763,75 +419,30 @@
     "officialSite": "http://puchimas.com/",
     "begin": "2014-04-05T15:30:00.000Z",
     "end": "2014-06-30T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YvfhX8ctndsibvCQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "2yXUwWBdBe0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "0e6da6b4ae5411e3a705",
-        "begin": "2014-04-01T02:45:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-01T02:45:04.000Z"
       },
       {
         "site": "bilibili",
         "id": "1727",
-        "begin": "2014-03-31T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1106",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-31T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "84083"
       },
       {
-        "site": "saraba1st",
-        "id": "1011802"
-      },
-      {
         "site": "nicovideo",
         "id": "petit-idolmaster02",
-        "begin": "2014-04-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T15:00:00.000Z"
       }
     ]
   },
@@ -850,28 +461,7 @@
     "officialSite": "http://mahouka.jp/",
     "begin": "2014-04-05T15:30:00.000Z",
     "end": "2014-09-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "143",
-        "begin": "2014-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1058",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "84872"
@@ -879,22 +469,12 @@
       {
         "site": "nicovideo",
         "id": "mahouka",
-        "begin": "2014-04-12T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-12T14:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80009361",
-        "begin": "2017-11-15T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-15T08:00:00.000Z"
       }
     ]
   },
@@ -913,45 +493,20 @@
     "officialSite": "http://penguin-empire.com/",
     "begin": "2014-04-05T09:30:00.000Z",
     "end": "2014-06-21T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/jqjds",
-        "begin": "2014-04-05T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1139",
-        "begin": "2014-04-05T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T10:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "91640"
       },
       {
-        "site": "saraba1st",
-        "id": "984480"
-      },
-      {
         "site": "nicovideo",
         "id": "penguin-empire",
-        "begin": "2014-04-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T15:30:00.000Z"
       }
     ]
   },
@@ -970,35 +525,20 @@
     "officialSite": "http://www.fairytail-tv.com/",
     "begin": "2014-04-05T01:30:00.000Z",
     "end": "2016-03-26T02:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2011/yjdwb",
-        "begin": "2014-04-05T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T06:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "91946"
       },
       {
-        "site": "saraba1st",
-        "id": "985076"
-      },
-      {
         "site": "nicovideo",
         "id": "fairytail",
-        "begin": "2014-04-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T15:00:00.000Z"
       }
     ]
   },
@@ -1017,37 +557,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/prettyrhythm/",
     "begin": "2014-04-05T01:00:00.000Z",
     "end": "2014-06-14T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "183e29b8a8c111e3a705",
-        "begin": "2014-04-08T02:56:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "MGNsN2ZJhWc",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1262",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T02:56:19.000Z"
       },
       {
         "site": "bangumi",
@@ -1070,65 +584,25 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/jewelpet6/",
     "begin": "2014-04-04T22:00:00.000Z",
     "end": "2015-03-28T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "73Je3ESqGlia7OaE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "95FqH0R7tO8",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "61658ec6aa6311e3a705",
-        "begin": "2014-04-08T03:07:20.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T03:07:20.000Z"
       },
       {
         "site": "letv",
         "id": "10000910",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1263",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "96775"
-      },
-      {
-        "site": "saraba1st",
-        "id": "998439"
       }
     ]
   },
@@ -1144,37 +618,16 @@
     "officialSite": "http://www.ytv.co.jp/kindaichi_r/",
     "begin": "2014-04-05T08:30:00.000Z",
     "end": "2014-09-27T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb2729",
-        "begin": "2015-08-14T17:08:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:08:57.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/jtysnr",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1140",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1183,12 +636,7 @@
       {
         "site": "nicovideo",
         "id": "kindaichi_r",
-        "begin": "2014-06-05T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-06-05T06:00:00.000Z"
       }
     ]
   },
@@ -1204,7 +652,6 @@
     "officialSite": "http://pacworld.channel.or.jp/",
     "begin": "2014-04-05T09:30:00.000Z",
     "end": "2015-04-25T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1225,55 +672,25 @@
     "officialSite": "http://gaworare-anime.com/",
     "begin": "2014-04-06T15:30:00.000Z",
     "end": "2014-06-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi8tfh",
-        "begin": "2014-04-06T22:45:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1109",
-        "begin": "2014-04-06T22:45:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T22:45:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "63927"
       },
       {
-        "site": "saraba1st",
-        "id": "1013469"
-      },
-      {
         "site": "nicovideo",
         "id": "gaworare-anime",
-        "begin": "2014-04-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4201",
-        "begin": "2014-04-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T16:00:01.000Z"
       }
     ]
   },
@@ -1293,55 +710,25 @@
     "officialSite": "http://www.lovelive-anime.jp/otonokizaka/",
     "begin": "2014-04-06T13:30:00.000Z",
     "end": "2014-06-29T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi8vct",
-        "begin": "2014-04-08T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "229",
-        "begin": "2014-04-08T03:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T03:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3071",
-        "begin": "2014-04-08T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T03:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "75989"
       },
       {
-        "site": "saraba1st",
-        "id": "1013287"
-      },
-      {
         "site": "nicovideo",
         "id": "lovelive02",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1360,45 +747,20 @@
     "officialSite": "http://captain-earth.net/",
     "begin": "2014-04-05T16:58:00.000Z",
     "end": "2014-09-20T17:43:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi8upt",
-        "begin": "2014-04-05T18:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1131",
-        "begin": "2014-04-05T18:28:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T18:28:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "83079"
       },
       {
-        "site": "saraba1st",
-        "id": "1034914"
-      },
-      {
         "site": "nicovideo",
         "id": "captain-earth",
-        "begin": "2014-05-16T12:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-16T12:30:00.000Z"
       }
     ]
   },
@@ -1417,55 +779,15 @@
     "officialSite": "http://www.j-haikyu.com/anime/index.html",
     "begin": "2014-04-06T08:00:00.000Z",
     "end": "2014-09-21T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "0a90146c4c1811e38b3f",
-        "begin": "2014-04-06T09:30:00.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2727",
-        "begin": "2014-04-06T09:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1249",
-        "begin": "2014-04-06T09:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "pCqPwSDgy7o",
-        "begin": "2014-04-06T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-06T09:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "84171"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1012982"
       }
     ]
   },
@@ -1485,75 +807,30 @@
     "officialSite": "http://www.ntv.co.jp/corda/",
     "begin": "2014-04-05T17:25:00.000Z",
     "end": "2014-06-21T19:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi8ugt",
-        "begin": "2014-04-05T20:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T20:20:00.000Z"
       },
       {
         "site": "youku",
         "id": "cc004620962411de83b1",
-        "begin": "2014-04-05T20:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "wF6vbd-qwD8",
-        "begin": "2014-04-05T20:20:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-05T20:20:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "169",
-        "begin": "2014-04-05T20:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1226",
-        "begin": "2014-04-05T20:20:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T20:20:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "85915"
       },
       {
-        "site": "saraba1st",
-        "id": "981423"
-      },
-      {
         "site": "nicovideo",
         "id": "corda_bs",
-        "begin": "2014-04-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-11T03:00:00.000Z"
       }
     ]
   },
@@ -1572,95 +849,35 @@
     "officialSite": "http://www9.nhk.or.jp/anime/babysteps/",
     "begin": "2014-04-06T08:30:00.000Z",
     "end": "2014-09-21T08:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "50943",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgi8tcp",
-        "begin": "2014-04-06T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T19:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1651",
-        "begin": "2014-04-06T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1235",
-        "begin": "2014-04-06T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Aa0hDsuTPws",
-        "begin": "2014-04-06T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-06T19:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "3b9a1d22800d11e3b8b7",
-        "begin": "2014-04-06T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T19:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10000911",
-        "begin": "2014-04-06T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "75930",
-        "begin": "2014-04-06T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-06T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "87717"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1013448"
       }
     ]
   },
@@ -1679,65 +896,30 @@
     "officialSite": "http://oneweekfriends.com/",
     "begin": "2014-04-06T15:00:00.000Z",
     "end": "2014-06-22T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "k/kg70mw6f4nhwwj8",
-        "begin": "2014-04-06T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-06T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "173",
-        "begin": "2014-04-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1118",
-        "begin": "2014-04-06T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "88493"
       },
       {
-        "site": "saraba1st",
-        "id": "992261"
-      },
-      {
         "site": "nicovideo",
         "id": "oneweekfriends",
-        "begin": "2014-04-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh83mxh",
-        "begin": "2017-06-30T16:02:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:35.000Z"
       }
     ]
   },
@@ -1756,55 +938,20 @@
     "officialSite": "http://www.vap.co.jp/gokukoku/",
     "begin": "2014-04-06T13:00:00.000Z",
     "end": "2014-06-29T13:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/jhdblxet",
-        "begin": "2014-04-06T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4218",
-        "begin": "2014-04-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1136",
-        "begin": "2014-04-06T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "89485"
       },
       {
-        "site": "saraba1st",
-        "id": "1013243"
-      },
-      {
         "site": "nicovideo",
         "id": "gokukoku",
-        "begin": "2014-04-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T15:00:00.000Z"
       }
     ]
   },
@@ -1823,95 +970,40 @@
     "officialSite": "http://www.kamiaso-anime.com/",
     "begin": "2014-04-05T16:00:00.000Z",
     "end": "2014-06-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HgPta9M5qedKyDA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "6bsD1DRIhK0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "a8216ff2734e11e3b8b7",
-        "begin": "2014-04-06T16:31:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T16:31:15.000Z"
       },
       {
         "site": "qq",
         "id": "5/5ok7kcoif1avn8c",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10000909",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "170",
-        "begin": "2014-04-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1124",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "90222"
       },
       {
-        "site": "saraba1st",
-        "id": "986014"
-      },
-      {
         "site": "nicovideo",
         "id": "kamiaso-anime",
-        "begin": "2014-04-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-11T15:00:00.000Z"
       }
     ]
   },
@@ -1930,75 +1022,30 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yugioh-arcv/",
     "begin": "2014-04-06T08:30:00.000Z",
     "end": "2017-03-26T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10000913",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "afDcWsIomNY5tx8",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "40c8abaa99e511e3b8b7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "j6bLOojGi-I",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "游戏王ARC-V",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "92161"
       },
       {
-        "site": "saraba1st",
-        "id": "980228"
-      },
-      {
         "site": "nicovideo",
         "id": "yugioh-arcv",
-        "begin": "2014-08-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-01T15:00:00.000Z"
       }
     ]
   },
@@ -2017,27 +1064,11 @@
     "officialSite": "http://www.ntv.co.jp/soreseka/",
     "begin": "2014-04-05T17:55:00.000Z",
     "end": "2014-06-28T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi8ul5",
-        "begin": "2014-04-05T20:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1141",
-        "begin": "2014-04-05T20:50:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T20:50:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2046,22 +1077,12 @@
       {
         "site": "nicovideo",
         "id": "soreseka",
-        "begin": "2014-04-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-11T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4152",
-        "begin": "2014-04-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-04T16:00:01.000Z"
       }
     ]
   },
@@ -2080,45 +1101,20 @@
     "officialSite": "http://breakblade.jp/",
     "begin": "2014-04-06T14:00:00.000Z",
     "end": "2014-06-22T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi8ta9",
-        "begin": "2014-04-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3807",
-        "begin": "2014-04-06T15:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1104",
-        "begin": "2014-04-06T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-06T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "95618"
-      },
-      {
-        "site": "saraba1st",
-        "id": "994542"
       }
     ]
   },
@@ -2137,45 +1133,20 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/dragon_kai/",
     "begin": "2014-04-06T00:00:00.000Z",
     "end": "2015-06-28T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/lzg2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb1cr1",
-        "begin": "2015-08-14T17:02:30.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1243",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:02:30.000Z"
       },
       {
         "site": "bangumi",
         "id": "97045"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1013327"
       }
     ]
   },
@@ -2191,37 +1162,16 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/matsutaro/",
     "begin": "2014-04-05T21:30:00.000Z",
     "end": "2014-09-27T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb274p",
-        "begin": "2015-08-14T17:07:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1254",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-14T17:07:17.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/xplsstl",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2230,12 +1180,7 @@
       {
         "site": "nicovideo",
         "id": "matsutaro",
-        "begin": "2014-05-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-15T03:00:00.000Z"
       }
     ]
   },
@@ -2251,37 +1196,16 @@
     "officialSite": "http://www.meshi-lodoss.com/",
     "begin": "2014-04-06T13:27:00.000Z",
     "end": "2014-06-29T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kYtl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "38a5e746bc9811e38b3f",
-        "begin": "2014-04-18T02:38:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "XtBb0twFu-Q",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-18T02:38:42.000Z"
       },
       {
         "site": "bangumi",
@@ -2290,22 +1214,12 @@
       {
         "site": "nicovideo",
         "id": "meshi_lodoss",
-        "begin": "2016-10-04T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "164",
-        "begin": "2014-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -2324,15 +1238,10 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/herobank/",
     "begin": "2014-04-07T09:30:00.000Z",
     "end": "2015-03-30T09:57:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "92936"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1013621"
       }
     ]
   },
@@ -2351,47 +1260,21 @@
     "officialSite": "http://www.oreca-anime.com/",
     "begin": "2014-04-07T09:00:00.000Z",
     "end": "2015-03-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2302",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrgi8f8t",
-        "begin": "2014-04-10T01:47:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T01:47:42.000Z"
       },
       {
         "site": "letv",
         "id": "10002883",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "KzUfnQVr2xl8ibmI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2400,12 +1283,7 @@
       {
         "site": "nicovideo",
         "id": "oreca",
-        "begin": "2014-04-21T10:15:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-21T10:15:00.000Z"
       }
     ]
   },
@@ -2425,65 +1303,30 @@
     "officialSite": "http://www.black-bullet.net/",
     "begin": "2014-04-08T13:30:00.000Z",
     "end": "2014-07-01T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10027930",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/hszd",
-        "begin": "2014-04-08T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1105",
-        "begin": "2014-04-08T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "84873"
       },
       {
-        "site": "saraba1st",
-        "id": "1013596"
-      },
-      {
         "site": "nicovideo",
         "id": "black-bullet",
-        "begin": "2014-04-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4181",
-        "begin": "2014-04-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-07T16:00:01.000Z"
       }
     ]
   },
@@ -2502,55 +1345,25 @@
     "officialSite": "http://mahoushoujyotaisen.com/",
     "begin": "2014-04-08T12:55:00.000Z",
     "end": "2014-09-30T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "50gzsRlic7y2QDnY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "z/zpvbrqfxv585n4l",
-        "begin": "2014-04-08T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-08T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "183",
-        "begin": "2014-04-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1282",
-        "begin": "2014-04-08T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "89211"
-      },
-      {
-        "site": "saraba1st",
-        "id": "976592"
       }
     ]
   },
@@ -2570,55 +1383,25 @@
     "officialSite": "http://mangakasan.tv/",
     "begin": "2014-04-07T16:05:00.000Z",
     "end": "2014-06-23T16:18:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/mhjyzsm",
-        "begin": "2014-04-07T19:18:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1257",
-        "begin": "2014-04-07T19:18:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-07T19:18:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "89751"
       },
       {
-        "site": "saraba1st",
-        "id": "1013474"
-      },
-      {
         "site": "nicovideo",
         "id": "mangakasan",
-        "begin": "2014-04-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "177",
-        "begin": "2014-04-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-07T16:00:01.000Z"
       }
     ]
   },
@@ -2638,75 +1421,35 @@
     "officialSite": "http://ngnl.jp/",
     "begin": "2014-04-09T12:30:00.000Z",
     "end": "2014-06-25T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "90MtqxN56SeKCHA",
-        "begin": "2014-04-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-09T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "604f2b5a70f211e38b3f",
-        "begin": "2014-04-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1121",
-        "begin": "2014-04-09T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "79227"
       },
       {
-        "site": "saraba1st",
-        "id": "1014091"
-      },
-      {
         "site": "nicovideo",
         "id": "ngnl-anime",
-        "begin": "2014-04-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-11T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "184",
-        "begin": "2014-04-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh8imfx",
-        "begin": "2018-11-28T07:50:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-28T07:50:43.000Z"
       }
     ]
   },
@@ -2726,45 +1469,20 @@
     "officialSite": "http://www.souleaternot.tv/",
     "begin": "2014-04-08T17:00:00.000Z",
     "end": "2014-07-01T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi8v2x",
-        "begin": "2014-04-08T17:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1271",
-        "begin": "2014-04-08T17:10:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-08T17:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "88041"
       },
       {
-        "site": "saraba1st",
-        "id": "972711"
-      },
-      {
         "site": "nicovideo",
         "id": "souleaternot",
-        "begin": "2014-04-17T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-17T15:30:00.000Z"
       }
     ]
   },
@@ -2780,45 +1498,20 @@
     "officialSite": "http://chaika-anime.jp/",
     "begin": "2014-04-09T16:05:00.000Z",
     "end": "2014-06-25T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "f/f840je4tjtjnwio",
-        "begin": "2014-04-09T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T17:35:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "187",
-        "begin": "2014-04-09T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1134",
-        "begin": "2014-04-09T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "85303"
-      },
-      {
-        "site": "saraba1st",
-        "id": "844509"
       }
     ]
   },
@@ -2837,75 +1530,30 @@
     "officialSite": "http://atelier-ps3.jp/escha-logy/anime/",
     "begin": "2014-04-10T13:00:00.000Z",
     "end": "2014-06-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TdWicPaULe7kcmgI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "97785dac9c5011e38b3f",
-        "begin": "2014-04-11T06:34:36.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "AfhZfbr4YAs",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-11T06:34:36.000Z"
       },
       {
         "site": "bilibili",
         "id": "190",
-        "begin": "2014-04-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1135",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "87593"
       },
       {
-        "site": "saraba1st",
-        "id": "970289"
-      },
-      {
         "site": "nicovideo",
         "id": "escha-logy",
-        "begin": "2014-04-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-14T03:00:00.000Z"
       }
     ]
   },
@@ -2924,55 +1572,25 @@
     "officialSite": "http://www.gochiusa.com/",
     "begin": "2014-04-10T13:30:00.000Z",
     "end": "2014-06-26T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/o2fm6biw90g8tbv",
-        "begin": "2014-04-10T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T17:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "191",
-        "begin": "2014-04-10T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1107",
-        "begin": "2014-04-10T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "88287"
       },
       {
-        "site": "saraba1st",
-        "id": "1014071"
-      },
-      {
         "site": "nicovideo",
         "id": "gochiusa",
-        "begin": "2014-04-16T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-16T03:00:00.000Z"
       }
     ]
   },
@@ -2988,45 +1606,20 @@
     "officialSite": "http://daishogun-anime.jp/",
     "begin": "2014-04-09T16:35:00.000Z",
     "end": "2014-06-25T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "96208",
-        "begin": "2014-04-09T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T18:05:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "189",
-        "begin": "2014-04-09T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1133",
-        "begin": "2014-04-09T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10252",
+        "begin": "2014-04-09T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "91626"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1010421"
       }
     ]
   },
@@ -3042,95 +1635,40 @@
     "officialSite": "http://www.dreamcreation.co.jp/inuneko/index.html",
     "begin": "2014-04-10T16:00:00.000Z",
     "end": "2014-06-26T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uKCMCnLYSIbpZ88",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10000884",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jscsr92k16z03ta",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "yxL8H61FFdc",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "88a13c1aa51311e3a705",
-        "begin": "2014-04-11T00:46:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-11T00:46:44.000Z"
       },
       {
         "site": "bilibili",
         "id": "110",
-        "begin": "2014-04-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1108",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "93509"
       },
       {
-        "site": "saraba1st",
-        "id": "1012534"
-      },
-      {
         "site": "nicovideo",
         "id": "anime_inuneko",
-        "begin": "2014-04-15T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-15T12:00:00.000Z"
       }
     ]
   },
@@ -3149,45 +1687,20 @@
     "officialSite": "http://www.pingpong-anime.tv/",
     "begin": "2014-04-10T16:00:00.000Z",
     "end": "2014-06-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1103",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "96105",
-        "begin": "2014-04-10T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T16:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "192",
-        "begin": "2014-04-10T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "id": "28221545",
+        "begin": "2014-04-10T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "93739"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1010574"
       }
     ]
   },
@@ -3206,55 +1719,25 @@
     "officialSite": "http://www.knightsofsidonia.com/",
     "begin": "2014-04-10T16:33:00.000Z",
     "end": "2014-06-26T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgi8f5p",
-        "begin": "2014-04-12T04:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1111",
-        "begin": "2014-04-12T04:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-12T04:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "77476"
       },
       {
-        "site": "saraba1st",
-        "id": "1014335"
-      },
-      {
         "site": "nicovideo",
         "id": "knightsofsidonia",
-        "begin": "2014-04-14T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-14T13:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "70301578",
-        "begin": "2014-07-04T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-04T07:00:00.000Z"
       }
     ]
   },
@@ -3273,45 +1756,20 @@
     "officialSite": "http://www.nanana.tv/",
     "begin": "2014-04-10T16:30:00.000Z",
     "end": "2014-06-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "96099",
-        "begin": "2014-04-10T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-10T17:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "193",
-        "begin": "2014-04-10T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1307",
-        "begin": "2014-04-10T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "90388"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1014235"
       }
     ]
   },
@@ -3330,45 +1788,20 @@
     "officialSite": "http://date-a-live-anime.com/",
     "begin": "2014-04-11T16:35:00.000Z",
     "end": "2014-06-13T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "96100",
-        "begin": "2014-04-11T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1122",
-        "begin": "2014-04-11T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-11T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "76325"
       },
       {
-        "site": "saraba1st",
-        "id": "1014549"
-      },
-      {
         "site": "nicovideo",
         "id": "date-a-live2",
-        "begin": "2019-01-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-06T03:00:00.000Z"
       }
     ]
   },
@@ -3387,75 +1820,30 @@
     "officialSite": "http://www.mekakucityactors.com/",
     "begin": "2014-04-12T15:00:00.000Z",
     "end": "2014-06-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "96098",
-        "begin": "2014-04-12T15:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-12T15:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "d4d711de711c11e3a705",
-        "begin": "2014-04-12T15:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "DNhSIN_Z3UY",
-        "begin": "2014-04-12T15:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-12T15:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "197",
-        "begin": "2014-04-12T15:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1342",
-        "begin": "2014-04-12T15:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-12T15:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "81186"
       },
       {
-        "site": "saraba1st",
-        "id": "995292"
-      },
-      {
         "site": "nicovideo",
         "id": "ch2587663",
-        "begin": "2014-01-25T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-25T15:00:00.000Z"
       }
     ]
   },
@@ -3472,85 +1860,40 @@
     "officialSite": "http://m3-project.com/",
     "begin": "2014-04-21T16:35:00.000Z",
     "end": "2014-09-29T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "V8qmJIzyYqADgek",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10003394",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgi95ql",
-        "begin": "2014-04-21T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-21T17:05:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/m3hg",
-        "begin": "2014-04-21T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-21T17:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "53e64c72ae7811e3a705",
-        "begin": "2014-04-21T17:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "bnjoDHGXv1c",
-        "begin": "2014-04-21T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-21T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "99740"
       },
       {
-        "site": "saraba1st",
-        "id": "1006444"
-      },
-      {
         "site": "nicovideo",
         "id": "m3-project",
-        "begin": "2014-04-22T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-22T03:00:00.000Z"
       }
     ]
   },
@@ -3569,47 +1912,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tamagotchi/",
     "begin": "2014-04-03T09:30:00.000Z",
     "end": "2015-03-26T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10001281",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "bba10b50c8f811e3a705",
-        "begin": "2014-04-21T03:32:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "7DQ9HNKpTxs",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-04-21T03:32:05.000Z"
       },
       {
         "site": "pptv",
         "id": "t6mDAWnPP33gXsY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3625,7 +1942,6 @@
     "officialSite": "http://www.gigantshooter.com/",
     "begin": "2014-04-01T09:45:00.000Z",
     "end": "2015-02-10T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3634,12 +1950,7 @@
       {
         "site": "nicovideo",
         "id": "gigantshooter",
-        "begin": "2014-04-09T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-09T10:00:00.000Z"
       }
     ]
   },
@@ -3655,7 +1966,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/kutsudaru/",
     "begin": "2014-04-02T09:45:00.000Z",
     "end": "2015-09-16T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3678,7 +1988,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/duelmastersvs/",
     "begin": "2014-04-04T23:30:00.000Z",
     "end": "2015-03-28T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3687,12 +1996,7 @@
       {
         "site": "nicovideo",
         "id": "duelmastersvs",
-        "begin": "2014-09-27T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-27T00:00:00.000Z"
       }
     ]
   },
@@ -3708,7 +2012,6 @@
     "officialSite": "http://ani.tv/carinoconi/",
     "begin": "2014-04-01T16:55:00.000Z",
     "end": "2014-09-30T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3724,7 +2027,6 @@
     "officialSite": "http://xn--u9j429qiq1a.jp/",
     "begin": "2014-04-11T09:20:00.000Z",
     "end": "2015-03-06T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3733,12 +2035,7 @@
       {
         "site": "nicovideo",
         "id": "takanotsume_ex",
-        "begin": "2014-04-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-13T15:00:00.000Z"
       }
     ]
   },
@@ -3754,7 +2051,6 @@
     "officialSite": "http://anime-dayan.com/",
     "begin": "2014-04-25T22:00:00.000Z",
     "end": "2015-04-24T22:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3763,12 +2059,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgyi8b9",
-        "begin": "2018-04-30T16:00:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-30T16:00:25.000Z"
       }
     ]
   },
@@ -3784,7 +2075,6 @@
     "officialSite": "http://kadendanshi.com/",
     "begin": "2014-04-29T08:59:00.000Z",
     "end": "2014-04-29T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3804,17 +2094,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_xy_me/",
     "begin": "2014-04-03T16:00:00.000Z",
     "end": "2015-10-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "53pW1DyiaElCzMZk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3830,7 +2114,6 @@
     "officialSite": "http://www.gtv.co.jp/program/animation/wfn/",
     "begin": "2014-04-24T16:00:00.000Z",
     "end": "2014-07-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3850,47 +2133,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/oreca_dracolle/dracolle/",
     "begin": "2014-04-07T16:00:00.000Z",
     "end": "2015-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "KjQgngZs3Bp9ib2M",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgi8fd5",
-        "begin": "2014-04-10T01:47:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-10T01:47:44.000Z"
       },
       {
         "site": "letv",
         "id": "10002886",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464596",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3899,12 +2156,7 @@
       {
         "site": "nicovideo",
         "id": "dracolle",
-        "begin": "2014-04-21T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-21T10:30:00.000Z"
       }
     ]
   },
@@ -3920,27 +2172,16 @@
     "officialSite": "http://www.shinchan-movie.com/",
     "begin": "2014-04-19T16:00:00.000Z",
     "end": "2014-04-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3aGLCXHXR4XoZs4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "p/plnzrinrw3t18n0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3960,17 +2201,11 @@
     "officialSite": "http://kadokawa-anime.jp/soraoto/",
     "begin": "2014-04-26T16:00:00.000Z",
     "end": "2014-04-26T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "f/f6i0p8c0vb9qohn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3991,27 +2226,16 @@
     "officialSite": "http://www.kenichianime.com/",
     "begin": "2014-04-08T16:00:00.000Z",
     "end": "2014-06-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HwHradE3pibVIxia4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbysup",
-        "begin": "2014-11-17T09:24:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-17T09:24:57.000Z"
       },
       {
         "site": "bangumi",
@@ -4031,17 +2255,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2014-04-19T16:00:00.000Z",
     "end": "2014-04-19T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -4050,22 +2268,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4081,17 +2289,11 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2014-04-01T08:35:00.000Z",
     "end": "2015-03-20T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XfXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4107,7 +2309,6 @@
     "officialSite": "",
     "begin": "2014-04-02T16:00:00.000Z",
     "end": "2014-09-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4116,12 +2317,7 @@
       {
         "site": "nicovideo",
         "id": "momonsandwitch",
-        "begin": "2014-03-08T05:01:15.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-08T05:01:15.000Z"
       }
     ]
   },
@@ -4137,7 +2333,6 @@
     "officialSite": "https://kosys.opap.jp/",
     "begin": "2014-04-09T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4146,12 +2341,7 @@
       {
         "site": "nicovideo",
         "id": "kosys",
-        "begin": "2013-11-24T08:28:42.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-11-24T08:28:42.000Z"
       }
     ]
   },
@@ -4167,7 +2357,6 @@
     "officialSite": "",
     "begin": "2014-04-03T16:00:00.000Z",
     "end": "2014-12-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4176,12 +2365,7 @@
       {
         "site": "pptv",
         "id": "SNKibPKQKergbmQE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4197,7 +2381,6 @@
     "officialSite": "http://tamakolovestory.com",
     "begin": "2014-04-26T16:00:00.000Z",
     "end": "2014-04-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4206,22 +2389,12 @@
       {
         "site": "pptv",
         "id": "7HZia4EiauHlyicPaU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4155",
-        "begin": "2014-04-25T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-04-25T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2014/05.json
+++ b/data/items/2014/05.json
@@ -12,17 +12,11 @@
     "officialSite": "http://www.project-magi.com/sinbad/",
     "begin": "2014-05-16T16:00:00.000Z",
     "end": "2015-07-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb2zx5",
-        "begin": "2015-04-21T09:43:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-21T09:43:55.000Z"
       },
       {
         "site": "bangumi",
@@ -42,17 +36,11 @@
     "officialSite": "",
     "begin": "2014-05-16T16:00:00.000Z",
     "end": "2014-06-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xFdBvyeNicTueHIQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -61,12 +49,7 @@
       {
         "site": "bilibili",
         "id": "212",
-        "begin": "2014-05-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-15T16:00:00.000Z"
       }
     ]
   },
@@ -82,17 +65,11 @@
     "officialSite": "http://www.ntv.co.jp/gj/",
     "begin": "2014-05-05T16:00:00.000Z",
     "end": "2014-05-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ta2HBW3TQ4HkYso",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,12 +78,7 @@
       {
         "site": "bilibili",
         "id": "3075",
-        "begin": "2014-05-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-05-04T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2014/06.json
+++ b/data/items/2014/06.json
@@ -7,87 +7,41 @@
     "officialSite": "http://ac.qq.com/event/sxdh/index.shtml",
     "begin": "2014-06-27T12:00:00.000Z",
     "end": "2016-01-20T12:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470010",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "1700",
-        "begin": "2014-07-24T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-24T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "tQfQT7cdjcsurDA",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bo64ctd5rtyc2fi",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhlwfaw",
-        "begin": "2014-09-12T06:20:12.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-09-12T06:20:12.000Z"
       },
       {
         "site": "letv",
         "id": "10002875",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/wpys",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "100147",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -107,7 +61,6 @@
     "officialSite": "http://www.toei-anim.co.jp/movie/seiya_cg/",
     "begin": "2014-06-21T16:00:00.000Z",
     "end": "2014-06-21T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -116,12 +69,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4um9",
-        "begin": "2016-02-16T07:22:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-16T07:22:34.000Z"
       }
     ]
   },
@@ -137,7 +85,6 @@
     "officialSite": "http://www.daikaijyu.com/rush/",
     "begin": "2014-06-24T16:00:00.000Z",
     "end": "2014-10-14T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -157,17 +104,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/inazumago/best_eleven/",
     "begin": "2014-06-13T16:00:00.000Z",
     "end": "2014-06-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "50AsqhJ46CaJB28",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -187,17 +128,11 @@
     "officialSite": "",
     "begin": "2014-06-17T16:00:00.000Z",
     "end": "2014-06-17T16:04:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wlo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -213,7 +148,6 @@
     "officialSite": "http://puyukai.com/agukaru/",
     "begin": "2014-06-06T16:00:00.000Z",
     "end": "2015-03-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -222,12 +156,7 @@
       {
         "site": "nicovideo",
         "id": "agukaru",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -246,7 +175,6 @@
     "officialSite": "http://www.p3m.jp/",
     "begin": "2014-06-07T16:00:00.000Z",
     "end": "2014-06-07T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -255,22 +183,12 @@
       {
         "site": "nicovideo",
         "id": "p3m",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80040329",
-        "begin": "2015-08-07T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T07:00:00.000Z"
       }
     ]
   },
@@ -289,7 +207,6 @@
     "officialSite": "http://kokaku-a.jp/arise/",
     "begin": "2014-06-17T16:00:00.000Z",
     "end": "2014-06-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -298,12 +215,7 @@
       {
         "site": "netflix",
         "id": "80021983",
-        "begin": "2017-01-31T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-31T08:00:00.000Z"
       }
     ]
   }

--- a/data/items/2014/07.json
+++ b/data/items/2014/07.json
@@ -11,57 +11,21 @@
     "officialSite": "http://www.dreamcreation.co.jp/aimaimi/",
     "begin": "2014-07-08T12:25:00.000Z",
     "end": "2014-09-23T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "x1dBvyeNicTueHIQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "SQfmIXvvt6Y",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "4f083bbebec411e3b8b7",
-        "begin": "2014-07-10T03:19:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-10T03:19:22.000Z"
       },
       {
         "site": "bilibili",
         "id": "8",
-        "begin": "2014-07-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2687",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-07T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -70,22 +34,12 @@
       {
         "site": "nicovideo",
         "id": "ch2591055",
-        "begin": "2014-07-09T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-09T12:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10003092",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -101,47 +55,16 @@
     "officialSite": "http://iwatobi-sc.com/",
     "begin": "2014-07-02T15:00:00.000Z",
     "end": "2014-09-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "eacf9a46b25e11e38b3f",
-        "begin": "2014-07-02T15:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-02T15:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "5201",
-        "begin": "2014-07-02T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2646",
-        "begin": "2014-07-02T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "m91s0qR6DIo",
-        "begin": "2014-07-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "124972",
+        "begin": "2014-07-02T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -150,12 +73,7 @@
       {
         "site": "nicovideo",
         "id": "iwatobi-sc02",
-        "begin": "2014-07-06T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T14:00:00.000Z"
       }
     ]
   },
@@ -172,105 +90,40 @@
     "officialSite": "http://bakumatsu.maql.co.jp/anime/index.html",
     "begin": "2014-07-02T14:30:00.000Z",
     "end": "2014-09-17T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgiff91",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-02T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "9",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2647",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-02T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10002832",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-02T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "a737b9a0df2a11e38b3f",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-02T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "bibicJR68VhcMmpAw",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "MZe5EBmyyJo",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "84931",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-02T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "99116"
       },
       {
-        "site": "saraba1st",
-        "id": "1004685"
-      },
-      {
         "site": "nicovideo",
         "id": "bakumatsu-maql",
-        "begin": "2014-07-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T15:30:00.000Z"
       }
     ]
   },
@@ -290,65 +143,30 @@
     "officialSite": "http://www.maql.co.jp/special/tokyoghoul/",
     "begin": "2014-07-03T15:00:00.000Z",
     "end": "2014-09-18T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif5id",
-        "begin": "2014-07-03T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2651",
-        "begin": "2014-07-03T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-03T16:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/djsz",
-        "begin": "2014-07-03T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-07-03T16:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "d/dxxmvywtpp8nz70",
-        "begin": "2014-07-03T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-07-03T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "93714"
       },
       {
-        "site": "saraba1st",
-        "id": "1038220"
-      },
-      {
         "site": "nicovideo",
         "id": "tokyoghoul",
-        "begin": "2014-07-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-09T15:30:00.000Z"
       }
     ]
   },
@@ -368,45 +186,20 @@
     "officialSite": "http://glasslip.jp/index.html",
     "begin": "2014-07-03T13:30:00.000Z",
     "end": "2014-09-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif3ql",
-        "begin": "2014-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2650",
-        "begin": "2014-07-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-03T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "99505"
       },
       {
-        "site": "saraba1st",
-        "id": "1038135"
-      },
-      {
         "site": "nicovideo",
         "id": "glasslip",
-        "begin": "2014-07-05T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T13:30:00.000Z"
       }
     ]
   },
@@ -426,35 +219,15 @@
     "officialSite": "http://argevollen.com/index.html",
     "begin": "2014-07-03T14:00:00.000Z",
     "end": "2014-12-18T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif3l1",
-        "begin": "2014-07-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2649",
-        "begin": "2014-07-03T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-03T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100498"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1030570"
       }
     ]
   },
@@ -470,65 +243,25 @@
     "officialSite": "http://www.tbs.co.jp/anime/railwars/",
     "begin": "2014-07-03T16:56:00.000Z",
     "end": "2014-09-18T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/railwars",
-        "begin": "2014-07-04T17:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-04T17:15:00.000Z"
       },
       {
         "site": "youku",
         "id": "8ada428acdbb11e3a705",
-        "begin": "2014-07-04T17:15:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "RI7751K7Boo",
-        "begin": "2014-07-04T17:15:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2652",
-        "begin": "2014-07-04T17:15:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-04T17:15:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "91420"
       },
       {
-        "site": "saraba1st",
-        "id": "1018612"
-      },
-      {
         "site": "nicovideo",
         "id": "railwars",
-        "begin": "2014-07-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-15T03:00:00.000Z"
       }
     ]
   },
@@ -547,55 +280,25 @@
     "officialSite": "http://www.tbs.co.jp/anime/locodol/",
     "begin": "2014-07-03T17:26:00.000Z",
     "end": "2015-04-04T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif399",
-        "begin": "2014-07-03T20:56:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-03T20:56:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4124",
-        "begin": "2014-07-03T20:56:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2653",
-        "begin": "2014-07-03T20:56:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-03T20:56:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "94236"
       },
       {
-        "site": "saraba1st",
-        "id": "1038660"
-      },
-      {
         "site": "nicovideo",
         "id": "locodol",
-        "begin": "2014-07-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-15T03:00:00.000Z"
       }
     ]
   },
@@ -614,45 +317,25 @@
     "officialSite": "http://sailormoon-official.com/animation/",
     "begin": "2014-07-05T10:00:00.000Z",
     "end": "2015-07-18T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb12nd",
-        "begin": "2015-08-17T03:04:36.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-17T03:04:36.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/msnzsc",
-        "begin": "2014-07-05T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T12:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "43523"
       },
       {
-        "site": "saraba1st",
-        "id": "1030124"
-      },
-      {
         "site": "nicovideo",
         "id": "sailormoon-Crystal",
-        "begin": "2014-07-05T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T10:00:00.000Z"
       }
     ]
   },
@@ -671,17 +354,11 @@
     "officialSite": "http://www.swordart-online.net/phantom/",
     "begin": "2014-07-05T14:30:00.000Z",
     "end": "2014-12-20T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10001115",
-        "begin": "2014-07-05T14:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-05T14:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -690,22 +367,12 @@
       {
         "site": "nicovideo",
         "id": "swordart02",
-        "begin": "2014-07-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80082107",
-        "begin": "2017-10-09T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-09T07:00:00.000Z"
       }
     ]
   },
@@ -725,55 +392,25 @@
     "officialSite": "http://www.aldnoahzero.com/",
     "begin": "2014-07-05T15:00:00.000Z",
     "end": "2014-09-20T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2661",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrgif6w9",
-        "begin": "2014-07-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-10T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "96918"
       },
       {
-        "site": "saraba1st",
-        "id": "999173"
-      },
-      {
         "site": "nicovideo",
         "id": "aldnoahzero",
-        "begin": "2014-07-05T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T15:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80040104",
-        "begin": "2015-10-09T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T07:00:00.000Z"
       }
     ]
   },
@@ -793,75 +430,35 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pripara/index2.html",
     "begin": "2014-07-05T01:00:00.000Z",
     "end": "2015-03-28T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhaj3bp",
-        "begin": "2016-04-05T09:50:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T09:50:12.000Z"
       },
       {
         "site": "qq",
         "id": "1/1c649pqidecllze",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10003003",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "94b79a0af68811e3b8b7",
-        "begin": "2014-07-08T02:27:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "CDmJERssqrQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-08T02:27:34.000Z"
       },
       {
         "site": "bangumi",
         "id": "99748"
       },
       {
-        "site": "saraba1st",
-        "id": "1006534"
-      },
-      {
         "site": "nicovideo",
         "id": "pripara",
-        "begin": "2014-07-18T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-18T10:30:00.000Z"
       }
     ]
   },
@@ -880,27 +477,11 @@
     "officialSite": "http://www.starchild.co.jp/special/shonen-hollywood-anime/",
     "begin": "2014-07-05T11:30:00.000Z",
     "end": "2014-09-27T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "4d1a493cdf2611e38b3f",
-        "begin": "2014-07-10T17:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "DTTu59W1Lyc",
-        "begin": "2014-07-10T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-10T17:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -909,12 +490,7 @@
       {
         "site": "nicovideo",
         "id": "shonen-hollywood",
-        "begin": "2014-07-13T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-13T13:30:00.000Z"
       }
     ]
   },
@@ -933,55 +509,20 @@
     "officialSite": "http://sabagebu.com/",
     "begin": "2014-07-06T13:30:00.000Z",
     "end": "2014-09-21T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "4074",
-        "begin": "2014-07-06T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2665",
-        "begin": "2014-07-06T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "sohu",
         "id": "s2014/scyxs",
-        "begin": "2014-07-06T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "82193"
       },
       {
-        "site": "saraba1st",
-        "id": "1027079"
-      },
-      {
         "site": "nicovideo",
         "id": "sabagebu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -997,55 +538,25 @@
     "officialSite": "http://www.barakamon.jp/",
     "begin": "2014-07-05T17:35:00.000Z",
     "end": "2014-09-27T18:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif715",
-        "begin": "2014-07-05T20:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2664",
-        "begin": "2014-07-05T20:50:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T20:50:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "83868"
       },
       {
-        "site": "saraba1st",
-        "id": "1021790"
-      },
-      {
         "site": "nicovideo",
         "id": "barakamon",
-        "begin": "2014-07-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4070",
-        "begin": "2014-07-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-04T16:00:01.000Z"
       }
     ]
   },
@@ -1061,55 +572,20 @@
     "officialSite": "http://www.vap.co.jp/jinsei/",
     "begin": "2014-07-06T13:00:00.000Z",
     "end": "2014-09-28T13:27:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2675",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "y1M9uyOJibTeaGIA",
-        "begin": "2014-07-06T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "48",
-        "begin": "2014-07-06T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-07-06T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "92430"
       },
       {
-        "site": "saraba1st",
-        "id": "1025185"
-      },
-      {
         "site": "nicovideo",
         "id": "jinsei_anime",
-        "begin": "2014-07-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-08T03:00:00.000Z"
       }
     ]
   },
@@ -1129,65 +605,25 @@
     "officialSite": "http://akame.tv/index.html",
     "begin": "2014-07-06T15:00:00.000Z",
     "end": "2014-12-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif6md",
-        "begin": "2014-07-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T16:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/zchzt",
-        "begin": "2014-07-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "52",
-        "begin": "2014-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2667",
-        "begin": "2014-07-06T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "94244"
       },
       {
-        "site": "saraba1st",
-        "id": "1025289"
-      },
-      {
         "site": "nicovideo",
         "id": "akame-tv",
-        "begin": "2014-07-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-08T15:30:00.000Z"
       }
     ]
   },
@@ -1203,37 +639,16 @@
     "officialSite": "http://www.akitashoten.co.jp/special/urayasu",
     "begin": "2014-07-06T13:27:00.000Z",
     "end": "2014-12-28T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "92",
-        "begin": "2014-07-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "hTkDFExYxJc",
-        "begin": "2014-07-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-06T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "d521ead8018b11e4a705",
-        "begin": "2014-07-06T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1242,12 +657,7 @@
       {
         "site": "nicovideo",
         "id": "urayas",
-        "begin": "2014-07-06T13:27:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T13:27:00.000Z"
       }
     ]
   },
@@ -1263,95 +673,40 @@
     "officialSite": "http://www.ntv.co.jp/basara_je/",
     "begin": "2014-07-05T17:05:00.000Z",
     "end": "2014-09-27T18:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "f48c67d0d8ec11e3a705",
-        "begin": "2014-07-05T19:50:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T19:50:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgif78l",
-        "begin": "2014-07-05T19:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T19:50:00.000Z"
       },
       {
         "site": "pptv",
         "id": "g59591icFNXPWVLw",
-        "begin": "2014-07-05T19:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T19:50:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1592",
-        "begin": "2014-07-05T19:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2663",
-        "begin": "2014-07-05T19:50:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-05T19:50:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/basara3",
-        "begin": "2014-07-05T19:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "YiWcAL0mKck",
-        "begin": "2014-07-05T19:50:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-05T19:50:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "99962"
       },
       {
-        "site": "saraba1st",
-        "id": "1039374"
-      },
-      {
         "site": "nicovideo",
         "id": "basara_je",
-        "begin": "2014-07-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T03:00:00.000Z"
       }
     ]
   },
@@ -1372,35 +727,15 @@
     "officialSite": "http://space-dandy.com/",
     "begin": "2014-07-06T14:00:00.000Z",
     "end": "2014-09-28T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif9il",
-        "begin": "2014-07-06T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2666",
-        "begin": "2014-07-06T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100501"
-      },
-      {
-        "site": "saraba1st",
-        "id": "961085"
       }
     ]
   },
@@ -1416,75 +751,30 @@
     "officialSite": "http://www.gundam-san.net/",
     "begin": "2014-07-06T10:28:00.000Z",
     "end": "2014-09-28T10:31:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jqqGBGzSQoDjYck",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "t/tk1y1g67qs2zafs",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "4635d25401bc11e4b2ad",
-        "begin": "2014-07-02T16:25:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "6hWlRzB6Y-g",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2669",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-02T16:25:15.000Z"
       },
       {
         "site": "bangumi",
         "id": "106834"
       },
       {
-        "site": "saraba1st",
-        "id": "1035536"
-      },
-      {
         "site": "letv",
         "id": "10003005",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1503,55 +793,20 @@
     "officialSite": "http://www.heart-bit.com/francesca/index.html",
     "begin": "2014-07-06T16:20:00.000Z",
     "end": "2014-12-14T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "d9f1a042f69d11e3b8b7",
-        "begin": "2014-07-10T16:26:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "R4_YggpzqDQ",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-10T16:26:46.000Z"
       },
       {
         "site": "bangumi",
         "id": "92415"
       },
       {
-        "site": "saraba1st",
-        "id": "1039560"
-      },
-      {
         "site": "nicovideo",
         "id": "francesca",
-        "begin": "2014-07-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "46",
-        "begin": "2014-07-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-12T15:00:00.000Z"
       }
     ]
   },
@@ -1570,75 +825,40 @@
     "officialSite": "http://aoha-anime.com/",
     "begin": "2014-07-07T15:00:00.000Z",
     "end": "2014-09-22T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Xr6aGIDmVpT3dd0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "108969",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10002705",
-        "begin": "2014-07-07T19:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-07T19:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "59",
-        "begin": "2014-07-07T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-07T19:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "92836"
       },
       {
-        "site": "saraba1st",
-        "id": "1015328"
-      },
-      {
         "site": "nicovideo",
         "id": "aoha-anime",
-        "begin": "2014-07-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-15T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh83pal",
-        "begin": "2017-06-30T16:02:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:45.000Z"
       }
     ]
   },
@@ -1654,27 +874,11 @@
     "officialSite": "http://ani.tv/yamishibai/",
     "begin": "2014-07-06T17:40:00.000Z",
     "end": "2014-09-28T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "367017a6f68d11e3b8b7",
-        "begin": "2014-07-06T18:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Rm4__32D5Uw",
-        "begin": "2014-07-06T18:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-06T18:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1697,65 +901,25 @@
     "officialSite": "http://www.himegoto-tv.jp/",
     "begin": "2014-07-07T14:54:00.000Z",
     "end": "2014-09-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2673",
-        "begin": "2014-07-07T16:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3227",
-        "begin": "2014-07-07T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "db8922f89de311e3a705",
-        "begin": "2014-07-07T16:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-07T16:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbvwad",
-        "begin": "2014-07-07T16:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-07-07T16:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "97927"
       },
       {
-        "site": "saraba1st",
-        "id": "1026747"
-      },
-      {
         "site": "nicovideo",
         "id": "himegoto-tv",
-        "begin": "2014-07-08T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-08T13:00:00.000Z"
       }
     ]
   },
@@ -1774,95 +938,40 @@
     "officialSite": "http://nozakikun.tv/",
     "begin": "2014-07-06T16:10:00.000Z",
     "end": "2014-09-21T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "dde1b9beb26211e3b8b7",
-        "begin": "2014-07-06T17:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T17:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10002971",
-        "begin": "2014-07-06T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2670",
-        "begin": "2014-07-06T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T17:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "53",
-        "begin": "2014-07-06T17:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T17:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgif6ex",
-        "begin": "2014-07-06T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T17:05:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/yksnyqtx",
-        "begin": "2014-07-06T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0BK5sqbKQm4",
-        "begin": "2014-07-06T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-06T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100449"
       },
       {
-        "site": "saraba1st",
-        "id": "1027876"
-      },
-      {
         "site": "nicovideo",
         "id": "nozakikun",
-        "begin": "2014-07-17T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-17T15:30:00.000Z"
       }
     ]
   },
@@ -1879,95 +988,35 @@
     "officialSite": "http://dmmd-anime.com/",
     "begin": "2014-07-06T16:40:00.000Z",
     "end": "2014-09-21T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "be6a268cb7e111e3a705",
-        "begin": "2014-07-06T17:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10002982",
-        "begin": "2014-07-06T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "55",
-        "begin": "2014-07-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2671",
-        "begin": "2014-07-06T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgif6qp",
-        "begin": "2014-07-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-06T17:35:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/dramaticalmurder",
-        "begin": "2014-07-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "JxD1VwA1MKE",
-        "begin": "2014-07-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-06T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100557"
       },
       {
-        "site": "saraba1st",
-        "id": "1009286"
-      },
-      {
         "site": "nicovideo",
         "id": "dmmd-anime",
-        "begin": "2014-07-14T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-14T15:30:00.000Z"
       }
     ]
   },
@@ -1983,55 +1032,20 @@
     "officialSite": "http://hanayamata.com/",
     "begin": "2014-07-07T16:35:00.000Z",
     "end": "2014-09-22T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2676",
-        "begin": "2014-07-07T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "o0ihNNG7-xM",
-        "begin": "2014-07-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "c4dde3c0f69111e3b2ad",
-        "begin": "2014-07-07T17:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-07T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "91222"
       },
       {
-        "site": "saraba1st",
-        "id": "1031383"
-      },
-      {
         "site": "nicovideo",
         "id": "hanayamata",
-        "begin": "2014-07-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T14:30:00.000Z"
       }
     ]
   },
@@ -2047,65 +1061,20 @@
     "officialSite": "http://momokyun.com/",
     "begin": "2014-07-08T15:30:00.000Z",
     "end": "2014-09-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2678",
-        "begin": "2014-07-08T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "lpPMdJ9BPtE",
-        "begin": "2014-07-08T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "54123fd8c54011e3a705",
-        "begin": "2014-07-08T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-08T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "93865"
       },
       {
-        "site": "saraba1st",
-        "id": "1040186"
-      },
-      {
         "site": "nicovideo",
         "id": "momokyun",
-        "begin": "2014-07-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "6371",
-        "begin": "2014-07-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T15:00:00.000Z"
       }
     ]
   },
@@ -2122,45 +1091,20 @@
     "officialSite": "http://hamatorapj.com/reply/",
     "begin": "2014-07-07T17:05:00.000Z",
     "end": "2014-09-22T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "abf5e98ad8ef11e3b8b7",
-        "begin": "2014-07-07T18:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "nAQOM1PVFNQ",
-        "begin": "2014-07-07T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-07T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "101322"
       },
       {
-        "site": "saraba1st",
-        "id": "965704"
-      },
-      {
         "site": "nicovideo",
         "id": "hamatora02",
-        "begin": "2014-07-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-10T14:00:00.000Z"
       }
     ]
   },
@@ -2180,35 +1124,20 @@
     "officialSite": "http://www.yamanosusume.com/",
     "begin": "2014-07-09T13:00:00.000Z",
     "end": "2014-12-24T13:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/qjbdssn2",
-        "begin": "2014-07-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-09T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "86670"
       },
       {
-        "site": "saraba1st",
-        "id": "1040210"
-      },
-      {
         "site": "nicovideo",
         "id": "yamanosusume2nd",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2224,45 +1153,20 @@
     "officialSite": "http://anime-rurumo.com/",
     "begin": "2014-07-09T12:00:00.000Z",
     "end": "2014-09-24T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif06l",
-        "begin": "2014-07-09T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2681",
-        "begin": "2014-07-09T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-09T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "102694"
       },
       {
-        "site": "saraba1st",
-        "id": "1034497"
-      },
-      {
         "site": "nicovideo",
         "id": "anime-rurumo",
-        "begin": "2014-07-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-12T15:00:00.000Z"
       }
     ]
   },
@@ -2279,55 +1183,20 @@
     "officialSite": "http://lovestage-tv.jp/",
     "begin": "2014-07-09T16:05:00.000Z",
     "end": "2014-09-10T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif0kh",
-        "begin": "2014-07-09T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2682",
-        "begin": "2014-07-09T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4080",
-        "begin": "2014-07-09T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-07-09T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "74755"
       },
       {
-        "site": "saraba1st",
-        "id": "1008435"
-      },
-      {
         "site": "nicovideo",
         "id": "lovestage",
-        "begin": "2016-11-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-01T06:00:00.000Z"
       }
     ]
   },
@@ -2347,55 +1216,25 @@
     "officialSite": "http://anime.prisma-illya.jp/2wei/",
     "begin": "2014-07-09T16:35:00.000Z",
     "end": "2014-09-10T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif0st",
-        "begin": "2014-07-09T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2683",
-        "begin": "2014-07-09T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-09T18:05:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "2574",
-        "begin": "2014-07-09T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "id": "80092",
+        "begin": "2014-07-09T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "83402"
       },
       {
-        "site": "saraba1st",
-        "id": "866827"
-      },
-      {
         "site": "nicovideo",
         "id": "prisma-illya-2wei",
-        "begin": "2016-09-02T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-02T06:00:00.000Z"
       }
     ]
   },
@@ -2412,25 +1251,15 @@
     "officialSite": "http://terror-in-tokyo.com/",
     "begin": "2014-07-10T16:10:00.000Z",
     "end": "2014-09-25T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10002584",
-        "begin": "2014-07-10T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-10T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100443"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1032193"
       }
     ]
   },
@@ -2447,45 +1276,20 @@
     "officialSite": "http://www.kuroshitsuji.tv/",
     "begin": "2014-07-10T17:44:00.000Z",
     "end": "2014-09-11T17:49:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "2688",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrgif36t",
-        "begin": "2014-07-10T18:19:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-10T18:19:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100526"
       },
       {
-        "site": "saraba1st",
-        "id": "1008984"
-      },
-      {
         "site": "nicovideo",
         "id": "kuroshitsuji-03",
-        "begin": "2014-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-14T16:00:00.000Z"
       }
     ]
   },
@@ -2504,67 +1308,21 @@
     "officialSite": "http://www.dreamcreation.co.jp/stpl2/",
     "begin": "2014-07-10T16:00:00.000Z",
     "end": "2014-09-25T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "poJu7FS6KmjLSbE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10003093",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "kP9MBFbhLH4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "fb9af3d4cdc011e3b8b7",
-        "begin": "2014-07-11T02:04:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2654",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "25",
-        "begin": "2014-07-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T02:04:16.000Z"
       },
       {
         "site": "bangumi",
@@ -2573,12 +1331,7 @@
       {
         "site": "nicovideo",
         "id": "stpl02",
-        "begin": "2014-07-15T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-15T12:00:00.000Z"
       }
     ]
   },
@@ -2597,45 +1350,20 @@
     "officialSite": "http://www.p4ga.jp/",
     "begin": "2014-07-10T17:14:00.000Z",
     "end": "2014-09-25T17:24:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgif2ph",
-        "begin": "2014-07-10T17:49:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2686",
-        "begin": "2014-07-10T17:49:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-10T17:49:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "103304"
       },
       {
-        "site": "saraba1st",
-        "id": "1040436"
-      },
-      {
         "site": "nicovideo",
         "id": "p4g",
-        "begin": "2014-07-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-12T16:00:00.000Z"
       }
     ]
   },
@@ -2652,25 +1380,15 @@
     "officialSite": "http://psycho-pass.com/",
     "begin": "2014-07-10T16:40:00.000Z",
     "end": "2014-09-18T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10002914",
-        "begin": "2014-07-10T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-10T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "103906"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1040512"
       }
     ]
   },
@@ -2686,45 +1404,20 @@
     "officialSite": "http://www.tokyo-esp.org/",
     "begin": "2014-07-11T16:35:00.000Z",
     "end": "2014-09-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrgiixqd",
-        "begin": "2014-07-11T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2689",
-        "begin": "2014-07-11T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "88676"
       },
       {
-        "site": "saraba1st",
-        "id": "1028553"
-      },
-      {
         "site": "bilibili",
-        "id": "26473",
-        "begin": "2019-01-23T06:46:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "11900440",
+        "begin": "2019-01-23T06:46:00.000Z"
       }
     ]
   },
@@ -2740,27 +1433,11 @@
     "officialSite": "http://corona106.tv/",
     "begin": "2014-07-11T16:05:00.000Z",
     "end": "2014-09-26T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/spfjdqlz",
-        "begin": "2014-07-11T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2692",
-        "begin": "2014-07-11T19:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-11T19:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2769,32 +1446,17 @@
       {
         "site": "nicovideo",
         "id": "rokujoma",
-        "begin": "2014-07-15T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-15T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhdtkd1",
-        "begin": "2017-08-10T01:06:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-10T01:06:43.000Z"
       },
       {
         "site": "bilibili",
-        "id": "4120",
-        "begin": "2014-07-10T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "75052",
+        "begin": "2014-07-10T16:00:01.000Z"
       }
     ]
   },
@@ -2810,45 +1472,20 @@
     "officialSite": "http://www.fujitv.co.jp/nobunaga-concerto-anime/index.html",
     "begin": "2014-07-11T17:10:00.000Z",
     "end": "2014-09-19T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "add9096ed8ed11e38b3f",
-        "begin": "2014-07-12T02:55:55.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Hg5kpLOCS0E",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-07-12T02:55:55.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/xcxzq",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "103671"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1035430"
       }
     ]
   },
@@ -2867,75 +1504,30 @@
     "officialSite": "http://www.bladedance.tv/",
     "begin": "2014-07-14T11:30:00.000Z",
     "end": "2014-09-29T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh923sd",
-        "begin": "2016-12-31T16:02:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-31T16:02:28.000Z"
       },
       {
         "site": "letv",
         "id": "10027926",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2014/jlsdjw",
-        "begin": "2014-07-14T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4137",
-        "begin": "2014-07-14T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "2694",
-        "begin": "2014-07-14T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-14T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "79226"
       },
       {
-        "site": "saraba1st",
-        "id": "1041594"
-      },
-      {
         "site": "nicovideo",
         "id": "bladedance-tv",
-        "begin": "2014-07-24T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-24T16:00:00.000Z"
       }
     ]
   },
@@ -2952,7 +1544,6 @@
     "officialSite": "http://minaraidiva.jp/",
     "begin": "2014-07-14T12:00:00.000Z",
     "end": "2014-09-22T12:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2961,12 +1552,7 @@
       {
         "site": "nicovideo",
         "id": "minaraidiva",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2982,37 +1568,21 @@
     "officialSite": "http://www.sushininja.jp/",
     "begin": "2014-07-03T16:00:00.000Z",
     "end": "2014-11-28T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb1i2p",
-        "begin": "2015-06-01T09:18:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-01T09:18:35.000Z"
       },
       {
         "site": "qq",
         "id": "t/t2ba472ebgp8ikk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2015/ssrz",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3021,12 +1591,7 @@
       {
         "site": "bilibili",
         "id": "4099",
-        "begin": "2014-07-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-02T16:00:01.000Z"
       }
     ]
   },
@@ -3042,47 +1607,26 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2014-07-19T16:00:00.000Z",
     "end": "2014-07-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "91w4th6E9DKVE3s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb8sh9",
-        "begin": "2015-09-17T05:39:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-17T05:39:45.000Z"
       },
       {
         "site": "qq",
         "id": "z/z57iqzs8ttl7b1k",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10017222",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3091,12 +1635,7 @@
       {
         "site": "bilibili",
         "id": "6389",
-        "begin": "2014-07-18T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-18T16:00:01.000Z"
       }
     ]
   },
@@ -3112,7 +1651,6 @@
     "officialSite": "http://www.pokemon-movie.jp/short/",
     "begin": "2014-07-19T17:10:00.000Z",
     "end": "2014-07-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3121,12 +1659,7 @@
       {
         "site": "bilibili",
         "id": "4107",
-        "begin": "2014-07-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-18T16:00:01.000Z"
       }
     ]
   },
@@ -3143,17 +1676,11 @@
     "officialSite": "http://marnie.jp/index.html",
     "begin": "2014-07-19T16:00:00.000Z",
     "end": "2014-07-19T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pYVv7VW7K2nMSrI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3173,17 +1700,11 @@
     "officialSite": "",
     "begin": "2014-07-11T16:00:00.000Z",
     "end": "2014-09-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "r4tl40uxIVicCQKg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3192,22 +1713,12 @@
       {
         "site": "nicovideo",
         "id": "bch-jinmenken",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4134",
-        "begin": "2014-07-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-07-10T16:00:01.000Z"
       }
     ]
   },
@@ -3223,7 +1734,6 @@
     "officialSite": "http://www.sumiko-anime.com/",
     "begin": "2014-07-04T16:00:00.000Z",
     "end": "2014-08-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3232,12 +1742,7 @@
       {
         "site": "nicovideo",
         "id": "sumiko-anime",
-        "begin": "2014-08-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-01T03:00:00.000Z"
       }
     ]
   },
@@ -3253,7 +1758,6 @@
     "officialSite": "http://k-project-movie.jpn.com/",
     "begin": "2014-07-12T16:00:00.000Z",
     "end": "2014-07-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3262,12 +1766,7 @@
       {
         "site": "nicovideo",
         "id": "k-project-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3283,7 +1782,6 @@
     "officialSite": "http://www.nonnontv.com",
     "begin": "2014-07-23T16:00:00.000Z",
     "end": "2014-07-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3292,12 +1790,7 @@
       {
         "site": "pptv",
         "id": "j7ehH4ftXZvibfOQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2014/08.json
+++ b/data/items/2014/08.json
@@ -12,65 +12,30 @@
     "officialSite": "http://www9.nhk.or.jp/anime/medamayaki/",
     "begin": "2014-08-04T15:10:00.000Z",
     "end": "2014-08-07T15:36:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1HVf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "84",
-        "begin": "2014-08-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "QeF47CAU9jM",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-08-04T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "a9b52a10241b11e4a705",
-        "begin": "2014-08-17T02:29:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-17T02:29:19.000Z"
       },
       {
         "site": "letv",
         "id": "10004046",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "103810"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1047196"
       }
     ]
   },
@@ -86,25 +51,15 @@
     "officialSite": "http://www.monogatari-series.com/2ndseason/",
     "begin": "2014-08-16T10:00:00.000Z",
     "end": "2014-08-16T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/hwy",
-        "begin": "2014-08-22T01:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-08-22T01:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "82322"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1049249"
       }
     ]
   },
@@ -120,17 +75,11 @@
     "officialSite": "http://terraformars.tv/",
     "begin": "2014-08-20T16:00:00.000Z",
     "end": "2014-11-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "8/8tdh5ttykqm9y65",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -150,17 +99,11 @@
     "officialSite": "http://doraemon-3d.com/",
     "begin": "2014-08-08T16:00:00.000Z",
     "end": "2014-08-08T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrog1cdo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -169,22 +112,12 @@
       {
         "site": "pptv",
         "id": "BiaELiafFXxwVo5k4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "c/ciw1zkqfr3cjfv7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -200,17 +133,11 @@
     "officialSite": "",
     "begin": "2014-08-29T16:00:00.000Z",
     "end": "2014-08-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SuzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -219,12 +146,7 @@
       {
         "site": "bilibili",
         "id": "3837",
-        "begin": "2014-08-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-28T16:00:01.000Z"
       }
     ]
   },
@@ -240,7 +162,6 @@
     "officialSite": "http://wwws.warnerbros.co.jp/uchukyodai-movie/",
     "begin": "2014-08-09T16:00:00.000Z",
     "end": "2014-08-09T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -249,12 +170,7 @@
       {
         "site": "pptv",
         "id": "fsmjIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -270,7 +186,6 @@
     "officialSite": "http://initiald-movie.com/",
     "begin": "2014-08-23T16:00:00.000Z",
     "end": "2014-08-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -279,22 +194,12 @@
       {
         "site": "pptv",
         "id": "cOzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3838",
-        "begin": "2014-08-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-22T16:00:01.000Z"
       }
     ]
   },
@@ -310,7 +215,6 @@
     "officialSite": "http://aoha-anime.com/",
     "begin": "2014-08-25T16:00:00.000Z",
     "end": "2014-12-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -319,22 +223,12 @@
       {
         "site": "pptv",
         "id": "xWpGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3782",
-        "begin": "2014-08-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-08-24T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2014/09.json
+++ b/data/items/2014/09.json
@@ -11,45 +11,20 @@
     "officialSite": "http://www.terraformars.tv/",
     "begin": "2014-09-26T15:30:00.000Z",
     "end": "2014-12-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "jGaFpdJqObQ",
-        "begin": "2014-09-26T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "ff86b776cf5f11e3b8b7",
-        "begin": "2014-09-26T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-26T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc139h",
-        "begin": "2014-09-26T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-26T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "96787"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1060590"
       }
     ]
   },
@@ -68,27 +43,11 @@
     "officialSite": "http://www.tribecoolcrew.net/",
     "begin": "2014-09-27T22:00:00.000Z",
     "end": "2015-10-03T22:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464859",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0yh5",
-        "begin": "2014-09-30T06:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-30T06:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -97,12 +56,7 @@
       {
         "site": "bilibili",
         "id": "3241",
-        "begin": "2014-09-27T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-27T16:00:01.000Z"
       }
     ]
   },
@@ -119,47 +73,16 @@
     "officialSite": "http://buddy-complex.jp/",
     "begin": "2014-09-29T15:00:00.000Z",
     "end": "2014-09-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464854",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc1759",
-        "begin": "2014-09-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-30T16:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/buddycomplex",
-        "begin": "2014-09-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "75159",
-        "begin": "2014-09-30T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-09-30T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -182,7 +105,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/lululolo/",
     "begin": "2014-09-25T08:25:00.000Z",
     "end": "2015-03-26T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -202,7 +124,6 @@
     "officialSite": "http://tinnyballoon.com/animation/",
     "begin": "2014-09-26T08:25:00.000Z",
     "end": "2015-03-27T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -222,17 +143,11 @@
     "officialSite": "http://www.karensenki.com/",
     "begin": "2014-09-27T16:00:00.000Z",
     "end": "2014-12-06T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7kgkogpw4B6Bic2c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -241,22 +156,12 @@
       {
         "site": "bilibili",
         "id": "343",
-        "begin": "2014-09-26T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-09-26T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10006162",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -272,17 +177,11 @@
     "officialSite": "http://www.shogakukan.co.jp/pr/anisun/fs/index.html",
     "begin": "2014-09-16T16:00:00.000Z",
     "end": "2015-02-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ACQQjvZczApt61M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -302,17 +201,11 @@
     "officialSite": "",
     "begin": "2014-09-24T16:00:00.000Z",
     "end": "2014-09-24T16:04:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wlo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -332,7 +225,6 @@
     "officialSite": "http://gdgdfairy.com/",
     "begin": "2014-09-27T16:00:00.000Z",
     "end": "2014-09-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -341,12 +233,7 @@
       {
         "site": "nicovideo",
         "id": "gdgd-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -362,7 +249,6 @@
     "officialSite": "",
     "begin": "2014-09-23T16:00:00.000Z",
     "end": "2014-09-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -371,12 +257,7 @@
       {
         "site": "pptv",
         "id": "xV85txibF9TOWFHw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2014/10.json
+++ b/data/items/2014/10.json
@@ -11,35 +11,20 @@
     "officialSite": "http://umanohone.jp/",
     "begin": "2014-10-02T13:30:00.000Z",
     "end": "2014-12-18T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "282",
-        "begin": "2014-10-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-02T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "103127"
       },
       {
-        "site": "saraba1st",
-        "id": "1062127"
-      },
-      {
         "site": "nicovideo",
         "id": "umanohone",
-        "begin": "2014-10-05T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T15:30:00.000Z"
       }
     ]
   },
@@ -59,25 +44,15 @@
     "officialSite": "http://www.aikatsu.net/03/index.html",
     "begin": "2014-10-02T09:00:00.000Z",
     "end": "2015-09-24T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc0yjx",
-        "begin": "2014-10-02T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-02T11:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "139318"
-      },
-      {
-        "site": "saraba1st",
-        "id": "930385"
       }
     ]
   },
@@ -97,55 +72,25 @@
     "officialSite": "http://www.g-reco.net/",
     "begin": "2014-10-02T10:30:00.000Z",
     "end": "2015-03-26T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9pr0l",
-        "begin": "2016-09-12T07:56:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-12T07:56:10.000Z"
       },
       {
         "site": "letv",
         "id": "10005222",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "iU6KdfiaSxo",
-        "begin": "2014-10-02T19:49:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "21e664b6b01011e3a705",
-        "begin": "2014-10-02T19:49:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-02T19:49:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "54551"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1061969"
       }
     ]
   },
@@ -161,85 +106,40 @@
     "officialSite": "http://www.tbs.co.jp/anime/amaburi/",
     "begin": "2014-10-06T18:40:00.000Z",
     "end": "2014-12-25T17:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10005260",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/wt2ko9mlf02fryc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "gKKODHTaSojradE",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "8c74cc8ace7611e3a705",
-        "begin": "2014-10-05T10:45:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "7CNapiWZqVk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-05T10:45:01.000Z"
       },
       {
         "site": "bilibili",
         "id": "281",
-        "begin": "2014-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "93545"
       },
       {
-        "site": "saraba1st",
-        "id": "1018501"
-      },
-      {
         "site": "nicovideo",
         "id": "amaburi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -255,77 +155,36 @@
     "officialSite": "http://www.dreamcreation.co.jp/danna/",
     "begin": "2014-10-02T16:00:00.000Z",
     "end": "2014-12-25T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nLaiaIIjuXpzicfeU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "151232",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1530",
-        "begin": "2014-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-02T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10005221",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "d3a9f5563d6d11e4b522",
-        "begin": "2014-10-04T05:18:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "G4w3mr-huo0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-04T05:18:44.000Z"
       },
       {
         "site": "qq",
         "id": "4/432204o0d8j3rnu",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -334,12 +193,7 @@
       {
         "site": "nicovideo",
         "id": "danna_anime",
-        "begin": "2014-10-07T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T12:00:00.000Z"
       }
     ]
   },
@@ -355,95 +209,40 @@
     "officialSite": "http://www.madan-anime.jp/",
     "begin": "2014-10-04T11:00:00.000Z",
     "end": "2014-12-27T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10005234",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464820",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0xbh",
-        "begin": "2014-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-04T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "291",
-        "begin": "2014-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-04T14:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "srmTEXnfT43wbtY",
-        "begin": "2014-10-04T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-10-04T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "17369f303d6511e4b2ad",
-        "begin": "2014-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "66Gn16iu3K4",
-        "begin": "2014-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-04T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "79229"
       },
       {
-        "site": "saraba1st",
-        "id": "1062470"
-      },
-      {
         "site": "nicovideo",
         "id": "madan-anime",
-        "begin": "2014-10-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T17:00:00.000Z"
       }
     ]
   },
@@ -460,27 +259,11 @@
     "officialSite": "http://dontenniwarau.com/",
     "begin": "2014-10-03T17:28:00.000Z",
     "end": "2014-12-19T17:38:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464836",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0xl1",
-        "begin": "2014-10-03T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-03T20:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -489,22 +272,12 @@
       {
         "site": "nicovideo",
         "id": "dontenniwarau",
-        "begin": "2014-10-04T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-04T17:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4060",
-        "begin": "2014-10-02T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-02T16:00:01.000Z"
       }
     ]
   },
@@ -522,75 +295,35 @@
     "officialSite": "http://garo-project.jp/ANIME/",
     "begin": "2014-10-03T16:23:00.000Z",
     "end": "2015-03-27T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GgXvbdU7qiblMyjI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0xnt",
-        "begin": "2014-10-03T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "gdZUtuYLZdw",
-        "begin": "2014-10-03T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-03T17:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3209",
-        "begin": "2014-10-03T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-03T17:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "7d04ee48fa7b11e3b8b7",
-        "begin": "2014-10-03T17:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-03T17:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "88741"
       },
       {
-        "site": "saraba1st",
-        "id": "1008874"
-      },
-      {
         "site": "nicovideo",
         "id": "garo-project",
-        "begin": "2014-10-17T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-17T16:00:00.000Z"
       }
     ]
   },
@@ -609,27 +342,11 @@
     "officialSite": "http://ushinawareta-mirai.com/",
     "begin": "2014-10-04T11:30:00.000Z",
     "end": "2014-12-20T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464840",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc108x",
-        "begin": "2014-10-09T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T17:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -638,22 +355,12 @@
       {
         "site": "nicovideo",
         "id": "ushinawareta-mirai",
-        "begin": "2014-10-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-12T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4067",
-        "begin": "2014-10-03T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-03T16:00:01.000Z"
       }
     ]
   },
@@ -673,105 +380,45 @@
     "officialSite": "http://www.fate-sn.com/ubw/",
     "begin": "2014-10-04T15:00:00.000Z",
     "end": "2014-12-27T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc107d",
-        "begin": "2014-10-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "RsfQldH8q6s",
-        "begin": "2014-10-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-09T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "5/54v59r074ncc1kq",
-        "begin": "2014-10-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-10-09T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "46465a1c711f11e38b3f",
-        "begin": "2014-10-09T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10005152",
-        "begin": "2014-10-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1586",
-        "begin": "2014-10-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464802",
-        "begin": "2014-10-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "95225"
       },
       {
-        "site": "saraba1st",
-        "id": "1062472"
-      },
-      {
         "site": "nicovideo",
         "id": "fate-sn2",
-        "begin": "2014-10-04T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-04T17:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80040330",
-        "begin": "2015-08-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-01T07:00:00.000Z"
       }
     ]
   },
@@ -791,85 +438,40 @@
     "officialSite": "http://www9.nhk.or.jp/anime/loghorizon/",
     "begin": "2014-10-04T08:30:00.000Z",
     "end": "2015-03-28T08:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10005232",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "290",
-        "begin": "2014-10-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T17:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "ibVs1sxuB8SibSEHg",
-        "begin": "2014-10-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T17:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc10bp",
-        "begin": "2014-10-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T17:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "78f9354e3d6411e4a080",
-        "begin": "2014-10-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "v7h-gGVVx6U",
-        "begin": "2014-10-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-09T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100517"
       },
       {
-        "site": "saraba1st",
-        "id": "946364"
-      },
-      {
         "site": "nicovideo",
         "id": "loghorizon02",
-        "begin": "2014-10-18T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-18T15:00:00.000Z"
       }
     ]
   },
@@ -885,35 +487,15 @@
     "officialSite": "http://selector-wixoss.com/",
     "begin": "2014-10-03T16:05:00.000Z",
     "end": "2014-12-19T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464830",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0xpd",
-        "begin": "2014-10-03T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-03T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "106314"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1009195"
       }
     ]
   },
@@ -933,65 +515,30 @@
     "officialSite": "http://www.ytv.co.jp/magickaito/",
     "begin": "2014-10-04T08:30:00.000Z",
     "end": "2015-03-28T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "f/fm95ukbvs36ejzw",
-        "begin": "2014-10-04T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-04T11:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "eebadce421c911e4a705",
-        "begin": "2014-10-04T11:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "2TdJoRW10F8",
-        "begin": "2014-10-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-04T11:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0x81",
-        "begin": "2014-10-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-04T11:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2014/gdjd1412",
-        "begin": "2014-10-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-04T11:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "109203"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1044817"
       }
     ]
   },
@@ -1010,55 +557,20 @@
     "officialSite": "http://www.grisaia-anime.com/kajitsu/",
     "begin": "2014-10-05T11:30:00.000Z",
     "end": "2014-12-28T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464838",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0zfl",
-        "begin": "2014-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "67376"
       },
       {
-        "site": "saraba1st",
-        "id": "1018763"
-      },
-      {
         "site": "nicovideo",
         "id": "grisaia-anime",
-        "begin": "2014-10-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4270",
-        "begin": "2014-10-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T16:30:00.000Z"
       }
     ]
   },
@@ -1077,45 +589,25 @@
     "officialSite": "http://sora-no-method.jp/",
     "begin": "2014-10-05T13:30:00.000Z",
     "end": "2014-12-28T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "296",
-        "begin": "2014-10-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100040"
       },
       {
-        "site": "saraba1st",
-        "id": "1009376"
-      },
-      {
         "site": "nicovideo",
         "id": "sora-no-method",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9jhyx",
-        "begin": "2017-04-04T03:14:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T03:14:10.000Z"
       }
     ]
   },
@@ -1134,45 +626,20 @@
     "officialSite": "http://www.ookamishojo-anime.jp/",
     "begin": "2014-10-05T13:00:00.000Z",
     "end": "2014-12-21T13:27:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464857",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0zph",
-        "begin": "2014-10-05T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "101518"
       },
       {
-        "site": "saraba1st",
-        "id": "1062786"
-      },
-      {
         "site": "nicovideo",
         "id": "ookamishojo-anime",
-        "begin": "2014-10-07T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T13:30:00.000Z"
       }
     ]
   },
@@ -1191,35 +658,20 @@
     "officialSite": "http://www.7-taizai.net/1st/",
     "begin": "2014-10-05T08:00:00.000Z",
     "end": "2015-03-29T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "101820"
       },
       {
-        "site": "saraba1st",
-        "id": "1045270"
-      },
-      {
         "site": "nicovideo",
         "id": "7-taizai",
-        "begin": "2014-10-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-11T15:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80050063",
-        "begin": "2015-11-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-01T07:00:00.000Z"
       }
     ]
   },
@@ -1239,45 +691,20 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/wt/",
     "begin": "2014-10-04T21:30:00.000Z",
     "end": "2016-04-02T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc0zzx",
-        "begin": "2014-10-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "境界触发者",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-10-05T03:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "104906"
       },
       {
-        "site": "saraba1st",
-        "id": "1035527"
-      },
-      {
         "site": "nicovideo",
         "id": "worldtrigger",
-        "begin": "2014-12-18T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-18T03:00:00.000Z"
       }
     ]
   },
@@ -1297,35 +724,20 @@
     "officialSite": "http://crossange.com/",
     "begin": "2014-10-04T16:30:00.000Z",
     "end": "2015-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc0zv1",
-        "begin": "2014-10-05T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T09:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3048",
-        "begin": "2014-10-05T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T09:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "109948"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1062484"
       }
     ]
   },
@@ -1342,55 +754,25 @@
     "officialSite": "http://shingekinobahamut-genesis.jp/",
     "begin": "2014-10-06T14:30:00.000Z",
     "end": "2014-12-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464822",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0z39",
-        "begin": "2014-10-06T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "91986"
       },
       {
-        "site": "saraba1st",
-        "id": "1062809"
-      },
-      {
         "site": "nicovideo",
         "id": "shingekinobahamut-genesis",
-        "begin": "2014-10-06T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T17:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4058",
-        "begin": "2014-10-05T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -1409,85 +791,35 @@
     "officialSite": "http://www.gugukoku.com/",
     "begin": "2014-10-05T16:05:00.000Z",
     "end": "2014-12-21T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464821",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0zdp",
-        "begin": "2014-10-05T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T17:05:00.000Z"
       },
       {
         "site": "pptv",
         "id": "FTUfnQVr2xl8ibmI",
-        "begin": "2014-10-05T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T17:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "e31f4ef6c92211e3a705",
-        "begin": "2014-10-05T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "pPuLbZdMqTY",
-        "begin": "2014-10-05T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-05T17:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "297",
-        "begin": "2014-10-05T17:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100227"
       },
       {
-        "site": "saraba1st",
-        "id": "1048668"
-      },
-      {
         "site": "nicovideo",
         "id": "gugukoku",
-        "begin": "2014-10-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-11T14:30:00.000Z"
       }
     ]
   },
@@ -1503,77 +835,31 @@
     "officialSite": "http://www.orefuro.jp/",
     "begin": "2014-10-06T14:54:00.000Z",
     "end": "2014-12-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kLKeHITqWpj7eeE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464850",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "311",
-        "begin": "2014-10-06T15:01:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T15:01:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0z1p",
-        "begin": "2014-10-06T15:01:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T15:01:00.000Z"
       },
       {
         "site": "qq",
         "id": "v/vkvksohhix5upx7",
-        "begin": "2014-10-06T15:01:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-06T15:01:00.000Z"
       },
       {
         "site": "youku",
         "id": "49e9085a3d6a11e4b522",
-        "begin": "2014-10-06T15:01:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Nb_J8BL62Pc",
-        "begin": "2014-10-06T15:01:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-06T15:01:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1582,12 +868,7 @@
       {
         "site": "nicovideo",
         "id": "orefuro",
-        "begin": "2014-10-07T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T13:00:00.000Z"
       }
     ]
   },
@@ -1606,57 +887,21 @@
     "officialSite": "http://www.ai-tenchi.jp/",
     "begin": "2014-10-06T12:55:00.000Z",
     "end": "2014-12-26T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Jf7aWMAmltQ3tR0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "cb776f203d6911e4b432",
-        "begin": "2014-10-05T10:51:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "CYo3K-hgmOs",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-05T10:51:01.000Z"
       },
       {
         "site": "qq",
         "id": "1/1b4rfk13s84xu48",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1617",
-        "begin": "2014-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1665,12 +910,7 @@
       {
         "site": "nicovideo",
         "id": "ai-tenchi",
-        "begin": "2014-10-06T12:55:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T12:55:00.000Z"
       }
     ]
   },
@@ -1690,85 +930,40 @@
     "officialSite": "http://s.mxtv.jp/joker/",
     "begin": "2014-10-06T10:00:00.000Z",
     "end": "2015-01-05T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oYNt61O5KWfKSLA",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10018937",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1569",
-        "begin": "2014-10-06T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T10:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0zch",
-        "begin": "2014-10-06T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T10:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "3da69dee21c911e4a705",
-        "begin": "2014-10-06T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464855",
-        "begin": "2014-10-06T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T10:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "107186"
       },
       {
-        "site": "saraba1st",
-        "id": "1062960"
-      },
-      {
         "site": "nicovideo",
         "id": "joker_anime",
-        "begin": "2014-11-02T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-02T15:00:00.000Z"
       }
     ]
   },
@@ -1787,95 +982,35 @@
     "officialSite": "http://inou-anime.com/",
     "begin": "2014-10-06T17:05:00.000Z",
     "end": "2014-12-22T18:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "G_nSPK6V5b0",
-        "begin": "2014-10-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "358dbc7007e611e4a705",
-        "begin": "2014-10-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T18:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0yyx",
-        "begin": "2014-10-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T18:05:00.000Z"
       },
       {
         "site": "pptv",
         "id": "ZL6aGIDmVpT3dd0",
-        "begin": "2014-10-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T18:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10005151",
-        "begin": "2014-10-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "313",
-        "begin": "2014-10-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464815",
-        "begin": "2014-10-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "99538"
       },
       {
-        "site": "saraba1st",
-        "id": "1005858"
-      },
-      {
         "site": "nicovideo",
         "id": "inou-anime",
-        "begin": "2014-10-09T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T14:00:00.000Z"
       }
     ]
   },
@@ -1891,27 +1026,11 @@
     "officialSite": "http://yowapeda.com/",
     "begin": "2014-10-06T16:35:00.000Z",
     "end": "2015-03-30T17:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "0-8oH78hMeI",
-        "begin": "2014-10-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "a2826926df3611e3b8b7",
-        "begin": "2014-10-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1920,12 +1039,7 @@
       {
         "site": "nicovideo",
         "id": "yowapeda_gr",
-        "begin": "2014-10-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-10T15:00:00.000Z"
       }
     ]
   },
@@ -1945,85 +1059,35 @@
     "officialSite": "http://www.marv.jp/special/yona/",
     "begin": "2014-10-07T14:00:00.000Z",
     "end": "2015-03-24T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "3sgyRBy1t1M",
-        "begin": "2014-10-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "d6c247ae3d6b11e4a080",
-        "begin": "2014-10-07T15:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0ytd",
-        "begin": "2014-10-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T15:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "e923NZ0Dc7EUkvo",
-        "begin": "2014-10-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464837",
-        "begin": "2014-10-07T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "107474"
       },
       {
-        "site": "saraba1st",
-        "id": "1038965"
-      },
-      {
         "site": "nicovideo",
         "id": "yona_anime",
-        "begin": "2014-10-14T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-14T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3072",
-        "begin": "2014-10-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-06T16:00:00.000Z"
       }
     ]
   },
@@ -2042,95 +1106,40 @@
     "officialSite": "http://www.daito-anime.com/",
     "begin": "2014-10-08T15:30:00.000Z",
     "end": "2014-12-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464842",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "mgtv",
         "id": "292456",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "323",
-        "begin": "2014-10-08T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "tQz-M8MDLYc",
-        "begin": "2014-10-08T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-08T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "8ea489d03d8611e4a080",
-        "begin": "2014-10-08T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-08T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "w/w9galx5d4dm0udo",
-        "begin": "2014-10-08T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-08T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbzby1",
-        "begin": "2014-10-08T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-08T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "67373"
       },
       {
-        "site": "saraba1st",
-        "id": "1056176"
-      },
-      {
         "site": "nicovideo",
         "id": "daito-anime",
-        "begin": "2014-10-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-08T16:00:00.000Z"
       }
     ]
   },
@@ -2150,85 +1159,30 @@
     "officialSite": "http://trinity-7.com/",
     "begin": "2014-10-07T16:40:00.000Z",
     "end": "2014-12-23T17:10:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464825",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "317",
-        "begin": "2014-10-07T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "8kRmJfnSOqg",
-        "begin": "2014-10-07T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "db2ab4f4066e11e4a705",
-        "begin": "2014-10-07T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T17:40:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc0yyl",
-        "begin": "2014-10-07T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T17:40:00.000Z"
       },
       {
         "site": "pptv",
         "id": "wl46uCCG9jSXFX0",
-        "begin": "2014-10-07T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T17:40:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "96977"
       },
       {
-        "site": "saraba1st",
-        "id": "1047068"
-      },
-      {
         "site": "nicovideo",
         "id": "trinity-7",
-        "begin": "2014-10-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-12T03:00:00.000Z"
       }
     ]
   },
@@ -2245,35 +1199,20 @@
     "officialSite": "http://shg.sega.jp/anime.html",
     "begin": "2014-10-08T13:00:00.000Z",
     "end": "2014-12-24T14:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "321",
-        "begin": "2014-10-08T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-08T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "101784"
       },
       {
-        "site": "saraba1st",
-        "id": "1014291"
-      },
-      {
         "site": "nicovideo",
         "id": "shg-sega",
-        "begin": "2014-10-11T14:45:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-11T14:45:00.000Z"
       }
     ]
   },
@@ -2293,27 +1232,16 @@
     "officialSite": "http://gundam-bf.net/",
     "begin": "2014-10-08T09:00:00.000Z",
     "end": "2015-04-01T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc0r3l",
-        "begin": "2016-08-09T06:20:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-09T06:20:33.000Z"
       },
       {
         "site": "letv",
         "id": "10005488",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2322,12 +1250,7 @@
       {
         "site": "bilibili",
         "id": "4268",
-        "begin": "2014-10-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-07T16:00:01.000Z"
       }
     ]
   },
@@ -2344,15 +1267,10 @@
     "officialSite": "http://psycho-pass.com/",
     "begin": "2014-10-09T16:10:00.000Z",
     "end": "2014-12-18T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "77625"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1058339"
       }
     ]
   },
@@ -2368,25 +1286,15 @@
     "officialSite": "http://www.kiseiju.jp/",
     "begin": "2014-10-08T16:29:00.000Z",
     "end": "2015-03-25T16:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "88433"
       },
       {
-        "site": "saraba1st",
-        "id": "1063506"
-      },
-      {
         "site": "nicovideo",
         "id": "kiseiju",
-        "begin": "2014-10-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T14:30:00.000Z"
       }
     ]
   },
@@ -2402,35 +1310,20 @@
     "officialSite": "http://chaika-anime.jp/",
     "begin": "2014-10-08T16:05:00.000Z",
     "end": "2014-12-10T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "c/crrtngniol48xnn",
-        "begin": "2014-10-08T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-08T17:35:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "188",
-        "begin": "2014-10-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-08T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "104219"
-      },
-      {
-        "site": "saraba1st",
-        "id": "844509"
       }
     ]
   },
@@ -2446,45 +1339,20 @@
     "officialSite": "http://shirobako-anime.com/",
     "begin": "2014-10-09T14:30:00.000Z",
     "end": "2015-03-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbzeox",
-        "begin": "2014-10-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464814",
-        "begin": "2014-10-09T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "110467"
       },
       {
-        "site": "saraba1st",
-        "id": "1047378"
-      },
-      {
         "site": "nicovideo",
         "id": "shirobako-anime",
-        "begin": "2014-10-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-13T03:00:00.000Z"
       }
     ]
   },
@@ -2505,55 +1373,30 @@
     "officialSite": "http://www.tbs.co.jp/anime/ore_twi/",
     "begin": "2014-10-09T16:41:00.000Z",
     "end": "2014-12-25T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10005167",
-        "begin": "2014-10-09T18:46:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T18:46:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbzehh",
-        "begin": "2014-10-09T18:46:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T18:46:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "324",
-        "begin": "2014-10-09T18:46:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T18:46:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "92429"
       },
       {
-        "site": "saraba1st",
-        "id": "1033326"
-      },
-      {
         "site": "nicovideo",
         "id": "ore_twi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2569,95 +1412,40 @@
     "officialSite": "http://www.kimiuso.jp/",
     "begin": "2014-10-09T16:40:00.000Z",
     "end": "2015-03-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "vVolwaPqgHI",
-        "begin": "2014-10-09T17:50:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "75eea0d2b24a11e38b3f",
-        "begin": "2014-10-09T17:50:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T17:50:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1699",
-        "begin": "2014-10-09T17:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T17:50:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbzeu5",
-        "begin": "2014-10-09T17:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464808",
-        "begin": "2014-10-09T17:50:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-09T17:50:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "307247",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "100444"
       },
       {
-        "site": "saraba1st",
-        "id": "1042677"
-      },
-      {
         "site": "netflix",
         "id": "80041089",
-        "begin": "2016-03-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-01T08:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "i/ivp7tg370jly0s8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2675,45 +1463,25 @@
     "officialSite": "http://www.bonkoi.com/",
     "begin": "2014-10-10T13:00:00.000Z",
     "end": "2015-03-20T13:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbz0ah",
-        "begin": "2014-10-18T13:38:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-18T13:38:38.000Z"
       },
       {
         "site": "bilibili",
         "id": "3070",
-        "begin": "2014-10-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-10T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "110485"
       },
       {
-        "site": "saraba1st",
-        "id": "1047454"
-      },
-      {
         "site": "nicovideo",
         "id": "bonkoi",
-        "begin": "2014-10-10T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-10T13:00:00.000Z"
       }
     ]
   },
@@ -2732,35 +1500,15 @@
     "officialSite": "http://www9.nhk.or.jp/anime/ronja/",
     "begin": "2014-10-11T10:00:00.000Z",
     "end": "2015-03-28T10:25:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "328",
-        "begin": "2014-10-11T13:48:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "96113"
       },
       {
-        "site": "saraba1st",
-        "id": "1052876"
-      },
-      {
         "site": "nicovideo",
         "id": "ronja",
-        "begin": "2014-10-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-11T15:00:00.000Z"
       }
     ]
   },
@@ -2780,95 +1528,35 @@
     "officialSite": "http://girlfriend-kari-anime.jp/",
     "begin": "2014-10-12T16:35:00.000Z",
     "end": "2014-12-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "fPpEVMRCTFc",
-        "begin": "2014-10-12T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "5d9421503e5011e4b2ad",
-        "begin": "2014-10-12T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "301",
-        "begin": "2014-10-12T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-12T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10005271",
-        "begin": "2014-10-12T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-10-12T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbz5w5",
-        "begin": "2014-10-12T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-12T17:35:00.000Z"
       },
       {
         "site": "pptv",
         "id": "j6mDAWnPP33gXsY",
-        "begin": "2014-10-12T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1464823",
-        "begin": "2014-10-12T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-12T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "106879"
       },
       {
-        "site": "saraba1st",
-        "id": "1047072"
-      },
-      {
         "site": "nicovideo",
         "id": "girlfriend-kari-anime",
-        "begin": "2014-10-21T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-21T03:00:00.000Z"
       }
     ]
   },
@@ -2884,55 +1572,25 @@
     "officialSite": "http://yuyuyu.tv/",
     "begin": "2014-10-16T17:19:00.000Z",
     "end": "2014-12-25T17:45:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1464812",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhbyz99",
-        "begin": "2014-10-16T19:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-16T19:50:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "109328"
       },
       {
-        "site": "saraba1st",
-        "id": "1045102"
-      },
-      {
         "site": "nicovideo",
         "id": "yuyuyu_tv",
-        "begin": "2014-10-19T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-19T13:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "4273",
-        "begin": "2014-10-15T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "95992",
+        "begin": "2014-10-15T16:00:01.000Z"
       }
     ]
   },
@@ -2948,35 +1606,20 @@
     "officialSite": "http://www.mushishi-anime.com/",
     "begin": "2014-10-18T15:30:00.000Z",
     "end": "2014-12-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/csxz",
-        "begin": "2014-10-23T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-23T20:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1715",
-        "begin": "2014-10-23T20:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-23T20:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "106207"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1010630"
       }
     ]
   },
@@ -2995,7 +1638,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/calimero/",
     "begin": "2014-10-06T22:30:00.000Z",
     "end": "2016-09-24T22:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3011,7 +1653,6 @@
     "officialSite": "http://narihero.com/",
     "begin": "2014-10-06T16:05:00.000Z",
     "end": "2014-12-22T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3034,7 +1675,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/oshiri/",
     "begin": "2014-10-06T09:25:00.000Z",
     "end": "2014-12-08T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3057,17 +1697,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cf-vanguard-g/",
     "begin": "2014-10-26T01:00:00.000Z",
     "end": "2015-10-04T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QibvFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3076,12 +1710,7 @@
       {
         "site": "nicovideo",
         "id": "cf-vanguard-g",
-        "begin": "2014-10-28T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-28T10:30:00.000Z"
       }
     ]
   },
@@ -3097,7 +1726,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/nano_invaders/index2.html",
     "begin": "2014-10-09T23:00:00.000Z",
     "end": "2015-10-03T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3118,57 +1746,31 @@
     "officialSite": "http://tenipuri.jp/",
     "begin": "2014-10-29T16:00:00.000Z",
     "end": "2015-06-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SOTQTrYcjMotqxM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5m1p",
-        "begin": "2015-07-03T05:41:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-03T05:41:18.000Z"
       },
       {
         "site": "qq",
         "id": "p/pxcpyw761v1ev03",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10012500",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "157294",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3177,12 +1779,7 @@
       {
         "site": "bilibili",
         "id": "2598",
-        "begin": "2014-10-28T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-28T16:00:00.000Z"
       }
     ]
   },
@@ -3198,17 +1795,11 @@
     "officialSite": "http://www.precure-movie.com/",
     "begin": "2014-10-11T16:00:00.000Z",
     "end": "2014-10-11T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       },
       {
         "site": "bangumi",
@@ -3217,22 +1808,7 @@
       {
         "site": "pptv",
         "id": "dtO9O6MJebcamAA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4062",
-        "begin": "2014-10-10T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3248,17 +1824,11 @@
     "officialSite": "http://www.hybridchild.jp/",
     "begin": "2014-10-29T16:00:00.000Z",
     "end": "2015-01-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "praiaIIjuXpzicfeU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3278,7 +1848,6 @@
     "officialSite": "",
     "begin": "2014-10-11T16:00:00.000Z",
     "end": "2014-10-11T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3298,17 +1867,11 @@
     "officialSite": "",
     "begin": "2014-10-03T16:00:00.000Z",
     "end": "2016-01-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "u5JibicGTKOnjbWcE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3317,12 +1880,7 @@
       {
         "site": "bilibili",
         "id": "1575",
-        "begin": "2014-10-02T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-02T16:00:00.000Z"
       }
     ]
   },
@@ -3338,31 +1896,15 @@
     "officialSite": "",
     "begin": "2014-10-17T16:00:00.000Z",
     "end": "2015-02-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "x2BMyjKYCEapJ48",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "103831"
-      },
-      {
-        "site": "bilibili",
-        "id": "4272",
-        "begin": "2014-10-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -3378,17 +1920,11 @@
     "officialSite": "",
     "begin": "2014-10-22T16:00:00.000Z",
     "end": "2014-10-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "mbqWFHziaUpDzcdk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3408,7 +1944,6 @@
     "officialSite": "http://narihero.com/",
     "begin": "2014-10-06T16:00:00.000Z",
     "end": "2014-12-22T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3417,22 +1952,12 @@
       {
         "site": "nicovideo",
         "id": "narihero",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "344",
-        "begin": "2014-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-05T16:00:00.000Z"
       }
     ]
   },
@@ -3448,7 +1973,6 @@
     "officialSite": "http://www.kuroshitsuji.tv/ova/",
     "begin": "2014-10-25T16:00:00.000Z",
     "end": "2014-11-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3457,12 +1981,7 @@
       {
         "site": "nicovideo",
         "id": "kuroshitsuji-bom",
-        "begin": "2018-06-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-06-13T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2014/11.json
+++ b/data/items/2014/11.json
@@ -12,18 +12,7 @@
     "officialSite": "",
     "begin": "2014-11-29T16:00:00.000Z",
     "end": "2014-11-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470117",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "119364"
@@ -43,17 +32,11 @@
     "officialSite": "http://animatorexpo.com",
     "begin": "2014-11-07T16:00:00.000Z",
     "end": "2015-10-09T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10006626",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -62,12 +45,7 @@
       {
         "site": "nicovideo",
         "id": "animatorexpo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -86,17 +64,11 @@
     "officialSite": "http://rakuen-tsuiho.com/",
     "begin": "2014-11-15T16:00:00.000Z",
     "end": "2014-11-15T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PiawIhu5UxAJl40s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -105,12 +77,7 @@
       {
         "site": "netflix",
         "id": "80038207",
-        "begin": "2015-06-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-01T07:00:00.000Z"
       }
     ]
   },
@@ -126,17 +93,11 @@
     "officialSite": "http://jyuza-anime.com/",
     "begin": "2014-11-28T16:00:00.000Z",
     "end": "2014-11-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JQDsatI4qOZJxy8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -156,17 +117,11 @@
     "officialSite": "",
     "begin": "2014-11-21T16:00:00.000Z",
     "end": "2015-04-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wWFLyTGXB0WoJo4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -175,12 +130,7 @@
       {
         "site": "bilibili",
         "id": "3568",
-        "begin": "2014-11-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-20T16:00:01.000Z"
       }
     ]
   },
@@ -196,7 +146,6 @@
     "officialSite": "http://zeushi-kun.jp/",
     "begin": "2014-11-29T16:00:00.000Z",
     "end": "2015-03-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -205,12 +154,7 @@
       {
         "site": "nicovideo",
         "id": "zeushi-kun",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -226,7 +170,6 @@
     "officialSite": "",
     "begin": "2014-11-17T16:00:00.000Z",
     "end": "2015-03-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -235,12 +178,7 @@
       {
         "site": "pptv",
         "id": "OBz4dt5EtPJV0zs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -252,7 +190,6 @@
     "officialSite": "",
     "begin": "2014-11-26T16:00:00.000Z",
     "end": "2014-11-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -261,22 +198,7 @@
       {
         "site": "pptv",
         "id": "1nBc2kKoGFa5N58",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "4081",
-        "begin": "2014-11-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -288,7 +210,6 @@
     "officialSite": "http://www.sonicthehedgehog.com/boom/en/",
     "begin": "2014-11-08T16:00:00.000Z",
     "end": "2015-11-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -297,12 +218,7 @@
       {
         "site": "letv",
         "id": "10008560",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -318,7 +234,6 @@
     "officialSite": "http://honeyworks.jp/release/03.html",
     "begin": "2014-11-26T16:00:00.000Z",
     "end": "2014-11-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -327,12 +242,7 @@
       {
         "site": "bilibili",
         "id": "4356",
-        "begin": "2014-11-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-11-25T16:00:01.000Z"
       }
     ]
   },
@@ -348,7 +258,6 @@
     "officialSite": "",
     "begin": "2014-11-22T16:00:00.000Z",
     "end": "2014-11-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -357,12 +266,7 @@
       {
         "site": "nicovideo",
         "id": "shingeki_movie",
-        "begin": "2018-12-27T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-27T03:00:00.000Z"
       }
     ]
   }

--- a/data/items/2014/12.json
+++ b/data/items/2014/12.json
@@ -11,35 +11,20 @@
     "officialSite": "http://www.monogatari-series.com/tsukimonogatari/",
     "begin": "2014-12-31T13:00:00.000Z",
     "end": "2014-12-31T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/dhppwy",
-        "begin": "2015-01-01T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-01T01:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "115932"
       },
       {
-        "site": "saraba1st",
-        "id": "1067041"
-      },
-      {
         "site": "nicovideo",
         "id": "tukimonogatari",
-        "begin": "2015-09-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-01T06:00:00.000Z"
       }
     ]
   },
@@ -51,57 +36,26 @@
     "officialSite": "http://ac.qq.com/event/ayakashi.html",
     "begin": "2014-12-12T12:00:00.000Z",
     "end": "2015-09-11T12:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470118",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "0XhU0jqgEE6xL5c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "o/o9b10rhvd7y5i9h",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhc233h",
-        "begin": "2014-12-12T03:55:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-12T03:55:18.000Z"
       },
       {
         "site": "mgtv",
         "id": "100159",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -125,47 +79,26 @@
     "officialSite": "http://toz.tales-ch.jp/",
     "begin": "2014-12-30T16:00:00.000Z",
     "end": "2014-12-30T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "HTgUkvpg0A5x71c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhau9sd",
-        "begin": "2016-07-31T16:00:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-31T16:00:26.000Z"
       },
       {
         "site": "letv",
         "id": "10025719",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "303219",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -174,12 +107,7 @@
       {
         "site": "bilibili",
         "id": "5939",
-        "begin": "2014-12-29T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-29T16:00:01.000Z"
       }
     ]
   },
@@ -195,27 +123,16 @@
     "officialSite": "http://www.ytv.co.jp/conan/sp2014/",
     "begin": "2014-12-26T16:00:00.000Z",
     "end": "2014-12-26T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrkrz7gc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2016/mztknjhcszaj",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -224,12 +141,7 @@
       {
         "site": "qq",
         "id": "y/ythwait80iq2294",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -245,7 +157,6 @@
     "officialSite": "",
     "begin": "2014-12-06T16:00:00.000Z",
     "end": "2014-12-06T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -265,7 +176,6 @@
     "officialSite": "http://w-witch.jp",
     "begin": "2014-12-12T16:00:00.000Z",
     "end": "2015-05-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -274,22 +184,12 @@
       {
         "site": "nicovideo",
         "id": "s-witchOVA",
-        "begin": "2016-10-11T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-11T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3844",
-        "begin": "2014-12-11T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-12-11T16:00:01.000Z"
       }
     ]
   },
@@ -305,7 +205,6 @@
     "officialSite": "http://www.aikatsu-movie.net/",
     "begin": "2014-12-13T16:00:00.000Z",
     "end": "2014-12-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -314,12 +213,7 @@
       {
         "site": "pptv",
         "id": "HQXvbdU7qiblMyjI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -335,7 +229,6 @@
     "officialSite": "http://www.yamajo-anime.com/",
     "begin": "2014-12-17T16:00:00.000Z",
     "end": "2015-05-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -344,22 +237,12 @@
       {
         "site": "pptv",
         "id": "1HBc2kKoGFa5N58",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "3586",
-        "begin": "2014-12-16T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10432",
+        "begin": "2014-12-16T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2015/01.json
+++ b/data/items/2015/01.json
@@ -11,55 +11,20 @@
     "officialSite": "http://milky-holmes.com/anime/td/",
     "begin": "2015-01-03T13:00:00.000Z",
     "end": "2015-03-28T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhaxgld",
-        "begin": "2015-01-03T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1694",
-        "begin": "2015-01-03T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470123",
-        "begin": "2015-01-03T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-03T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "113631"
       },
       {
-        "site": "saraba1st",
-        "id": "1080898"
-      },
-      {
         "site": "nicovideo",
         "id": "milky-holmes04",
-        "begin": "2015-01-07T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-07T14:30:00.000Z"
       }
     ]
   },
@@ -78,85 +43,30 @@
     "officialSite": "http://absoluteduo.com/",
     "begin": "2015-01-04T11:30:00.000Z",
     "end": "2015-03-22T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "p_w6pxA6H0c",
-        "begin": "2015-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "891372fc3ed411e4b522",
-        "begin": "2015-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1524",
-        "begin": "2015-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaxac1",
-        "begin": "2015-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007482",
-        "begin": "2015-01-05T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470155",
-        "begin": "2015-01-05T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "108757"
       },
       {
-        "site": "saraba1st",
-        "id": "1044298"
-      },
-      {
         "site": "nicovideo",
         "id": "absoluteduo",
-        "begin": "2015-01-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-08T16:00:00.000Z"
       }
     ]
   },
@@ -172,95 +82,40 @@
     "officialSite": "http://www.fal-gaku.com/",
     "begin": "2015-01-04T13:27:00.000Z",
     "end": "2015-03-22T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Oxr2dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/9tg48xlvp2rjssv",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10007745",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "33455b5a6dcf11e3a705",
-        "begin": "2014-01-06T01:55:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "VyjqLWiyiSU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2014-01-06T01:55:57.000Z"
       },
       {
         "site": "bilibili",
         "id": "1490",
-        "begin": "2015-01-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470156",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-03T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "110961"
       },
       {
-        "site": "saraba1st",
-        "id": "958301"
-      },
-      {
         "site": "nicovideo",
         "id": "falgaku-sc",
-        "begin": "2016-11-08T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-08T06:00:00.000Z"
       }
     ]
   },
@@ -276,7 +131,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/wasimo/",
     "begin": "2015-01-05T09:00:00.000Z",
     "end": "2015-03-24T09:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -285,12 +139,7 @@
       {
         "site": "bilibili",
         "id": "5911",
-        "begin": "2014-03-09T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-03-09T16:00:01.000Z"
       }
     ]
   },
@@ -309,55 +158,25 @@
     "officialSite": "http://www.yurikuma.jp/",
     "begin": "2015-01-05T15:30:00.000Z",
     "end": "2015-03-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2015/bhxfb",
-        "begin": "2015-01-05T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470128",
-        "begin": "2015-01-05T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "59825"
       },
       {
-        "site": "saraba1st",
-        "id": "1069130"
-      },
-      {
         "site": "nicovideo",
         "id": "yurikuma_anime",
-        "begin": "2015-01-15T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-15T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4216",
-        "begin": "2015-01-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-04T16:00:01.000Z"
       }
     ]
   },
@@ -373,35 +192,20 @@
     "officialSite": "http://www.tvk-yokohama.com/doamai/",
     "begin": "2015-01-05T10:55:00.000Z",
     "end": "2015-03-31T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10007888",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "uZ139V3DM3HUUro",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "116050"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1075009"
       }
     ]
   },
@@ -418,105 +222,45 @@
     "officialSite": "http://mikagesha.com/",
     "begin": "2015-01-05T17:05:00.000Z",
     "end": "2015-03-30T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "105499",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "s3GSriQOpPw",
-        "begin": "2015-01-05T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "1bac0432478911e4abda",
-        "begin": "2015-01-05T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T19:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1523",
-        "begin": "2015-01-05T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T19:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaxakd",
-        "begin": "2015-01-05T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T19:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007496",
-        "begin": "2015-01-05T19:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T19:05:00.000Z"
       },
       {
         "site": "qq",
         "id": "9/91ekf8i4watxc1p",
-        "begin": "2015-01-05T19:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470157",
-        "begin": "2015-01-05T19:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-05T19:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "109724"
       },
       {
-        "site": "saraba1st",
-        "id": "849816"
-      },
-      {
         "site": "nicovideo",
         "id": "mikagesha2",
-        "begin": "2015-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T03:00:00.000Z"
       }
     ]
   },
@@ -532,27 +276,16 @@
     "officialSite": "http://www.qtransformers.com/",
     "begin": "2015-01-06T12:55:00.000Z",
     "end": "2015-03-31T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "upp29FzCMnDTUbk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10007850",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -575,47 +308,21 @@
     "officialSite": "http://dreamcreation.co.jp/militari/",
     "begin": "2015-01-07T14:25:00.000Z",
     "end": "2015-03-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "w/w8yxncfnqnljt6b",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10007860",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "vJh08lrAMG7RT7c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1515",
-        "begin": "2015-01-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -624,12 +331,7 @@
       {
         "site": "nicovideo",
         "id": "militari",
-        "begin": "2015-01-07T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-07T12:00:00.000Z"
       }
     ]
   },
@@ -646,85 +348,35 @@
     "officialSite": "http://boueibu.com/",
     "begin": "2015-01-06T16:40:00.000Z",
     "end": "2015-03-24T17:10:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "pPX6jWIhZnI",
-        "begin": "2015-01-06T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "514b5a7259c511e4b432",
-        "begin": "2015-01-06T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-06T17:40:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhax3mh",
-        "begin": "2015-01-06T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-06T17:40:00.000Z"
       },
       {
         "site": "qq",
         "id": "v/vc71qe27w79ma3c",
-        "begin": "2015-01-06T17:40:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-06T17:40:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1520",
-        "begin": "2015-01-06T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470137",
-        "begin": "2015-01-06T17:40:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-06T17:40:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "114394"
       },
       {
-        "site": "saraba1st",
-        "id": "1072199"
-      },
-      {
         "site": "nicovideo",
         "id": "boueibu",
-        "begin": "2015-01-10T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T13:30:00.000Z"
       }
     ]
   },
@@ -743,35 +395,15 @@
     "officialSite": "http://kancolle-anime.jp/",
     "begin": "2015-01-07T16:05:00.000Z",
     "end": "2015-03-25T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470133",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "84386"
       },
       {
-        "site": "saraba1st",
-        "id": "1009008"
-      },
-      {
         "site": "nicovideo",
         "id": "kancolle-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -790,65 +422,30 @@
     "officialSite": "http://anime-shinmaimaou.com/",
     "begin": "2015-01-07T16:35:00.000Z",
     "end": "2015-03-25T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhawvm1",
-        "begin": "2015-01-07T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-01-07T18:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007486",
-        "begin": "2015-01-07T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-01-07T18:05:00.000Z"
       },
       {
         "site": "qq",
         "id": "7/70zp9wog1azxki9",
-        "begin": "2015-01-07T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470125",
-        "begin": "2015-01-07T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-07T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100205"
       },
       {
-        "site": "saraba1st",
-        "id": "1047900"
-      },
-      {
         "site": "bilibili",
         "id": "6286",
-        "begin": "2015-01-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-06T16:00:01.000Z"
       }
     ]
   },
@@ -867,65 +464,25 @@
     "officialSite": "http://www.saenai.tv/",
     "begin": "2015-01-08T15:50:00.000Z",
     "end": "2015-03-26T18:34:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "MC8VIcj1lSI",
-        "begin": "2015-01-08T17:20:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "090ec930b26611e3a705",
-        "begin": "2015-01-08T17:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-08T17:20:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhawxqd",
-        "begin": "2015-01-08T17:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-08T17:20:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1512",
-        "begin": "2015-01-08T17:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470120",
-        "begin": "2015-01-08T17:20:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-08T17:20:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100403"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1075666"
       }
     ]
   },
@@ -944,25 +501,15 @@
     "officialSite": "http://www.marv.jp/special/tokyoghoul/",
     "begin": "2015-01-08T15:00:00.000Z",
     "end": "2015-03-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "115292"
       },
       {
-        "site": "saraba1st",
-        "id": "1087847"
-      },
-      {
         "site": "nicovideo",
         "id": "tokyoghoul_rootA",
-        "begin": "2015-01-14T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-14T15:30:00.000Z"
       }
     ]
   },
@@ -978,37 +525,16 @@
     "officialSite": "http://ketsuekigatakun.com/",
     "begin": "2015-01-08T12:55:00.000Z",
     "end": "2015-03-26T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "9/9wq4zk57yyxkf5l",
-        "begin": "2015-01-09T03:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1519",
-        "begin": "2015-01-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470161",
-        "begin": "2015-01-09T03:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T03:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1017,12 +543,7 @@
       {
         "site": "nicovideo",
         "id": "ketsuekigata-kun2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1041,27 +562,16 @@
     "officialSite": "http://www.pankis.net/",
     "begin": "2015-01-08T14:54:00.000Z",
     "end": "2015-06-18T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10007889",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "NBr2dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1070,22 +580,12 @@
       {
         "site": "nicovideo",
         "id": "pankis",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1698",
-        "begin": "2015-01-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -1103,55 +603,25 @@
     "officialSite": "http://fafner-exodus.jp",
     "begin": "2015-01-08T17:34:00.000Z",
     "end": "2015-04-02T17:59:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhax0et",
-        "begin": "2015-01-08T18:04:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-08T18:04:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4108",
-        "begin": "2015-01-08T18:04:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470131",
-        "begin": "2015-01-08T18:04:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-08T18:04:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "60901"
       },
       {
-        "site": "saraba1st",
-        "id": "905127"
-      },
-      {
         "site": "nicovideo",
         "id": "fafner-exodus",
-        "begin": "2011-12-02T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-12-02T06:00:00.000Z"
       }
     ]
   },
@@ -1170,115 +640,50 @@
     "officialSite": "http://imas-cinderella.com/",
     "begin": "2015-01-09T15:00:00.000Z",
     "end": "2015-04-10T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "kankan",
-        "id": "87458",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "mgtv",
         "id": "291091",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay5rp",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "w/wgzklo5zkrgalda",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "UfPdW8Mpmdc6uCA",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007495",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "qgdKuHlPg9g",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-01-09T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "1e13314abec311e38b3f",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1509",
-        "begin": "2015-01-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "101399"
       },
       {
-        "site": "saraba1st",
-        "id": "1059367"
-      },
-      {
         "site": "nicovideo",
         "id": "imas-cinderella",
-        "begin": "2015-01-12T12:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-12T12:30:00.000Z"
       }
     ]
   },
@@ -1297,85 +702,35 @@
     "officialSite": "http://www.tbs.co.jp/anime/koufuku_g/",
     "begin": "2015-01-08T17:01:00.000Z",
     "end": "2015-03-26T17:59:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "mDLBXR-RtX4",
-        "begin": "2015-01-09T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "d92606e290a511e4b2ad",
-        "begin": "2015-01-09T00:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T00:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "d/df4xtlcgfw0ka3y",
-        "begin": "2015-01-09T00:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-01-09T00:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2569",
-        "begin": "2015-01-09T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T00:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhax0m9",
-        "begin": "2015-01-09T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470160",
-        "begin": "2015-01-09T00:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T00:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "105969"
       },
       {
-        "site": "saraba1st",
-        "id": "1047525"
-      },
-      {
         "site": "nicovideo",
         "id": "koufuku_g",
-        "begin": "2015-01-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-13T03:00:00.000Z"
       }
     ]
   },
@@ -1391,45 +746,20 @@
     "officialSite": "http://www.tbs.co.jp/anime/fafnir/",
     "begin": "2015-01-08T17:31:00.000Z",
     "end": "2015-03-26T18:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zGhEwiaqQAD6hH4c",
-        "begin": "2015-01-09T00:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1511",
-        "begin": "2015-01-09T00:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-09T00:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "106981"
       },
       {
-        "site": "saraba1st",
-        "id": "1060396"
-      },
-      {
         "site": "nicovideo",
         "id": "fafnir",
-        "begin": "2015-01-12T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-12T13:30:00.000Z"
       }
     ]
   },
@@ -1448,27 +778,16 @@
     "officialSite": "http://jojo-animation.com/sc/",
     "begin": "2015-01-09T15:30:00.000Z",
     "end": "2015-06-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "631X1T2jE1G0Mpo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb0qs9",
-        "begin": "2015-03-11T14:30:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-11T14:30:16.000Z"
       },
       {
         "site": "bangumi",
@@ -1489,75 +808,30 @@
     "officialSite": "http://www.dogdays.tv/",
     "begin": "2015-01-10T15:30:00.000Z",
     "end": "2015-03-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "Gy9E2vV4e18",
-        "begin": "2015-01-15T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "f7651dc2599c11e4b522",
-        "begin": "2015-01-15T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-15T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay55h",
-        "begin": "2015-01-15T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-15T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "i/i2pfes4ebq4fapc",
-        "begin": "2015-01-15T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-15T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1633",
-        "begin": "2015-01-15T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470122",
-        "begin": "2015-01-15T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-15T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "54942"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1048989"
       }
     ]
   },
@@ -1574,95 +848,40 @@
     "officialSite": "http://www.durarara.com/",
     "begin": "2015-01-10T14:30:00.000Z",
     "end": "2015-03-28T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "Se7oGWDr_GA",
-        "begin": "2015-01-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "2c9c7552acd811e38b3f",
-        "begin": "2015-01-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T15:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "4/4gmobofw9fltve9",
-        "begin": "2015-01-10T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay53x",
-        "begin": "2015-01-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1505",
-        "begin": "2015-01-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470124",
-        "begin": "2015-01-10T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "99941"
       },
       {
-        "site": "saraba1st",
-        "id": "1047071"
-      },
-      {
         "site": "nicovideo",
         "id": "durarara02",
-        "begin": "2015-01-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-15T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80040119",
-        "begin": "2015-10-09T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T07:00:00.000Z"
       }
     ]
   },
@@ -1681,35 +900,15 @@
     "officialSite": "http://www.ansatsu-anime.com/",
     "begin": "2015-01-09T17:00:00.000Z",
     "end": "2015-06-19T16:25:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "暗杀教室",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "106818"
       },
       {
-        "site": "saraba1st",
-        "id": "1035553"
-      },
-      {
         "site": "iqiyi",
         "id": "a_19rrhay5ht",
-        "begin": "2015-04-10T09:20:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T09:20:40.000Z"
       }
     ]
   },
@@ -1729,27 +928,11 @@
     "officialSite": "http://www.aldnoahzero.com/",
     "begin": "2015-01-10T15:00:00.000Z",
     "end": "2015-03-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhay589",
-        "begin": "2015-01-15T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470135",
-        "begin": "2015-01-15T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-15T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1758,12 +941,7 @@
       {
         "site": "netflix",
         "id": "80040104",
-        "begin": "2015-10-09T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T07:00:00.000Z"
       }
     ]
   },
@@ -1782,55 +960,20 @@
     "officialSite": "http://www.starchild.co.jp/special/shonen-hollywood-anime/",
     "begin": "2015-01-10T11:30:00.000Z",
     "end": "2015-04-04T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "mdEeE4selJA",
-        "begin": "2015-01-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "9029aaa259cd11e4a080",
-        "begin": "2015-01-10T15:00:00.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470138",
-        "begin": "2015-01-10T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "114488"
       },
       {
-        "site": "saraba1st",
-        "id": "1110036"
-      },
-      {
         "site": "nicovideo",
         "id": "shonen-hollywood02",
-        "begin": "2015-01-18T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-18T14:00:00.000Z"
       }
     ]
   },
@@ -1849,45 +992,20 @@
     "officialSite": "http://www.vap.co.jp/deathparade/",
     "begin": "2015-01-09T16:58:00.000Z",
     "end": "2015-03-27T17:43:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470162",
-        "begin": "2015-01-09T20:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhaxopx",
-        "begin": "2015-01-09T20:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-01-09T20:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "116742"
       },
       {
-        "site": "saraba1st",
-        "id": "1070060"
-      },
-      {
         "site": "nicovideo",
         "id": "deathparade",
-        "begin": "2015-01-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T15:00:00.000Z"
       }
     ]
   },
@@ -1906,75 +1024,30 @@
     "officialSite": "http://www.junketsu-maria.tv/",
     "begin": "2015-01-11T13:30:00.000Z",
     "end": "2015-03-29T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "QYODtlZ-1EY",
-        "begin": "2015-01-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "8a0d8e1c59b511e4b2ad",
-        "begin": "2015-01-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007476",
-        "begin": "2015-01-11T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay4hp",
-        "begin": "2015-01-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1491",
-        "begin": "2015-01-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470130",
-        "begin": "2015-01-11T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "84801"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1053508"
       }
     ]
   },
@@ -1991,107 +1064,41 @@
     "officialSite": "http://www.kurobas.com/",
     "begin": "2015-01-10T17:58:00.000Z",
     "end": "2015-06-30T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "109729",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "otzt4Efipjo",
-        "begin": "2015-01-10T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "4d028dc407e411e48b3f",
-        "begin": "2015-01-10T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T21:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay4z1",
-        "begin": "2015-01-10T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T21:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007490",
-        "begin": "2015-01-10T21:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T21:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "3/3th0scjmjz8bz8i",
-        "begin": "2015-01-10T21:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T21:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "u5t181vBMWicSULg",
-        "begin": "2015-01-10T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "87456",
-        "begin": "2015-01-10T21:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T21:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1626",
-        "begin": "2015-01-10T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "黑子的篮球%20第三季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-01-10T21:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2117,65 +1124,25 @@
     "officialSite": "http://rollinggirls.com/",
     "begin": "2015-01-10T16:58:00.000Z",
     "end": "2015-03-28T17:28:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "kJVciY-eLyA",
-        "begin": "2015-01-10T17:58:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "06ef4ef059ae11e4b522",
-        "begin": "2015-01-10T17:58:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T17:58:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay4vl",
-        "begin": "2015-01-10T17:58:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470126",
-        "begin": "2015-01-10T17:58:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-10T17:58:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "110600"
       },
       {
-        "site": "saraba1st",
-        "id": "1047621"
-      },
-      {
         "site": "nicovideo",
         "id": "rollinggirls",
-        "begin": "2015-01-13T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-13T14:30:00.000Z"
       }
     ]
   },
@@ -2191,115 +1158,45 @@
     "officialSite": "http://yatterman.jp/",
     "begin": "2015-01-11T13:00:00.000Z",
     "end": "2015-03-29T13:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "292440",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "uaWpGglH27U",
-        "begin": "2015-01-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "d10324de8f3a11e4a080",
-        "begin": "2015-01-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay4qp",
-        "begin": "2015-01-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T15:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007473",
-        "begin": "2015-01-11T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T15:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "3/3udwgbjzd6l7ruw",
-        "begin": "2015-01-11T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "87476",
-        "begin": "2015-01-11T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1492",
-        "begin": "2015-01-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470149",
-        "begin": "2015-01-11T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "116034"
       },
       {
-        "site": "saraba1st",
-        "id": "1068878"
-      },
-      {
         "site": "nicovideo",
         "id": "yatterman",
-        "begin": "2015-01-20T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-20T16:00:00.000Z"
       }
     ]
   },
@@ -2315,95 +1212,35 @@
     "officialSite": "http://warubure-anime.com/",
     "begin": "2015-01-11T16:05:00.000Z",
     "end": "2015-03-29T16:55:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "eFktdfkfKZc",
-        "begin": "2015-01-11T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "7ff0045e59c011e4b432",
-        "begin": "2015-01-11T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T17:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay4m1",
-        "begin": "2015-01-11T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T17:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007478",
-        "begin": "2015-01-11T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T17:05:00.000Z"
       },
       {
         "site": "qq",
         "id": "z/zq603skcxexud1x",
-        "begin": "2015-01-11T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1488",
-        "begin": "2015-01-11T17:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470134",
-        "begin": "2015-01-11T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "96600"
       },
       {
-        "site": "saraba1st",
-        "id": "1072613"
-      },
-      {
         "site": "nicovideo",
         "id": "warubure-anime",
-        "begin": "2015-01-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-14T15:00:00.000Z"
       }
     ]
   },
@@ -2419,105 +1256,45 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/sengokumusou/",
     "begin": "2015-01-11T16:35:00.000Z",
     "end": "2015-03-29T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhay4c5",
-        "begin": "2015-01-11T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T18:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "PRj0ctpAsO5Rzzc",
-        "begin": "2015-01-11T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T18:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "m/mhmtum2yxj7j2ss",
-        "begin": "2015-01-11T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T18:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007480",
-        "begin": "2015-01-11T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "f7OqHM6hee4",
-        "begin": "2015-01-11T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-01-11T18:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "8a899d3e960c11e4b2ad",
-        "begin": "2015-01-11T18:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "87459",
-        "begin": "2015-01-11T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T18:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1658",
-        "begin": "2015-01-11T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-11T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "117029"
       },
       {
-        "site": "saraba1st",
-        "id": "1071535"
-      },
-      {
         "site": "nicovideo",
         "id": "sengokumusou",
-        "begin": "2015-01-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-17T15:00:00.000Z"
       }
     ]
   },
@@ -2536,35 +1313,20 @@
     "officialSite": "http://sailormoon-official.com/animation/",
     "begin": "2015-01-17T10:00:00.000Z",
     "end": "2015-07-18T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2014/msnzsc",
-        "begin": "2015-01-17T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-17T12:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb12nd",
-        "begin": "2015-01-17T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-17T12:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "147686"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1030124"
       }
     ]
   },
@@ -2581,55 +1343,25 @@
     "officialSite": "http://isuca.net/",
     "begin": "2015-01-23T16:35:00.000Z",
     "end": "2015-03-27T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10007487",
-        "begin": "2015-01-23T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-23T18:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1527",
-        "begin": "2015-01-23T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470136",
-        "begin": "2015-01-23T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-23T18:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhavmqx",
-        "begin": "2015-01-23T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-23T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "106292"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1053410"
       }
     ]
   },
@@ -2649,35 +1381,15 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/princess_precure",
     "begin": "2015-01-31T23:30:00.000Z",
     "end": "2016-01-31T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhawapx",
-        "begin": "2015-02-14T16:11:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Go!%20Princess%20光之美少女",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-02-14T16:11:15.000Z"
       },
       {
         "site": "bangumi",
         "id": "119279"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1069504"
       }
     ]
   },
@@ -2693,7 +1405,6 @@
     "officialSite": "http://twin-angel.com/media.html",
     "begin": "2015-01-30T16:00:00.000Z",
     "end": "2015-01-30T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2713,7 +1424,6 @@
     "officialSite": "",
     "begin": "2015-01-07T16:00:00.000Z",
     "end": "2015-01-07T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2722,22 +1432,12 @@
       {
         "site": "pptv",
         "id": "SezIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3502",
-        "begin": "2015-01-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-01-06T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2015/02.json
+++ b/data/items/2015/02.json
@@ -11,65 +11,25 @@
     "officialSite": "http://mental-anime.jp/",
     "begin": "2015-02-12T20:00:00.000Z",
     "end": "2015-06-25T20:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "p/p9g77zamk0kvlka",
-        "begin": "2015-02-12T20:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-02-12T20:35:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1528",
-        "begin": "2015-02-12T20:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470154",
-        "begin": "2015-02-12T20:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "动画心疗系",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-02-12T20:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "115338"
       },
       {
-        "site": "saraba1st",
-        "id": "1096724"
-      },
-      {
         "site": "nicovideo",
         "id": "mental-anime",
-        "begin": "2015-02-12T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-02-12T20:00:00.000Z"
       }
     ]
   },
@@ -85,17 +45,11 @@
     "officialSite": "http://www.gundam-the-origin.net/",
     "begin": "2015-02-28T16:00:00.000Z",
     "end": "2018-05-05T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "samDAWnPP33gXsY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -115,17 +69,11 @@
     "officialSite": "http://hana-alice.jp/",
     "begin": "2015-02-20T16:00:00.000Z",
     "end": "2015-02-20T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "OhXicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -145,17 +93,11 @@
     "officialSite": "http://yuruyuri.com/",
     "begin": "2015-02-18T16:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "LgTwbtY8rOpNyzM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -164,12 +106,7 @@
       {
         "site": "nicovideo",
         "id": "nachuyachumi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -185,17 +122,11 @@
     "officialSite": "http://musani.jp/works/index.html",
     "begin": "2015-02-25T16:00:00.000Z",
     "end": "2015-02-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PRP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -215,7 +146,6 @@
     "officialSite": "",
     "begin": "2015-02-23T16:00:00.000Z",
     "end": "2017-03-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -224,12 +154,7 @@
       {
         "site": "pptv",
         "id": "hqCMCnLYSIbpZ88",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -245,7 +170,6 @@
     "officialSite": "",
     "begin": "2015-02-26T16:00:00.000Z",
     "end": "2015-02-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -254,12 +178,7 @@
       {
         "site": "pptv",
         "id": "WvDcWsIomNY5tx8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2015/03.json
+++ b/data/items/2015/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.ntv.co.jp/funaanime/",
     "begin": "2015-03-29T23:00:00.000Z",
     "end": "2016-03-29T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "funaanime",
-        "begin": "2015-04-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T03:00:00.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/miraclecatdan/",
     "begin": "2015-03-31T09:45:00.000Z",
     "end": "2016-02-23T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -49,13 +42,8 @@
       },
       {
         "site": "bilibili",
-        "id": "24969",
-        "begin": "2015-03-30T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "113432",
+        "begin": "2015-03-30T16:00:01.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "http://www.dlife.jp/lineup/disney/tsumtsum/",
     "begin": "2015-03-22T09:00:00.000Z",
     "end": "2015-11-01T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -87,7 +74,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/wasimo/",
     "begin": "2015-03-30T09:00:00.000Z",
     "end": "2015-08-25T09:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -103,87 +89,41 @@
     "officialSite": "http://ac.qq.com/event/yzdmx201510/index.html",
     "begin": "2015-03-31T12:00:00.000Z",
     "end": "2015-10-30T12:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470273",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "2542",
-        "begin": "2015-02-28T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-02-28T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "bsWvLZX7a6kMiavI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "t/tjcnpm8ju18qojf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhayff9",
-        "begin": "2015-03-31T04:21:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-31T04:21:33.000Z"
       },
       {
         "site": "letv",
         "id": "10008864",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2015/yzdmx",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "157132",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -203,27 +143,16 @@
     "officialSite": "http://www.precure-allstars.com/",
     "begin": "2015-03-14T16:00:00.000Z",
     "end": "2015-03-14T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "jZ9591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       },
       {
         "site": "bangumi",
@@ -243,17 +172,11 @@
     "officialSite": "http://doraeiga.com/2015/",
     "begin": "2015-03-07T16:00:00.000Z",
     "end": "2015-03-07T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10011871",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -262,12 +185,7 @@
       {
         "site": "bilibili",
         "id": "3902",
-        "begin": "2015-03-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-03-06T16:00:01.000Z"
       }
     ]
   },
@@ -283,17 +201,11 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2015-03-30T08:35:00.000Z",
     "end": "2016-01-03T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VicvVU7shkc8ysBg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -313,17 +225,11 @@
     "officialSite": "http://animemirai.jp/ongakushoujo.html",
     "begin": "2015-03-22T16:00:00.000Z",
     "end": "2015-03-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QibjEQqoQgL4hnwc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -343,17 +249,11 @@
     "officialSite": "http://animemirai.jp/akino.html",
     "begin": "2015-03-22T16:00:00.000Z",
     "end": "2015-03-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QibjEQqoQgL4hnwc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -373,17 +273,11 @@
     "officialSite": "http://animemirai.jp/happy.html",
     "begin": "2015-03-22T16:00:00.000Z",
     "end": "2015-03-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QibjEQqoQgL4hnwc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -403,17 +297,11 @@
     "officialSite": "http://animemirai.jp/kumi.html",
     "begin": "2015-03-22T16:00:00.000Z",
     "end": "2015-03-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "QibjEQqoQgL4hnwc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -433,7 +321,6 @@
     "officialSite": "http://www.knightsofsidonia.com/",
     "begin": "2015-03-06T16:00:00.000Z",
     "end": "2015-03-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -442,22 +329,12 @@
       {
         "site": "nicovideo",
         "id": "movie-sidonia",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "UPbiaYMguntwicvSU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -473,7 +350,6 @@
     "officialSite": "",
     "begin": "2015-03-04T16:00:00.000Z",
     "end": "2015-03-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -482,12 +358,7 @@
       {
         "site": "pptv",
         "id": "iaJ56ibGDGNnTXVb0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2015/04.json
+++ b/data/items/2015/04.json
@@ -16,27 +16,11 @@
     "officialSite": "http://www.sunrise-inc.co.jp/battlespirits7/",
     "begin": "2015-04-01T09:30:00.000Z",
     "end": "2016-03-30T09:57:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "upB8ibmLIOHbZV78",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "战魂王：烈火斗魂",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -56,105 +40,40 @@
     "officialSite": "http://www.tbs.co.jp/anime/oregairu/",
     "begin": "2015-04-02T16:51:00.000Z",
     "end": "2015-06-25T17:18:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "1540",
-        "begin": "2015-04-03T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T02:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "TibXPTbUbia8ksqhI",
-        "begin": "2015-04-03T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-04-03T02:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "d569d83ace9511e3a705",
-        "begin": "2015-04-03T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "hdhCMzUcgYo",
-        "begin": "2015-04-03T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470225",
-        "begin": "2015-04-03T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaylad",
-        "begin": "2015-04-03T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "我的青春恋爱物语果然有问题%E3%80%82第二季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-03T02:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "102134"
       },
       {
-        "site": "saraba1st",
-        "id": "1108194"
-      },
-      {
         "site": "nicovideo",
         "id": "oregairu2",
-        "begin": "2015-04-20T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-20T11:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "m/mq4at8jbjx8zd1k",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -174,85 +93,40 @@
     "officialSite": "http://www.tbs.co.jp/anime/re-kan/",
     "begin": "2015-04-02T17:21:00.000Z",
     "end": "2015-06-25T17:48:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrharzr1",
-        "begin": "2016-07-13T10:23:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-13T10:23:25.000Z"
       },
       {
         "site": "letv",
         "id": "10008917",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ReFClUjqXTk",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "92c6dbead1f011e4b522",
-        "begin": "2015-04-22T13:07:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-22T13:07:35.000Z"
       },
       {
         "site": "pptv",
         "id": "Rib3HRa0Tg8Ekogo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "110568"
       },
       {
-        "site": "saraba1st",
-        "id": "1079762"
-      },
-      {
         "site": "nicovideo",
         "id": "re-kan",
-        "begin": "2015-04-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-13T15:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "1560",
-        "begin": "2015-04-01T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "60212",
+        "begin": "2015-04-01T16:00:01.000Z"
       }
     ]
   },
@@ -271,65 +145,25 @@
     "officialSite": "http://nanoha-vivid.tv/",
     "begin": "2015-04-03T13:30:00.000Z",
     "end": "2015-06-19T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "1538",
-        "begin": "2015-04-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "J8Qhnbr20CQ",
-        "begin": "2015-04-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-04-03T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "9677b238d1f411e4b432",
-        "begin": "2015-04-03T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "魔法少女奈叶%20ViVid",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-03T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "110867"
       },
       {
-        "site": "saraba1st",
-        "id": "1109622"
-      },
-      {
         "site": "iqiyi",
         "id": "a_19rrh8hjed",
-        "begin": "2017-05-05T08:43:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-05-05T08:43:42.000Z"
       }
     ]
   },
@@ -345,87 +179,31 @@
     "officialSite": "http://www.dreamcreation.co.jp/danna/",
     "begin": "2015-04-02T16:00:00.000Z",
     "end": "2015-06-25T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "109630",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1655",
-        "begin": "2015-04-02T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-02T17:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "sZeBic2fNPXveXMQ",
-        "begin": "2015-04-02T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-02T17:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008623",
-        "begin": "2015-04-02T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-02T17:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "95416adcd1ed11e4a080",
-        "begin": "2015-04-02T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "tV7IdRONs7Y",
-        "begin": "2015-04-02T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470224",
-        "begin": "2015-04-02T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "关于完全听不懂老公在说什么的事%20第二季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-02T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -434,12 +212,7 @@
       {
         "site": "nicovideo",
         "id": "danna02_anime",
-        "begin": "2015-04-07T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T12:00:00.000Z"
       }
     ]
   },
@@ -460,95 +233,35 @@
     "officialSite": "http://www.yukichan-anime.com/",
     "begin": "2015-04-03T16:40:00.000Z",
     "end": "2015-07-17T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "ElqA9e3gel0",
-        "begin": "2015-04-03T18:10:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "3eebb5a2d1f711e4abda",
-        "begin": "2015-04-03T18:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T18:10:00.000Z"
       },
       {
         "site": "qq",
         "id": "l/l2h6j510vy2r11e",
-        "begin": "2015-04-03T18:10:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T18:10:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008624",
-        "begin": "2015-04-03T18:10:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T18:10:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1558",
-        "begin": "2015-04-03T18:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470229",
-        "begin": "2015-04-03T18:10:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "小长门有希的消失",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-03T18:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "90815"
       },
       {
-        "site": "saraba1st",
-        "id": "1097771"
-      },
-      {
         "site": "nicovideo",
         "id": "yukichan_anime",
-        "begin": "2015-04-23T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-23T03:00:00.000Z"
       }
     ]
   },
@@ -564,35 +277,15 @@
     "officialSite": "http://www.haremking.tv/",
     "begin": "2015-04-04T14:00:00.000Z",
     "end": "2015-06-20T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "恶魔高校%20D×D%20BorN",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "106212"
       },
       {
-        "site": "saraba1st",
-        "id": "1079903"
-      },
-      {
         "site": "nicovideo",
         "id": "haremking3",
-        "begin": "2015-04-16T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-16T16:30:00.000Z"
       }
     ]
   },
@@ -609,115 +302,45 @@
     "officialSite": "http://www.fate-sn.com/ubw/",
     "begin": "2015-04-04T15:00:00.000Z",
     "end": "2015-06-27T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "geFp2M0qg4A",
-        "begin": "2015-04-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "10005152",
-        "begin": "2015-04-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "5/54v59r074ncc1kq",
-        "begin": "2015-04-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-09T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1587",
-        "begin": "2015-04-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay91x",
-        "begin": "2015-04-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "dde7f9fa3d6811e4a080",
-        "begin": "2015-04-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470239",
-        "begin": "2015-04-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Fate/stay%20night%20UBW",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-09T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "109386"
       },
       {
-        "site": "saraba1st",
-        "id": "1062472"
-      },
-      {
         "site": "nicovideo",
         "id": "fate-sn2",
-        "begin": "2014-10-04T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-10-04T17:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80040330",
-        "begin": "2015-08-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-01T07:00:00.000Z"
       }
     ]
   },
@@ -736,115 +359,45 @@
     "officialSite": "http://owarino-seraph.jp/",
     "begin": "2015-04-04T13:00:00.000Z",
     "end": "2015-06-20T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "109724",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "oGlXUbsk0Hw",
-        "begin": "2015-04-04T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "7b76708ad29111e49e2a",
-        "begin": "2015-04-04T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T14:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "i/izsh50sm4ysz5j5",
-        "begin": "2015-04-04T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1555",
-        "begin": "2015-04-04T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T14:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008808",
-        "begin": "2015-04-04T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T14:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "u5F7ibWHHN3XYVr4",
-        "begin": "2015-04-04T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470236",
-        "begin": "2015-04-04T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "终结的炽天使",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-04T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "112151"
       },
       {
-        "site": "saraba1st",
-        "id": "1052660"
-      },
-      {
         "site": "nicovideo",
         "id": "owarino_seraph",
-        "begin": "2015-04-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-06T16:00:00.000Z"
       }
     ]
   },
@@ -863,95 +416,35 @@
     "officialSite": "http://www.plastic-memories.jp/",
     "begin": "2015-04-04T15:30:00.000Z",
     "end": "2015-06-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470240",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "RevFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "1aSNea7HH_E",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "15ef07b4d29011e4b522",
-        "begin": "2015-04-22T08:19:51.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-22T08:19:51.000Z"
       },
       {
         "site": "letv",
         "id": "10008948",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1552",
-        "begin": "2015-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "可塑性记忆",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-03T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "114685"
       },
       {
-        "site": "saraba1st",
-        "id": "1060762"
-      },
-      {
         "site": "nicovideo",
         "id": "plastic_memories",
-        "begin": "2015-04-09T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T13:30:00.000Z"
       }
     ]
   },
@@ -968,75 +461,35 @@
     "officialSite": "http://danmachi.com/",
     "begin": "2015-04-03T16:05:00.000Z",
     "end": "2015-06-26T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UicnTUbkfj80wrhY",
-        "begin": "2015-04-03T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T16:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "f16e24acd1f811e4a080",
-        "begin": "2015-04-03T16:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "在地下城尋求邂逅是否搞错了什么",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-03T16:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "116287"
       },
       {
-        "site": "saraba1st",
-        "id": "1085164"
-      },
-      {
         "site": "nicovideo",
         "id": "danmachi",
-        "begin": "2015-04-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhfl8wd",
-        "begin": "2018-04-30T16:00:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-30T16:00:17.000Z"
       },
       {
         "site": "netflix",
         "id": "80185873",
-        "begin": "2019-03-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-03-14T16:00:00.000Z"
       }
     ]
   },
@@ -1055,95 +508,40 @@
     "officialSite": "http://www.shokugekinosoma.com/",
     "begin": "2015-04-03T17:25:00.000Z",
     "end": "2015-09-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "109719",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1559",
-        "begin": "2015-04-03T21:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T21:10:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay9y1",
-        "begin": "2015-04-03T21:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T21:10:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008945",
-        "begin": "2015-04-03T21:10:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T21:10:00.000Z"
       },
       {
         "site": "pptv",
         "id": "gqKODHTaSojradE",
-        "begin": "2015-04-03T21:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470280",
-        "begin": "2015-04-03T21:10:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "食戟之灵",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-03T21:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "116461"
       },
       {
-        "site": "saraba1st",
-        "id": "1073181"
-      },
-      {
         "site": "qq",
         "id": "c/ci8ts7nhtkjpai2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1163,65 +561,20 @@
     "officialSite": "http://anime-rinne.com/",
     "begin": "2015-04-04T08:30:00.000Z",
     "end": "2015-09-19T08:55:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470234",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "08c88ac2d1fc11e4b692",
-        "begin": "2015-04-06T13:18:29.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "XZptOiXSN6Y",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "境界之轮回",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-06T13:18:29.000Z"
       },
       {
         "site": "bangumi",
         "id": "117731"
       },
       {
-        "site": "saraba1st",
-        "id": "1074549"
-      },
-      {
         "site": "nicovideo",
         "id": "rinne_anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1240,95 +593,30 @@
     "officialSite": "http://www.guns-project.jp/",
     "begin": "2015-04-04T14:30:00.000Z",
     "end": "2015-06-20T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "KyDPNt8PGn4",
-        "begin": "2015-04-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "28c17ee4d20411e4b522",
-        "begin": "2015-04-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T15:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008462",
-        "begin": "2015-04-04T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay9ld",
-        "begin": "2015-04-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1554",
-        "begin": "2015-04-04T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470238",
-        "begin": "2015-04-04T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "枪神斯托拉塔斯",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-04T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "119677"
       },
       {
-        "site": "saraba1st",
-        "id": "1109839"
-      },
-      {
         "site": "nicovideo",
         "id": "guns_project",
-        "begin": "2015-04-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T15:00:00.000Z"
       }
     ]
   },
@@ -1347,25 +635,15 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pripara/",
     "begin": "2015-04-04T01:00:00.000Z",
     "end": "2016-03-28T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "120186"
       },
       {
-        "site": "saraba1st",
-        "id": "1006534"
-      },
-      {
         "site": "nicovideo",
         "id": "pripara02",
-        "begin": "2015-04-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-16T15:00:00.000Z"
       }
     ]
   },
@@ -1381,67 +659,21 @@
     "officialSite": "http://www.cucuri.co.jp/holmes.html",
     "begin": "2015-04-03T16:55:00.000Z",
     "end": "2015-06-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "W7crDVrgjUU",
-        "begin": "2015-04-03T17:55:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "01bc34c0d1fe11e4a080",
-        "begin": "2015-04-03T17:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T17:55:00.000Z"
       },
       {
         "site": "qq",
         "id": "z/zkzeoy0ybuydkp7",
-        "begin": "2015-04-03T17:55:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T17:55:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1557",
-        "begin": "2015-04-03T17:55:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470230",
-        "begin": "2015-04-03T17:55:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "吸血鬼福尔摩斯",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-03T17:55:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1450,12 +682,7 @@
       {
         "site": "nicovideo",
         "id": "vampire-holmes",
-        "begin": "2015-04-03T16:55:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T16:55:00.000Z"
       }
     ]
   },
@@ -1475,85 +702,30 @@
     "officialSite": "http://www.ytv.co.jp/denpa/",
     "begin": "2015-04-04T08:30:00.000Z",
     "end": "2015-09-26T09:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "IaqccpIZFkw",
-        "begin": "2015-04-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "f9733d54d20211e4b522",
-        "begin": "2015-04-04T11:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T11:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008627",
-        "begin": "2015-04-04T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T11:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay9ot",
-        "begin": "2015-04-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T11:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "r4Vv7VW7K2nMSrI",
-        "begin": "2015-04-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470235",
-        "begin": "2015-04-04T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "电波教师",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-04T11:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "122606"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1090714"
       }
     ]
   },
@@ -1573,57 +745,21 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/jewelpet7/",
     "begin": "2015-04-03T22:00:00.000Z",
     "end": "2015-12-26T01:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "12db35ccd50e11e4b522",
-        "begin": "2015-04-22T05:20:27.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-22T05:20:27.000Z"
       },
       {
         "site": "letv",
         "id": "10008950",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "4f9dl2adFPg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "3nVf3UWrG1m8OqI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "1671",
-        "begin": "2015-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1644,85 +780,35 @@
     "officialSite": "http://archive-r.utapri.tv/",
     "begin": "2015-04-04T16:00:00.000Z",
     "end": "2015-06-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "XuEeF0KkEWc",
-        "begin": "2015-04-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "efa80170d20611e4b432",
-        "begin": "2015-04-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "9/9ni9yqck4tdy63j",
-        "begin": "2015-04-04T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1563",
-        "begin": "2015-04-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470241",
-        "begin": "2015-04-04T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008836",
-        "begin": "2015-04-04T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "89488"
       },
       {
-        "site": "saraba1st",
-        "id": "1072239"
-      },
-      {
         "site": "nicovideo",
         "id": "utapri3",
-        "begin": "2015-04-07T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T14:30:00.000Z"
       }
     ]
   },
@@ -1739,75 +825,25 @@
     "officialSite": "http://www.kinmosa.com/",
     "begin": "2015-04-05T15:00:00.000Z",
     "end": "2015-06-21T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "SfWjXGa2scU",
-        "begin": "2015-04-06T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "bd48f46ece9711e38b3f",
-        "begin": "2015-04-06T18:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-06T18:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3491",
-        "begin": "2015-04-06T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470248",
-        "begin": "2015-04-06T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Hello!!黄金拼图",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-06T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "100405"
       },
       {
-        "site": "saraba1st",
-        "id": "1008592"
-      },
-      {
         "site": "nicovideo",
         "id": "kinmosa2",
-        "begin": "2015-04-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T16:00:00.000Z"
       }
     ]
   },
@@ -1828,115 +864,50 @@
     "officialSite": "http://kekkaisensen.com/",
     "begin": "2015-04-04T17:28:00.000Z",
     "end": "2015-10-03T19:47:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "109727",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "a0ZSHooKbdg",
-        "begin": "2015-04-04T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "3f3c69e0d37b11e4b692",
-        "begin": "2015-04-04T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T18:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008625",
-        "begin": "2015-04-04T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-04-04T18:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "UvjUUrogkM4xrxc",
-        "begin": "2015-04-04T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T18:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay9bt",
-        "begin": "2015-04-04T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T18:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1553",
-        "begin": "2015-04-04T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "血界战线",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-04T18:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "105075"
       },
       {
-        "site": "saraba1st",
-        "id": "1069689"
-      },
-      {
         "site": "nicovideo",
         "id": "kekkaisensen",
-        "begin": "2015-04-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T15:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "o/o3ujve87s5wfxj1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1952,55 +923,25 @@
     "officialSite": "http://www.ntv.co.jp/tesapuru/",
     "begin": "2015-04-04T16:55:00.000Z",
     "end": "2015-06-27T18:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "1580",
-        "begin": "2015-04-03T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-03T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "nLOdG4PpWZf6eOA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "摸索吧！部活剧%20第三季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "112838"
       },
       {
-        "site": "saraba1st",
-        "id": "962886"
-      },
-      {
         "site": "nicovideo",
         "id": "tesabu",
-        "begin": "2013-10-05T17:50:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2013-10-05T17:50:00.000Z"
       }
     ]
   },
@@ -2017,45 +958,20 @@
     "officialSite": "http://showbyrock-anime.com/",
     "begin": "2015-04-05T13:00:00.000Z",
     "end": "2015-06-21T13:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb7k19",
-        "begin": "2015-09-24T07:58:19.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "摇滚都市",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-09-24T07:58:19.000Z"
       },
       {
         "site": "bangumi",
         "id": "112905"
       },
       {
-        "site": "saraba1st",
-        "id": "1100035"
-      },
-      {
         "site": "nicovideo",
         "id": "showbyrock_anime",
-        "begin": "2015-04-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T03:00:00.000Z"
       }
     ]
   },
@@ -2075,65 +991,25 @@
     "officialSite": "http://www9.nhk.or.jp/anime/babysteps/",
     "begin": "2015-04-05T08:30:00.000Z",
     "end": "2015-09-20T08:55:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "5EughhrPa3A",
-        "begin": "2015-04-05T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "460a9d2cd29611e4a080",
-        "begin": "2015-04-05T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T17:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaybvd",
-        "begin": "2015-04-05T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "网球优等生%20第二季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-05T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "113906"
       },
       {
-        "site": "saraba1st",
-        "id": "1013448"
-      },
-      {
         "site": "bilibili",
         "id": "1652",
-        "begin": "2015-04-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-04T16:00:00.000Z"
       }
     ]
   },
@@ -2153,125 +1029,50 @@
     "officialSite": "http://www.arslan.jp/",
     "begin": "2015-04-05T08:00:00.000Z",
     "end": "2015-09-27T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "150637",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Ko7krCYz4w4",
-        "begin": "2015-04-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "851f4dbcd29811e4b692",
-        "begin": "2015-04-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T14:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008629",
-        "begin": "2015-04-05T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T14:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "2/2nqzaniq3tunys1",
-        "begin": "2015-04-05T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T14:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "TibbSULgejswvrRU",
-        "begin": "2015-04-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T14:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1551",
-        "begin": "2015-04-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaybsx",
-        "begin": "2015-04-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470244",
-        "begin": "2015-04-05T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "亚尔斯兰战记",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-05T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "116871"
       },
       {
-        "site": "saraba1st",
-        "id": "1086821"
-      },
-      {
         "site": "nicovideo",
         "id": "arslan",
-        "begin": "2015-04-14T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-14T16:30:00.000Z"
       }
     ]
   },
@@ -2290,47 +1091,16 @@
     "officialSite": "http://rainycocoa.jp/anime/",
     "begin": "2015-04-05T13:27:00.000Z",
     "end": "2015-06-28T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "1550",
-        "begin": "2015-04-05T15:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "LdZ-0sB7aoY",
-        "begin": "2015-04-05T15:28:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-04-05T15:28:00.000Z"
       },
       {
         "site": "youku",
         "id": "7d8b36f8d29b11e49e2a",
-        "begin": "2015-04-05T15:28:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "雨色可可",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-05T15:28:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2339,12 +1109,7 @@
       {
         "site": "nicovideo",
         "id": "rainycocoa",
-        "begin": "2015-04-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-06T15:00:00.000Z"
       }
     ]
   },
@@ -2360,77 +1125,26 @@
     "officialSite": "http://kokaku-a.jp/tv/",
     "begin": "2015-04-05T13:30:00.000Z",
     "end": "2015-06-14T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "292436",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "I3F-I2rXmBI",
-        "begin": "2015-04-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "76ca4f38d29c11e4b8e3",
-        "begin": "2015-04-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1568",
-        "begin": "2015-04-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T14:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "h/hp6xc4to1ytnkof",
-        "begin": "2015-04-05T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470247",
-        "begin": "2015-04-05T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "攻壳机动队ARISE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-05T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2439,12 +1153,7 @@
       {
         "site": "nicovideo",
         "id": "arise",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2463,7 +1172,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/duelmastersvsr/",
     "begin": "2015-04-04T23:30:00.000Z",
     "end": "2016-03-27T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2472,12 +1180,7 @@
       {
         "site": "nicovideo",
         "id": "duelmastersvsr",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2497,55 +1200,30 @@
     "officialSite": "http://s.mxtv.jp/joker/",
     "begin": "2015-04-06T10:00:00.000Z",
     "end": "2015-06-29T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Exic5d99FtfNW1Dw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10021112",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaybf1",
-        "begin": "2015-04-06T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-06T10:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "122864"
       },
       {
-        "site": "saraba1st",
-        "id": "1062960"
-      },
-      {
         "site": "bilibili",
         "id": "1570",
-        "begin": "2015-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T16:00:00.000Z"
       }
     ]
   },
@@ -2561,47 +1239,21 @@
     "officialSite": "http://kakusen-kun.com/",
     "begin": "2015-04-06T14:54:00.000Z",
     "end": "2015-06-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "2880e626d36311e49e2a",
-        "begin": "2015-04-21T13:21:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "CoWG9Wl37gI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-04-21T13:21:02.000Z"
       },
       {
         "site": "pptv",
         "id": "m7CcGoLoWJb5d98",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1572",
-        "begin": "2015-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2610,12 +1262,7 @@
       {
         "site": "nicovideo",
         "id": "kakusen-kun",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2636,55 +1283,20 @@
     "officialSite": "http://diaace.com/",
     "begin": "2015-04-06T09:00:00.000Z",
     "end": "2016-03-28T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhc1049",
-        "begin": "2014-10-28T05:54:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1465812",
-        "begin": "2015-04-06T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "钻石王牌",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-10-28T05:54:34.000Z"
       },
       {
         "site": "bangumi",
         "id": "129844"
       },
       {
-        "site": "saraba1st",
-        "id": "916299"
-      },
-      {
         "site": "nicovideo",
         "id": "diaace2",
-        "begin": "2015-04-12T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-12T14:30:00.000Z"
       }
     ]
   },
@@ -2700,65 +1312,25 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2015-04-06T16:05:00.000Z",
     "end": "2015-06-22T16:08:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "kLehH4ftXZvibfOQ",
-        "begin": "2015-04-06T17:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-06T17:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "4a5b3b64d36011e4b522",
-        "begin": "2015-04-06T17:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "VBWDfQZtHTc",
-        "begin": "2015-04-06T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "网球并不可笑嘛",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-06T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "91322"
       },
       {
-        "site": "saraba1st",
-        "id": "861754"
-      },
-      {
         "site": "nicovideo",
         "id": "te-kyu4",
-        "begin": "2015-04-23T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-23T04:00:00.000Z"
       }
     ]
   },
@@ -2777,115 +1349,45 @@
     "officialSite": "http://tv.anime-eupho.com/",
     "begin": "2015-04-07T15:30:00.000Z",
     "end": "2015-06-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "109804",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "hbSbEkGBZtk",
-        "begin": "2015-04-07T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "41f367f4d35f11e4b522",
-        "begin": "2015-04-07T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008635",
-        "begin": "2015-04-07T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1547",
-        "begin": "2015-04-07T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "QObSULgejswvrRU",
-        "begin": "2015-04-07T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "o/oesitw7dajrcifs",
-        "begin": "2015-04-07T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470254",
-        "begin": "2015-04-07T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "吹响！上低音号",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-07T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "115908"
       },
       {
-        "site": "saraba1st",
-        "id": "1085129"
-      },
-      {
         "site": "nicovideo",
         "id": "euphonium",
-        "begin": "2015-04-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-11T14:30:00.000Z"
       }
     ]
   },
@@ -2902,85 +1404,35 @@
     "officialSite": "http://mikagura-gakuen.com/",
     "begin": "2015-04-06T17:35:00.000Z",
     "end": "2015-06-22T18:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10008964",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "038f718ed35e11e49e2a",
-        "begin": "2015-04-22T13:34:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "br_kIWGRomI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-04-22T13:34:28.000Z"
       },
       {
         "site": "pptv",
         "id": "uY9p50ib1JWPGRKw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "1548",
-        "begin": "2015-04-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "御神乐学园组曲",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "119886"
       },
       {
-        "site": "saraba1st",
-        "id": "1083182"
-      },
-      {
         "site": "nicovideo",
         "id": "mikagura_gakuen",
-        "begin": "2015-04-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-07T15:00:00.000Z"
       }
     ]
   },
@@ -2996,65 +1448,25 @@
     "officialSite": "http://te-kyu.com/nasuno/",
     "begin": "2015-04-06T16:08:00.000Z",
     "end": "2015-06-22T16:11:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "j6SQDnbcTIrta9M",
-        "begin": "2015-04-06T17:08:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-06T17:08:00.000Z"
       },
       {
         "site": "youku",
         "id": "f02d84bcd36411e4b432",
-        "begin": "2015-04-06T17:08:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "4je4z0F0NQg",
-        "begin": "2015-04-06T17:08:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "我是高宫茄乃",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-06T17:08:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "120042"
       },
       {
-        "site": "saraba1st",
-        "id": "1125545"
-      },
-      {
         "site": "nicovideo",
         "id": "nasuno",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3073,37 +1485,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/gintama/index2.html",
     "begin": "2015-04-08T09:00:00.000Z",
     "end": "2016-03-30T09:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "92J2xqpSxWY",
-        "begin": "2015-04-08T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "cc0026e0962411de83b1",
-        "begin": "2015-04-08T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470255",
-        "begin": "2015-04-08T10:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-08T10:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3112,12 +1498,7 @@
       {
         "site": "nicovideo",
         "id": "gintama2015",
-        "begin": "2015-04-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T03:00:00.000Z"
       }
     ]
   },
@@ -3133,55 +1514,20 @@
     "officialSite": "http://sbr-gx.jp/",
     "begin": "2015-04-08T17:45:00.000Z",
     "end": "2015-06-24T18:14:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UvPdW8Mpmdc6uCA",
-        "begin": "2015-04-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "3ab8310ad2cd11e4b432",
-        "begin": "2015-04-09T15:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "czE_W65mzZk",
-        "begin": "2015-04-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "放学后的昴星团",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-09T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "86517"
-      },
-      {
-        "site": "saraba1st",
-        "id": "984745"
       }
     ]
   },
@@ -3200,35 +1546,15 @@
     "officialSite": "http://triagex-anime.jp/",
     "begin": "2015-04-08T16:05:00.000Z",
     "end": "2015-06-10T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "绝命制裁X",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "112305"
       },
       {
-        "site": "saraba1st",
-        "id": "1078488"
-      },
-      {
         "site": "nicovideo",
         "id": "triagex",
-        "begin": "2015-04-24T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-24T03:00:00.000Z"
       }
     ]
   },
@@ -3247,45 +1573,20 @@
     "officialSite": "http://www.anime-ore.jp/",
     "begin": "2015-04-08T17:29:00.000Z",
     "end": "2015-09-23T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10008807",
-        "begin": "2015-04-08T19:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "俺物语",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-08T19:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "117153"
       },
       {
-        "site": "saraba1st",
-        "id": "1072023"
-      },
-      {
         "site": "nicovideo",
         "id": "anime_ore",
-        "begin": "2015-04-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T03:00:00.000Z"
       }
     ]
   },
@@ -3301,75 +1602,25 @@
     "officialSite": "http://etotama.com/",
     "begin": "2015-04-09T14:00:00.000Z",
     "end": "2015-06-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "hGd4jZGmtp4",
-        "begin": "2015-04-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "f5e8534ed35711e4b692",
-        "begin": "2015-04-09T15:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhazgvh",
-        "begin": "2015-04-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470259",
-        "begin": "2015-04-09T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "干支魂",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-09T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "117558"
       },
       {
-        "site": "saraba1st",
-        "id": "1080679"
-      },
-      {
         "site": "nicovideo",
         "id": "etotama",
-        "begin": "2015-04-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-11T15:00:00.000Z"
       }
     ]
   },
@@ -3385,45 +1636,15 @@
     "officialSite": "http://www.punchline.jp/",
     "begin": "2015-04-09T15:50:00.000Z",
     "end": "2015-06-25T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "ab2bcd5cd37c11e4b432",
-        "begin": "2015-04-09T17:25:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "punch+line",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2541",
-        "begin": "2015-04-09T17:25:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T17:25:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "118782"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1077609"
       }
     ]
   },
@@ -3440,95 +1661,35 @@
     "officialSite": "http://www.nisekoi.jp/",
     "begin": "2015-04-10T14:30:00.000Z",
     "end": "2015-06-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470261",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0zm0C-rHX9E",
-        "begin": "2015-04-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "cdd2de40d2c811e4b2ad",
-        "begin": "2015-04-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T15:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008544",
-        "begin": "2015-04-10T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T15:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "po1n5U2zI2HEQqo",
-        "begin": "2015-04-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1574",
-        "begin": "2015-04-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "伪恋%20第二季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-10T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "114758"
       },
       {
-        "site": "saraba1st",
-        "id": "1083535"
-      },
-      {
         "site": "nicovideo",
         "id": "nisekoi2",
-        "begin": "2015-04-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-15T03:00:00.000Z"
       }
     ]
   },
@@ -3544,85 +1705,35 @@
     "officialSite": "http://urawa-usagi.com/",
     "begin": "2015-04-09T16:35:00.000Z",
     "end": "2015-06-25T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "1597",
-        "begin": "2015-04-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-08T16:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10009011",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "oolj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "86145e1e080411e5a080",
-        "begin": "2015-04-10T15:15:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "sPbFm3CUJp0",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "浦和小调",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-10T15:15:50.000Z"
       },
       {
         "site": "bangumi",
         "id": "115339"
       },
       {
-        "site": "saraba1st",
-        "id": "1092393"
-      },
-      {
         "site": "nicovideo",
         "id": "urawa_usagi",
-        "begin": "2015-04-09T16:40:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T16:40:00.000Z"
       }
     ]
   },
@@ -3643,95 +1754,35 @@
     "officialSite": "http://www.knightsofsidonia.com/",
     "begin": "2015-04-10T17:10:00.000Z",
     "end": "2015-06-26T17:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "292437",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "sdrYzuBFDuo",
-        "begin": "2015-04-10T18:25:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "94e46f16d2c511e4b692",
-        "begin": "2015-04-10T18:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T18:25:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "1577",
-        "begin": "2015-04-10T18:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-10T18:25:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhayby5",
-        "begin": "2015-04-10T18:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470262",
-        "begin": "2015-04-10T18:25:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "希德尼娅的骑士%20第九行星战役",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-10T18:25:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "105255"
       },
       {
-        "site": "saraba1st",
-        "id": "1014335"
-      },
-      {
         "site": "nicovideo",
         "id": "knightsofsidonia02",
-        "begin": "2015-04-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-15T15:00:00.000Z"
       }
     ]
   },
@@ -3748,55 +1799,25 @@
     "officialSite": "http://www.yamajo-anime.com/",
     "begin": "2015-04-12T14:30:00.000Z",
     "end": "2015-06-28T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "payIBm7URILlY8s",
-        "begin": "2015-04-13T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-13T00:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "29e2a70ad2c011e4b8e3",
-        "begin": "2015-04-13T00:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "山田君与7人魔女",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-04-13T00:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "118906"
       },
       {
-        "site": "saraba1st",
-        "id": "1080438"
-      },
-      {
         "site": "nicovideo",
         "id": "yamajo",
-        "begin": "2015-04-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-17T03:00:00.000Z"
       }
     ]
   },
@@ -3815,55 +1836,25 @@
     "officialSite": "http://www.grisaia-anime.com/",
     "begin": "2015-04-12T14:00:00.000Z",
     "end": "2015-04-12T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrnl2yac",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470263",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "121187"
       },
       {
-        "site": "saraba1st",
-        "id": "1018763"
-      },
-      {
         "site": "nicovideo",
         "id": "grisaia2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "4170",
-        "begin": "2015-04-11T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "100712",
+        "begin": "2015-04-11T16:00:01.000Z"
       }
     ]
   },
@@ -3883,27 +1874,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/sushi/",
     "begin": "2015-04-15T15:40:00.000Z",
     "end": "2015-11-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "3HNd20OpGVe6OKA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470282",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3912,12 +1887,7 @@
       {
         "site": "bilibili",
         "id": "1738",
-        "begin": "2015-04-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-14T16:00:00.000Z"
       }
     ]
   },
@@ -3937,35 +1907,10 @@
     "officialSite": "http://www.ninjaslayer-animation.com/",
     "begin": "2015-04-16T14:00:00.000Z",
     "end": "2015-10-08T14:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470264",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "忍者杀手",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "101437"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1038832"
       }
     ]
   },
@@ -3984,75 +1929,25 @@
     "officialSite": "http://www.grisaia-anime.com/",
     "begin": "2015-04-19T14:00:00.000Z",
     "end": "2015-06-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "灰色的乐园",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470270",
-        "begin": "2015-04-19T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "97gX03tWpr8",
-        "begin": "2015-04-19T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "247ce45ed2b311e4abda",
-        "begin": "2015-04-19T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-19T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaz2bh",
-        "begin": "2015-04-19T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-19T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "130234"
       },
       {
-        "site": "saraba1st",
-        "id": "1018763"
-      },
-      {
         "site": "nicovideo",
         "id": "grisaia_rakuen",
-        "begin": "2015-04-20T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-20T16:30:00.000Z"
       }
     ]
   },
@@ -4064,7 +1959,6 @@
     "officialSite": "http://xn--u9j429qiq1a.jp/",
     "begin": "2015-04-03T09:20:00.000Z",
     "end": "2016-03-04T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4073,12 +1967,7 @@
       {
         "site": "nicovideo",
         "id": "takanotsume_do",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4097,7 +1986,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/gon/",
     "begin": "2015-04-04T00:14:00.000Z",
     "end": "2015-09-26T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4117,7 +2005,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/tamagotchi/",
     "begin": "2015-04-02T09:00:00.000Z",
     "end": "2015-09-24T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4140,47 +2027,16 @@
     "officialSite": "http://www.tv-aichi.co.jp/fc-buddyfight100/",
     "begin": "2015-04-10T23:00:00.000Z",
     "end": "2016-03-25T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "0a14b8a862d411e3a705",
-        "begin": "2014-01-11T10:01:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-11T10:01:38.000Z"
       },
       {
         "site": "qq",
         "id": "g/gkvdkxuaepreo2m",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0yYeCeFSZDo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2642",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4203,7 +2059,6 @@
     "officialSite": "http://www.nhk.or.jp/seimei/pikaia.html",
     "begin": "2015-04-29T01:00:00.000Z",
     "end": "2015-07-30T01:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4227,55 +2082,20 @@
     "officialSite": "http://saintseiya-gold.com/",
     "begin": "2015-04-10T15:00:00.000Z",
     "end": "2015-09-25T15:24:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470265",
-        "begin": "2014-04-11T01:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhaz605",
-        "begin": "2014-04-11T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "圣斗士星矢+黄金魂",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2014-04-11T01:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "116716"
       },
       {
-        "site": "saraba1st",
-        "id": "1094185"
-      },
-      {
         "site": "nicovideo",
         "id": "saintseiya-gold",
-        "begin": "2015-04-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-17T15:00:00.000Z"
       }
     ]
   },
@@ -4291,77 +2111,36 @@
     "officialSite": "http://ac.qq.com/event/sxdh/index.shtml",
     "begin": "2015-04-16T12:00:00.000Z",
     "end": "2016-03-10T12:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470276",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "2649",
-        "begin": "2015-04-15T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-15T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "03hU0jqgEE6xL5c",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "v/vjiuhcokx7v28sf",
-        "begin": "2015-04-16T12:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-16T12:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10009093",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2015/wjbxf",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "150513",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4382,17 +2161,11 @@
     "officialSite": "http://www.d2015gw.com/",
     "begin": "2015-04-18T16:00:00.000Z",
     "end": "2015-04-18T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rr95thbo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4401,12 +2174,7 @@
       {
         "site": "nicovideo",
         "id": "dbz-Revival-of-F",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4422,17 +2190,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2015-04-18T16:00:00.000Z",
     "end": "2015-04-18T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zual",
-        "begin": "2016-11-11T08:33:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-11T08:33:52.000Z"
       },
       {
         "site": "bangumi",
@@ -4441,22 +2203,12 @@
       {
         "site": "pptv",
         "id": "NQHradE3pibVIxia4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bu8qr3h1vbia2kd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4473,27 +2225,16 @@
     "officialSite": "http://www.mtvjapan.com/usavich/",
     "begin": "2015-04-10T16:00:00.000Z",
     "end": "2015-08-28T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PxP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha7u19",
-        "begin": "2016-12-14T06:04:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-14T06:04:55.000Z"
       },
       {
         "site": "bangumi",
@@ -4502,22 +2243,12 @@
       {
         "site": "qq",
         "id": "e/el3as30vkbcwepb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2034",
-        "begin": "2015-04-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-09T16:00:00.000Z"
       }
     ]
   },
@@ -4529,7 +2260,6 @@
     "officialSite": "http://www.panpaka.com/",
     "begin": "2015-04-04T16:00:00.000Z",
     "end": "2015-10-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4549,7 +2279,6 @@
     "officialSite": "http://www.p3m.jp/",
     "begin": "2015-04-04T16:00:00.000Z",
     "end": "2015-04-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4558,12 +2287,7 @@
       {
         "site": "nicovideo",
         "id": "p3m",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4579,7 +2303,6 @@
     "officialSite": "",
     "begin": "2015-04-24T16:00:00.000Z",
     "end": "2015-04-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4588,12 +2311,7 @@
       {
         "site": "pptv",
         "id": "ByoGhOxSwgBj4Uk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2015/05.json
+++ b/data/items/2015/05.json
@@ -14,18 +14,7 @@
     "officialSite": "http://www.robot-girlsz.com/",
     "begin": "2015-05-20T13:30:00.000Z",
     "end": "2015-10-19T15:10:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470286",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "121002"
@@ -33,22 +22,12 @@
       {
         "site": "nicovideo",
         "id": "robot-girlsz2",
-        "begin": "2015-05-20T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-20T13:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3802",
-        "begin": "2015-05-19T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-19T16:00:01.000Z"
       }
     ]
   },
@@ -64,37 +43,21 @@
     "officialSite": "http://www.geass.jp/akito/",
     "begin": "2015-05-02T16:00:00.000Z",
     "end": "2015-05-02T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "otmjIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9mhz9",
-        "begin": "2016-08-31T16:02:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:02:16.000Z"
       },
       {
         "site": "letv",
         "id": "82177",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -114,31 +77,15 @@
     "officialSite": "http://www.durarara.com/ova/",
     "begin": "2015-05-30T16:00:00.000Z",
     "end": "2015-05-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PwnjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "126581"
-      },
-      {
-        "site": "bilibili",
-        "id": "3538",
-        "begin": "2015-05-29T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -156,17 +103,11 @@
     "officialSite": "http://www.mushishi-anime.com/",
     "begin": "2015-05-16T16:00:00.000Z",
     "end": "2015-05-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Aia0Hhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -175,22 +116,12 @@
       {
         "site": "nicovideo",
         "id": "mushishi-tokubetsuhen02",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2648",
-        "begin": "2015-05-15T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-15T16:00:00.000Z"
       }
     ]
   },
@@ -206,7 +137,6 @@
     "officialSite": "http://bakavon.com/",
     "begin": "2015-05-23T16:00:00.000Z",
     "end": "2015-05-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -215,22 +145,12 @@
       {
         "site": "nicovideo",
         "id": "bakavon",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5866",
-        "begin": "2015-05-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-22T16:00:01.000Z"
       }
     ]
   },
@@ -246,7 +166,6 @@
     "officialSite": "http://initiald-movie.com/",
     "begin": "2015-05-23T16:00:00.000Z",
     "end": "2015-05-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -255,22 +174,12 @@
       {
         "site": "pptv",
         "id": "cOzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3839",
-        "begin": "2015-05-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-22T16:00:01.000Z"
       }
     ]
   },
@@ -286,7 +195,6 @@
     "officialSite": "http://tamayura.info/",
     "begin": "2015-05-08T16:00:00.000Z",
     "end": "2016-04-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -295,22 +203,12 @@
       {
         "site": "pptv",
         "id": "QOjEQqoQgL4hnwc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2800",
-        "begin": "2015-05-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-07T16:00:00.000Z"
       }
     ]
   },
@@ -326,7 +224,6 @@
     "officialSite": "",
     "begin": "2015-05-15T16:00:00.000Z",
     "end": "2015-05-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -335,22 +232,12 @@
       {
         "site": "pptv",
         "id": "nrKeHITqWpj7eeE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3423",
-        "begin": "2015-05-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-14T16:00:01.000Z"
       }
     ]
   },
@@ -369,7 +256,6 @@
     "officialSite": "http://sarusuberi-movie.com/",
     "begin": "2015-05-08T16:00:00.000Z",
     "end": "2015-05-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -378,12 +264,7 @@
       {
         "site": "netflix",
         "id": "80075828",
-        "begin": "2017-10-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-01T07:00:00.000Z"
       }
     ]
   },
@@ -399,7 +280,6 @@
     "officialSite": "http://nyaruko.com/",
     "begin": "2015-05-30T16:00:00.000Z",
     "end": "2015-05-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -408,22 +288,12 @@
       {
         "site": "nicovideo",
         "id": "nyaruko-f",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2941",
-        "begin": "2015-05-29T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-05-29T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2015/06.json
+++ b/data/items/2015/06.json
@@ -7,77 +7,36 @@
     "officialSite": "http://ac.qq.com/event/huyao/index.html",
     "begin": "2015-06-26T12:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470335",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "2543",
-        "begin": "2015-06-25T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-06-25T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "xWxIxia6UBEKlI4s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "0/0sdnyl7h86atoyt",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5yg1",
-        "begin": "2016-03-15T10:02:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-15T10:02:00.000Z"
       },
       {
         "site": "letv",
         "id": "10010294",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "156998",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -97,17 +56,11 @@
     "officialSite": "http://typhoon-noruda.com/",
     "begin": "2015-06-05T16:00:00.000Z",
     "end": "2015-06-05T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10008488",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -127,17 +80,11 @@
     "officialSite": "",
     "begin": "2015-06-24T16:00:00.000Z",
     "end": "2015-06-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1ntV0zuhEUibyMJg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -157,7 +104,6 @@
     "officialSite": "http://yowapeda.com/reroad/",
     "begin": "2015-06-12T16:00:00.000Z",
     "end": "2015-06-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -166,12 +112,7 @@
       {
         "site": "pptv",
         "id": "ety4Np4EdLIVkics",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -187,7 +128,6 @@
     "officialSite": "",
     "begin": "2015-06-27T16:00:00.000Z",
     "end": "2015-06-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -196,12 +136,7 @@
       {
         "site": "nicovideo",
         "id": "shingeki_movie",
-        "begin": "2018-12-27T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-27T03:00:00.000Z"
       }
     ]
   }

--- a/data/items/2015/07.json
+++ b/data/items/2015/07.json
@@ -14,55 +14,15 @@
     "officialSite": "http://www.dreamcreation.co.jp/okusama/",
     "begin": "2015-07-01T15:30:00.000Z",
     "end": "2015-09-16T15:40:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "2600",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470292",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "我老婆是学生会长",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "119889"
       },
       {
-        "site": "saraba1st",
-        "id": "1091463"
-      },
-      {
         "site": "nicovideo",
         "id": "okusama",
-        "begin": "2015-07-08T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T12:00:00.000Z"
       }
     ]
   },
@@ -84,85 +44,35 @@
     "officialSite": "http://gangsta-project.com/",
     "begin": "2015-07-01T17:44:00.000Z",
     "end": "2015-09-23T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhas5xl",
-        "begin": "2016-07-14T10:16:33.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-14T10:16:33.000Z"
       },
       {
         "site": "letv",
         "id": "10010424",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2601",
-        "begin": "2015-06-30T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470326",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "GANGSTA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-06-30T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "107957"
       },
       {
-        "site": "saraba1st",
-        "id": "1050492"
-      },
-      {
         "site": "nicovideo",
         "id": "gangsta-project",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80201315",
-        "begin": "2019-02-28T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-28T16:00:00.000Z"
       }
     ]
   },
@@ -181,95 +91,35 @@
     "officialSite": "http://www.rampokitan.com/",
     "begin": "2015-07-02T15:55:00.000Z",
     "end": "2015-09-17T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "157292",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "bONAn7JK874",
-        "begin": "2015-07-02T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "8f02e3561a5611e5b5ce",
-        "begin": "2015-07-02T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T17:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2585",
-        "begin": "2015-07-02T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T17:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10010419",
-        "begin": "2015-07-02T17:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T17:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "a/a3xvy009de4vael",
-        "begin": "2015-07-02T17:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470321",
-        "begin": "2015-07-02T17:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "乱步奇谭",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-02T17:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "118785"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1105940"
       }
     ]
   },
@@ -290,115 +140,45 @@
     "officialSite": "http://chaosdragon.red/",
     "begin": "2015-07-02T13:30:00.000Z",
     "end": "2015-09-17T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "dIoKgU-j9O4",
-        "begin": "2015-07-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "b3f16e30197511e5b522",
-        "begin": "2015-07-02T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T14:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "0XlT0TmfD02wLpY",
-        "begin": "2015-07-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2571",
-        "begin": "2015-07-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T14:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10010403",
-        "begin": "2015-07-02T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T14:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "s/s8q3rwmi1vcyhuu",
-        "begin": "2015-07-02T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470293",
-        "begin": "2015-07-02T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "赤龙战役",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-02T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5q85",
-        "begin": "2015-07-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "125917"
       },
       {
-        "site": "saraba1st",
-        "id": "1098159"
-      },
-      {
         "site": "nicovideo",
         "id": "chaosdragon-red",
-        "begin": "2015-07-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T16:30:00.000Z"
       }
     ]
   },
@@ -418,95 +198,40 @@
     "officialSite": "http://aqlogos.com/",
     "begin": "2015-07-02T15:30:00.000Z",
     "end": "2015-12-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2579",
-        "begin": "2015-07-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10010420",
-        "begin": "2015-07-02T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "9/90ono2pk2blgqwd",
-        "begin": "2015-07-02T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "uZB8ibmLIOHbZV78",
-        "begin": "2015-07-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "ff83eed81aea11e5b2ad",
-        "begin": "2015-07-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Nd659aHmzbc",
-        "begin": "2015-07-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "创圣%20LOGOS",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-02T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "126024"
       },
       {
-        "site": "saraba1st",
-        "id": "1098193"
-      },
-      {
         "site": "nicovideo",
         "id": "aqlogos",
-        "begin": "2015-07-20T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-20T15:30:00.000Z"
       }
     ]
   },
@@ -526,85 +251,35 @@
     "officialSite": "http://www.tbs.co.jp/anime/dande/",
     "begin": "2015-07-02T17:18:00.000Z",
     "end": "2015-09-17T17:46:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "uJF7ibWHHN3XYVr4",
-        "begin": "2015-07-03T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "OJg0wZ-E11A",
-        "begin": "2015-07-03T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-03T00:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "5d031b5a198911e5b2ad",
-        "begin": "2015-07-03T00:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-03T00:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2613",
-        "begin": "2015-07-03T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "城下町的蒲公英",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-03T00:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "117556"
       },
       {
-        "site": "saraba1st",
-        "id": "1104147"
-      },
-      {
         "site": "nicovideo",
         "id": "dande",
-        "begin": "2015-07-27T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-27T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh8772l",
-        "begin": "2017-09-30T01:56:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-30T01:56:01.000Z"
       }
     ]
   },
@@ -624,27 +299,11 @@
     "officialSite": "http://hetalia.com/twt/",
     "begin": "2015-07-09T15:00:00.000Z",
     "end": "2015-10-15T15:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2581",
-        "begin": "2015-07-04T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "黑塔利亚%20The%20World%20Twinkle",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-04T04:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -653,12 +312,7 @@
       {
         "site": "nicovideo",
         "id": "hetalia-World-Twinkle",
-        "begin": "2015-07-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T15:00:00.000Z"
       }
     ]
   },
@@ -678,85 +332,25 @@
     "officialSite": "http://gate-anime.com/",
     "begin": "2015-07-03T15:30:00.000Z",
     "end": "2015-09-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10010438",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "20ee3d961af811e5b5ce",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "5VmCpjgOBFw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "OhD8euJIuPZZ1z8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "GATE奇幻自卫队",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470300",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2618",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "120445"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1083120"
       }
     ]
   },
@@ -776,27 +370,11 @@
     "officialSite": "http://wooser.tv/",
     "begin": "2015-07-03T14:09:00.000Z",
     "end": "2015-09-25T14:17:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2615",
-        "begin": "2015-07-03T14:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "T宝的悲惨日常%20梦幻篇",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-03T14:20:00.000Z"
       },
       {
         "site": "bangumi",
@@ -805,12 +383,7 @@
       {
         "site": "nicovideo",
         "id": "wooser-tv-mugen",
-        "begin": "2015-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-03T14:30:00.000Z"
       }
     ]
   },
@@ -829,45 +402,15 @@
     "officialSite": "http://ushitora.tv/",
     "begin": "2015-07-03T13:30:00.000Z",
     "end": "2015-12-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "UW8uUaXCUQg",
-        "begin": "2015-07-03T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "58f52458197611e5b432",
-        "begin": "2015-07-03T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "潮与虎",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-03T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "124185"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1128233"
       }
     ]
   },
@@ -886,105 +429,40 @@
     "officialSite": "http://www.tbs.co.jp/anime/aoharu/",
     "begin": "2015-07-02T16:48:00.000Z",
     "end": "2015-12-24T17:36:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2589",
-        "begin": "2015-07-03T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-03T13:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5qax",
-        "begin": "2015-07-03T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-03T13:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "1/1f1gzzkyhi264mg",
-        "begin": "2015-07-03T13:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "3z2CdeVaST8",
-        "begin": "2015-07-03T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-03T13:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "14014ec81ae611e5abda",
-        "begin": "2015-07-03T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-03T13:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "KALubNQ6quhLyTE",
-        "begin": "2015-07-03T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470322",
-        "begin": "2015-07-03T13:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "青春X机关枪",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-03T13:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "126779"
       },
       {
-        "site": "saraba1st",
-        "id": "1106176"
-      },
-      {
         "site": "nicovideo",
         "id": "aoharu",
-        "begin": "2015-07-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-13T03:00:00.000Z"
       }
     ]
   },
@@ -1005,65 +483,25 @@
     "officialSite": "http://wakabagirl.com/",
     "begin": "2015-07-03T13:40:00.000Z",
     "end": "2015-09-25T13:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2590",
-        "begin": "2015-07-03T14:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "2xZbLVJzdxk",
-        "begin": "2015-07-03T14:25:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-03T14:25:00.000Z"
       },
       {
         "site": "youku",
         "id": "5a5b31301a5111e5abda",
-        "begin": "2015-07-03T14:25:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "若叶女孩",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-03T14:25:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "128635"
       },
       {
-        "site": "saraba1st",
-        "id": "1132051"
-      },
-      {
         "site": "nicovideo",
         "id": "wakabagirl",
-        "begin": "2015-07-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-11T15:00:00.000Z"
       }
     ]
   },
@@ -1082,47 +520,16 @@
     "officialSite": "http://www.starchild.co.jp/special/miss_monochrome_anime_2/",
     "begin": "2015-07-03T13:30:00.000Z",
     "end": "2015-09-25T13:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2617",
-        "begin": "2015-07-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-02T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "7c16449c198c11e59e2a",
-        "begin": "2015-07-06T09:15:14.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470299",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "黑白小姐%20第二季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-06T09:15:14.000Z"
       },
       {
         "site": "bangumi",
@@ -1131,12 +538,7 @@
       {
         "site": "nicovideo",
         "id": "miss-monochrome2",
-        "begin": "2015-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -1156,85 +558,25 @@
     "officialSite": "http://www.symphogear-gx.com/",
     "begin": "2015-07-03T18:10:00.000Z",
     "end": "2015-09-25T19:40:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "2621",
-        "begin": "2015-07-03T19:10:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "战姬绝唱Symphogear%20GX",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470332",
-        "begin": "2015-07-03T19:10:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "10010494",
-        "begin": "2015-07-03T19:10:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-03T19:10:00.000Z"
       },
       {
         "site": "youku",
         "id": "37d43f201af711e5b522",
-        "begin": "2015-07-03T19:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "hMxCr_0EXZc",
-        "begin": "2015-07-03T19:10:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-03T19:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "90512"
       },
       {
-        "site": "saraba1st",
-        "id": "1104425"
-      },
-      {
         "site": "nicovideo",
         "id": "symphogear-gx",
-        "begin": "2015-07-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T14:30:00.000Z"
       }
     ]
   },
@@ -1253,65 +595,25 @@
     "officialSite": "http://www.wagnaria.com/",
     "begin": "2015-07-04T15:30:00.000Z",
     "end": "2015-12-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2587",
-        "begin": "2015-07-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T17:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "21b943001af911e5b2ad",
-        "begin": "2015-07-09T17:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "OWrP8KCU_84",
-        "begin": "2015-07-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "WORKING!!!迷糊餐厅%20第三季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-09T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "110648"
       },
       {
-        "site": "saraba1st",
-        "id": "1083900"
-      },
-      {
         "site": "nicovideo",
         "id": "working-03",
-        "begin": "2015-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -1330,105 +632,40 @@
     "officialSite": "http://www.durarara.com/",
     "begin": "2015-07-04T14:30:00.000Z",
     "end": "2015-09-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "Se7oGWDr_GA",
-        "begin": "2015-07-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "2c9c7552acd811e38b3f",
-        "begin": "2015-07-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-04T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2595",
-        "begin": "2015-07-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-04T15:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "4/4gmobofw9fltve9",
-        "begin": "2015-07-04T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-04T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5awh",
-        "begin": "2017-07-01T07:26:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470302",
-        "begin": "2015-07-04T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "无头骑士异闻录×2%20转",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2017-07-01T07:26:57.000Z"
       },
       {
         "site": "bangumi",
         "id": "114967"
       },
       {
-        "site": "saraba1st",
-        "id": "1047071"
-      },
-      {
         "site": "nicovideo",
         "id": "durarara03",
-        "begin": "2015-07-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80040119",
-        "begin": "2015-10-09T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T07:00:00.000Z"
       }
     ]
   },
@@ -1448,45 +685,20 @@
     "officialSite": "http://www.shimoseka.com/",
     "begin": "2015-07-04T14:00:00.000Z",
     "end": "2015-09-19T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2586",
-        "begin": "2015-07-09T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "下流梗不存在的灰暗世界",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-09T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "115780"
       },
       {
-        "site": "saraba1st",
-        "id": "1092026"
-      },
-      {
         "site": "nicovideo",
         "id": "shimoseka",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1506,134 +718,55 @@
     "officialSite": "http://charlotte-anime.jp/",
     "begin": "2015-07-04T15:00:00.000Z",
     "end": "2015-09-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "166311",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "tO8jG72LwdY",
-        "begin": "2015-07-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "074ab022197c11e5b5ce",
-        "begin": "2015-07-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "OQicpZ881peNGxCw",
-        "begin": "2015-07-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T16:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2572",
-        "begin": "2015-07-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10010346",
-        "begin": "2015-07-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5qhd",
-        "begin": "2015-07-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "k/keh8jx4nea7e5w0",
-        "begin": "2015-07-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470328",
-        "begin": "2015-07-09T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Charlotte",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-09T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "120925"
       },
       {
-        "site": "saraba1st",
-        "id": "1080677"
-      },
-      {
         "site": "nicovideo",
         "id": "charlotte-anime",
-        "begin": "2015-07-06T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-06T13:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80142917",
         "begin": "2017-12-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
         "comment": "港区可见"
       }
     ]
@@ -1653,65 +786,25 @@
     "officialSite": "http://www.classroom-crisis.com/",
     "begin": "2015-07-03T16:57:00.000Z",
     "end": "2015-09-25T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2582",
-        "begin": "2015-07-03T18:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-03T18:25:00.000Z"
       },
       {
         "site": "youku",
         "id": "698d6ccc1aec11e5b692",
-        "begin": "2015-07-03T18:25:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "WQW4z5dDdEo",
-        "begin": "2015-07-03T18:25:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Classroom☆Crisis",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-03T18:25:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "129087"
       },
       {
-        "site": "saraba1st",
-        "id": "1105931"
-      },
-      {
         "site": "nicovideo",
         "id": "classroom-crisis",
-        "begin": "2015-07-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-10T03:00:00.000Z"
       }
     ]
   },
@@ -1730,75 +823,25 @@
     "officialSite": "http://www.ntv.co.jp/GC_insight/",
     "begin": "2015-07-04T16:55:00.000Z",
     "end": "2015-09-26T18:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "wk_5UB9cfe4",
-        "begin": "2015-07-04T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "1ed08068197d11e5a080",
-        "begin": "2015-07-04T20:30:00.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470304",
-        "begin": "2015-07-04T20:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "科学小飞侠+CROWDS+insight",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-04T20:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "86721"
       },
       {
-        "site": "saraba1st",
-        "id": "931511"
-      },
-      {
         "site": "nicovideo",
         "id": "GC_insight",
-        "begin": "2015-07-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-05T03:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "2612",
-        "begin": "2015-07-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "75912",
+        "begin": "2015-07-04T16:00:01.000Z"
       }
     ]
   },
@@ -1817,105 +860,40 @@
     "officialSite": "http://anime.godeater.jp/",
     "begin": "2015-07-12T13:30:00.000Z",
     "end": "2016-03-26T10:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "n3RSRsUtHhk",
-        "begin": "2015-07-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "7f52b0ce197c11e5a080",
-        "begin": "2015-07-05T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-05T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2591",
-        "begin": "2015-07-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-05T14:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10010338",
-        "begin": "2015-07-05T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-05T14:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "w/wdp6c3tyxfha0l8",
-        "begin": "2015-07-05T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-05T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5by1",
-        "begin": "2015-07-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470289",
-        "begin": "2015-07-05T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "噬神者",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-05T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "113629"
       },
       {
-        "site": "saraba1st",
-        "id": "1058853"
-      },
-      {
         "site": "nicovideo",
         "id": "godeater-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1934,115 +912,45 @@
     "officialSite": "http://rokka-anime.jp/",
     "begin": "2015-07-04T17:58:00.000Z",
     "end": "2015-09-19T18:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "e/ekcyxmd6r13mh6o",
-        "begin": "2015-07-04T19:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "8nSAQ0J0quI",
-        "begin": "2015-07-04T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-04T19:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "e86a7b88197611e5b5ce",
-        "begin": "2015-07-04T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-04T19:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2584",
-        "begin": "2015-07-04T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-04T19:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10010418",
-        "begin": "2015-07-04T19:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-04T19:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "krehH4ftXZvibfOQ",
-        "begin": "2015-07-04T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-04T19:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5knt",
-        "begin": "2015-07-04T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470327",
-        "begin": "2015-07-04T19:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "六花的勇者",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-04T19:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "118067"
       },
       {
-        "site": "saraba1st",
-        "id": "1132308"
-      },
-      {
         "site": "nicovideo",
         "id": "rokka",
-        "begin": "2015-07-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T15:30:00.000Z"
       }
     ]
   },
@@ -2061,65 +969,25 @@
     "officialSite": "http://vproject.jp/anime/",
     "begin": "2015-07-05T13:00:00.000Z",
     "end": "2015-09-27T13:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470305",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "2599",
-        "begin": "2015-07-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-11T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "kbuVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "VENUS%20PROJECT",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "127294"
       },
       {
-        "site": "saraba1st",
-        "id": "1101700"
-      },
-      {
         "site": "nicovideo",
         "id": "venus-project-tv",
-        "begin": "2015-07-05T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-05T13:30:00.000Z"
       }
     ]
   },
@@ -2138,57 +1006,16 @@
     "officialSite": "http://www.wakakozake.jp/",
     "begin": "2015-07-05T13:25:00.000Z",
     "end": "2015-09-20T13:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470306",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "和歌子酒",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "2602",
-        "begin": "2015-07-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-04T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "cbe6bddc1afc11e5b2ad",
-        "begin": "2015-07-06T09:15:14.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "hAbiy9lIw6k",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-06T09:15:14.000Z"
       },
       {
         "site": "bangumi",
@@ -2197,12 +1024,7 @@
       {
         "site": "nicovideo",
         "id": "wakakozake_anime",
-        "begin": "2015-07-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-07T15:00:00.000Z"
       }
     ]
   },
@@ -2222,35 +1044,15 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/dragon_s/",
     "begin": "2015-07-05T00:00:00.000Z",
     "end": "2018-03-25T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb5shh",
-        "begin": "2015-07-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "龙珠%20超",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-05T03:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "132220"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1115780"
       }
     ]
   },
@@ -2269,37 +1071,11 @@
     "officialSite": "http://www.kbc.co.jp/santa/",
     "begin": "2015-07-04T16:42:00.000Z",
     "end": "2015-10-25T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470339",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "c36ad75a1afd11e5a080",
-        "begin": "2015-07-10T06:05:58.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "E8YUOmQkfmw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-10T06:05:58.000Z"
       },
       {
         "site": "bangumi",
@@ -2322,35 +1098,15 @@
     "officialSite": "http://www.j-toloveru.com/",
     "begin": "2015-07-06T15:00:00.000Z",
     "end": "2015-10-28T18:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "To%20Love%20RU%20Darkness%202nd",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "120763"
       },
       {
-        "site": "saraba1st",
-        "id": "1133092"
-      },
-      {
         "site": "nicovideo",
         "id": "to-love-ru4",
-        "begin": "2015-07-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T03:00:00.000Z"
       }
     ]
   },
@@ -2370,105 +1126,40 @@
     "officialSite": "http://clarines-kingdom.com/",
     "begin": "2015-07-06T15:00:00.000Z",
     "end": "2015-09-21T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "StDyVAcEEkA",
-        "begin": "2015-07-06T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "389e1aea197e11e5b5ce",
-        "begin": "2015-07-06T18:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-06T18:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2578",
-        "begin": "2015-07-06T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-06T18:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5pv5",
-        "begin": "2015-07-06T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-06T18:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "2/2hndczgdvkpzff5",
-        "begin": "2015-07-06T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470308",
-        "begin": "2015-07-06T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "赤发白雪姬",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-06T18:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "g6aSEHjeTozvbdU",
-        "begin": "2015-07-06T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-06T18:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "126034"
       },
       {
-        "site": "saraba1st",
-        "id": "1098643"
-      },
-      {
         "site": "nicovideo",
         "id": "clarines-kingdom",
-        "begin": "2015-07-18T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-18T14:30:00.000Z"
       }
     ]
   },
@@ -2487,18 +1178,7 @@
     "officialSite": "http://www.qtransformers.com/",
     "begin": "2015-07-06T09:55:00.000Z",
     "end": "2015-10-01T09:59:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "comment": "",
-        "exist": null,
-        "url": "http://www.bilibili.com/sp/Q%E7%89%88%E5%8F%98%E5%BD%A2%E9%87%91%E5%88%9A%2520%E5%BD%92%E6%9D%A5%E7%9A%84%E6%93%8E%E5%A4%A9%E6%9F%B1%E4%B9%8B%E8%B0%9C#S-2010"
-      },
       {
         "site": "bangumi",
         "id": "135992"
@@ -2506,12 +1186,7 @@
       {
         "site": "nicovideo",
         "id": "qtransformers",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2530,65 +1205,20 @@
     "officialSite": "http://www.nonnontv.com/top.html",
     "begin": "2015-07-06T17:05:00.000Z",
     "end": "2015-09-21T17:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "-3O0GyT_JkQ",
-        "begin": "2015-07-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "837ad5f2198411e5b432",
-        "begin": "2015-07-06T18:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470310",
-        "begin": "2015-07-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "悠哉日常大王%20Repeat",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-06T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "101442"
       },
       {
-        "site": "saraba1st",
-        "id": "960462"
-      },
-      {
         "site": "nicovideo",
         "id": "nonnontv02",
-        "begin": "2015-07-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-16T16:00:00.000Z"
       }
     ]
   },
@@ -2607,65 +1237,25 @@
     "officialSite": "http://overlord-anime.com/",
     "begin": "2015-07-07T14:00:00.000Z",
     "end": "2015-09-29T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2576",
-        "begin": "2015-07-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-07T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "64aa68201afd11e5b432",
-        "begin": "2015-07-07T15:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "q-oIiGcAaiI",
-        "begin": "2015-07-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Overlord",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-07T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "112146"
       },
       {
-        "site": "saraba1st",
-        "id": "1105959"
-      },
-      {
         "site": "nicovideo",
         "id": "overlord-anime",
-        "begin": "2015-07-16T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-16T17:00:00.000Z"
       }
     ]
   },
@@ -2684,65 +1274,25 @@
     "officialSite": "http://soregaseiyu.com/",
     "begin": "2015-07-07T14:00:00.000Z",
     "end": "2015-09-29T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2588",
-        "begin": "2015-07-07T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-07T20:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "fe0c3a541b1411e5b692",
-        "begin": "2015-07-07T20:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "muSo-21H4qo",
-        "begin": "2015-07-07T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "那就是声优",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-07T20:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "121377"
       },
       {
-        "site": "saraba1st",
-        "id": "1089124"
-      },
-      {
         "site": "nicovideo",
         "id": "soregaseiyu",
-        "begin": "2015-07-10T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-10T13:30:00.000Z"
       }
     ]
   },
@@ -2762,65 +1312,20 @@
     "officialSite": "http://jitsuwata.tv/",
     "begin": "2015-07-06T16:35:00.000Z",
     "end": "2015-09-28T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "XJZSLm81Y-8",
-        "begin": "2015-07-06T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "961bfe7c197d11e5b5ce",
-        "begin": "2015-07-06T17:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470291",
-        "begin": "2015-07-06T17:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "其实我是",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-06T17:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "123539"
       },
       {
-        "site": "saraba1st",
-        "id": "1105933"
-      },
-      {
         "site": "nicovideo",
         "id": "jitsuwata",
-        "begin": "2015-07-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-13T03:00:00.000Z"
       }
     ]
   },
@@ -2840,47 +1345,16 @@
     "officialSite": "http://milliondoll.com/",
     "begin": "2015-07-06T16:11:00.000Z",
     "end": "2015-09-21T16:16:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2577",
-        "begin": "2015-07-06T16:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-06T16:20:00.000Z"
       },
       {
         "site": "youku",
         "id": "6627edf21afe11e5b5ce",
-        "begin": "2015-07-06T16:20:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ZTzQXgNfUcg",
-        "begin": "2015-07-06T16:20:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Million%20Doll",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-06T16:20:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2889,12 +1363,7 @@
       {
         "site": "nicovideo",
         "id": "animemd",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2915,55 +1384,20 @@
     "officialSite": "http://monmusu.tv/",
     "begin": "2015-07-07T15:30:00.000Z",
     "end": "2015-09-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "8/8yjy00f3wg1tz63",
-        "begin": "2015-07-07T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "魔物娘的相伴日常",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2624",
-        "begin": "2015-07-07T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-07T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "127979"
       },
       {
-        "site": "saraba1st",
-        "id": "1112789"
-      },
-      {
         "site": "nicovideo",
         "id": "monmusu-anime",
-        "begin": "2015-07-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T16:00:00.000Z"
       }
     ]
   },
@@ -2982,55 +1416,20 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2015-07-06T16:05:00.000Z",
     "end": "2015-09-21T16:08:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470290",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "2604",
-        "begin": "2015-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "网球并不可笑嘛Ⅴ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "130452"
       },
       {
-        "site": "saraba1st",
-        "id": "861754"
-      },
-      {
         "site": "nicovideo",
         "id": "te-kyu5",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3049,75 +1448,25 @@
     "officialSite": "http://www.kaijusakabakanpai.com/",
     "begin": "2015-07-07T12:55:00.000Z",
     "end": "2015-09-29T13:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "怪兽酒场干杯！",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470311",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "2608",
-        "begin": "2015-07-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-06T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "14019f301b1411e5b522",
-        "begin": "2015-07-10T06:05:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "-ScJYfqsTf4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-10T06:05:58.000Z"
       },
       {
         "site": "pptv",
         "id": "RefRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "133962"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1120026"
       }
     ]
   },
@@ -3136,75 +1485,30 @@
     "officialSite": "http://ku-sen.jp/",
     "begin": "2015-07-08T15:30:00.000Z",
     "end": "2015-09-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2583",
-        "begin": "2015-07-08T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T17:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "a/aan1um3pt3nue20",
-        "begin": "2015-07-08T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T17:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "1675c8261afc11e5b5ce",
-        "begin": "2015-07-08T17:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "5Uc8Zc-opHo",
-        "begin": "2015-07-08T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "空战魔导士候补生的教官",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-08T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "108377"
       },
       {
-        "site": "saraba1st",
-        "id": "1041582"
-      },
-      {
         "site": "nicovideo",
         "id": "ku-sen",
-        "begin": "2015-07-25T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-25T03:00:00.000Z"
       }
     ]
   },
@@ -3224,47 +1528,11 @@
     "officialSite": "http://bikini-warriors.com/anime/",
     "begin": "2015-07-07T16:35:00.000Z",
     "end": "2015-09-22T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10010613",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470313",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "比基尼勇士",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2609",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3273,12 +1541,7 @@
       {
         "site": "nicovideo",
         "id": "bikini-warriors",
-        "begin": "2015-07-07T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-07T16:35:00.000Z"
       }
     ]
   },
@@ -3298,65 +1561,25 @@
     "officialSite": "http://suzakinishi.tv/",
     "begin": "2015-07-08T12:55:00.000Z",
     "end": "2015-09-23T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2593",
-        "begin": "2015-07-08T12:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T12:55:00.000Z"
       },
       {
         "site": "youku",
         "id": "e09e684a1ae511e5a080",
-        "begin": "2015-07-08T12:55:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "dJ1sytgsCa4",
-        "begin": "2015-07-08T12:55:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "洲崎西",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-08T12:55:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "135202"
       },
       {
-        "site": "saraba1st",
-        "id": "1130470"
-      },
-      {
         "site": "nicovideo",
         "id": "suzakinishi",
-        "begin": "2015-07-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T03:00:00.000Z"
       }
     ]
   },
@@ -3375,85 +1598,35 @@
     "officialSite": "http://gakkougurashi.com/",
     "begin": "2015-07-09T12:30:00.000Z",
     "end": "2015-09-24T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9o7qd",
-        "begin": "2016-08-17T06:57:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-17T06:57:17.000Z"
       },
       {
         "site": "bilibili",
         "id": "2592",
-        "begin": "2015-07-09T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T18:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "f/f6za0go0jf6fzrm",
-        "begin": "2015-07-09T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T18:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "9e7a96501af911e5b432",
-        "begin": "2015-07-09T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "VS6KqsiOduc",
-        "begin": "2015-07-09T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "学园孤岛",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-09T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "106693"
       },
       {
-        "site": "saraba1st",
-        "id": "1098963"
-      },
-      {
         "site": "nicovideo",
         "id": "gakkougurashi",
-        "begin": "2015-07-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T16:00:00.000Z"
       }
     ]
   },
@@ -3472,31 +1645,15 @@
     "officialSite": "http://suzukisan.info/",
     "begin": "2015-07-08T16:05:00.000Z",
     "end": "2015-09-23T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "q/q9zzprtw17v6r01",
-        "begin": "2015-07-08T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "109541"
-      },
-      {
-        "site": "bilibili",
-        "id": "2627",
-        "begin": "2015-07-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -3517,125 +1674,50 @@
     "officialSite": "http://umaru-ani.me/",
     "begin": "2015-07-08T17:15:00.000Z",
     "end": "2015-09-23T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iaaCMCnLYSIbpZ88",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "291320",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "4IsZAYXiK2M",
-        "begin": "2015-07-08T19:14:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "c4d8c0401afb11e5b5ce",
-        "begin": "2015-07-08T19:14:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T19:14:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2580",
-        "begin": "2015-07-08T19:14:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T19:14:00.000Z"
       },
       {
         "site": "letv",
         "id": "10010414",
-        "begin": "2015-07-08T19:14:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-08T19:14:00.000Z"
       },
       {
         "site": "qq",
         "id": "3/3lriily11h16j01",
-        "begin": "2015-07-08T19:14:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-08T19:14:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5bo5",
-        "begin": "2015-07-08T19:14:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470315",
-        "begin": "2015-07-08T19:14:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "干物妹",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-08T19:14:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "120187"
       },
       {
-        "site": "saraba1st",
-        "id": "1121104"
-      },
-      {
         "site": "nicovideo",
         "id": "umaru-anime",
-        "begin": "2015-07-13T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-13T13:00:00.000Z"
       }
     ]
   },
@@ -3654,65 +1736,25 @@
     "officialSite": "http://www.dreamcreation.co.jp/danchigai/",
     "begin": "2015-07-09T16:00:00.000Z",
     "end": "2015-09-24T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2614",
-        "begin": "2015-07-09T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T16:15:00.000Z"
       },
       {
         "site": "youku",
         "id": "ff6613541af911e5b5ce",
-        "begin": "2015-07-09T16:15:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "jMT-3fMlm9I",
-        "begin": "2015-07-09T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "群居姐妹",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-09T16:15:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "125896"
       },
       {
-        "site": "saraba1st",
-        "id": "1103737"
-      },
-      {
         "site": "nicovideo",
         "id": "danchigai",
-        "begin": "2015-07-14T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-14T12:00:00.000Z"
       }
     ]
   },
@@ -3731,45 +1773,15 @@
     "officialSite": "http://prison-anime.com/",
     "begin": "2015-07-10T16:05:00.000Z",
     "end": "2015-09-25T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "o/ouwrkn72batk58k",
-        "begin": "2015-07-10T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2625",
-        "begin": "2015-07-10T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "监狱学园",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-10T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "110048"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1134032"
       }
     ]
   },
@@ -3788,37 +1800,16 @@
     "officialSite": "http://makuranodanshi.com/",
     "begin": "2015-07-13T16:16:00.000Z",
     "end": "2015-09-28T16:09:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "v/vxk0pmz40gf0hz0",
-        "begin": "2015-07-13T16:15:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-13T16:15:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2610",
-        "begin": "2015-07-13T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "枕男子",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-13T16:15:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3827,12 +1818,7 @@
       {
         "site": "nicovideo",
         "id": "makuranodanshi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3851,115 +1837,40 @@
     "officialSite": "http://imas-cinderella.com/",
     "begin": "2015-07-17T15:00:00.000Z",
     "end": "2015-10-16T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2594",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "qgdKuHlPg9g",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-07-17T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "1e13314abec311e38b3f",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470343",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-17T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhay5rp",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-17T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10007495",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-17T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "UfPdW8Mpmdc6uCA",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "kankan",
-        "id": "87458",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-17T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "w/wgzklo5zkrgalda",
-        "begin": "2015-07-17T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "偶像大师灰姑娘",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-17T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "130231"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1059367"
       }
     ]
   },
@@ -3979,75 +1890,30 @@
     "officialSite": "http://anime.prisma-illya.jp/2weihelz/",
     "begin": "2015-07-24T16:40:00.000Z",
     "end": "2015-09-25T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10029260",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2575",
-        "begin": "2015-07-24T18:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470318",
-        "begin": "2015-07-24T18:10:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-24T18:10:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5qkt",
-        "begin": "2015-07-24T18:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "魔法少女☆伊莉雅%202wei%20Herz!",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-07-24T18:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "113134"
       },
       {
-        "site": "saraba1st",
-        "id": "1137399"
-      },
-      {
         "site": "nicovideo",
         "id": "prisma-illya02",
-        "begin": "2015-08-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-13T03:00:00.000Z"
       }
     ]
   },
@@ -4066,7 +1932,6 @@
     "officialSite": "http://www.comico.jp/special/index.nhn?docno=1",
     "begin": "2015-07-02T12:55:00.000Z",
     "end": "2015-09-24T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4089,17 +1954,11 @@
     "officialSite": "http://littlewitchacademia.jp/",
     "begin": "2015-07-03T16:00:00.000Z",
     "end": "2015-07-03T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10010553",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4108,12 +1967,7 @@
       {
         "site": "netflix",
         "id": "80078599",
-        "begin": "2015-10-09T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T19:00:00.000Z"
       }
     ]
   },
@@ -4129,37 +1983,21 @@
     "officialSite": "http://www.geass.jp/akito/",
     "begin": "2015-07-04T16:00:00.000Z",
     "end": "2015-07-04T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "otmjIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9mhz9",
-        "begin": "2016-08-31T16:02:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:02:16.000Z"
       },
       {
         "site": "letv",
         "id": "82177",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4179,7 +2017,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2015-07-18T16:00:00.000Z",
     "end": "2015-07-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4188,32 +2025,17 @@
       {
         "site": "pptv",
         "id": "jLiaUEnrgUI7xb9c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "7/7ae7ryh30iv3gpm",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "6480",
-        "begin": "2015-07-17T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-17T16:00:01.000Z"
       }
     ]
   },
@@ -4229,7 +2051,6 @@
     "officialSite": "http://www.pokemon-movie.jp/short/",
     "begin": "2015-07-18T17:10:00.000Z",
     "end": "2015-07-18T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4249,17 +2070,11 @@
     "officialSite": "http://www.pokemon-movie.jp/short/",
     "begin": "2015-07-25T16:00:00.000Z",
     "end": "2015-07-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2HJe3ESqGlia7OaE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4279,17 +2094,11 @@
     "officialSite": "http://musani.jp/works/index-2.html",
     "begin": "2015-07-29T16:00:00.000Z",
     "end": "2015-07-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "5Ucxrxd97SuODHQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4298,12 +2107,7 @@
       {
         "site": "bilibili",
         "id": "4148",
-        "begin": "2015-07-28T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-28T16:00:01.000Z"
       }
     ]
   },
@@ -4319,17 +2123,11 @@
     "officialSite": "",
     "begin": "2015-07-25T16:00:00.000Z",
     "end": "2015-07-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "2XNd20OpGVe6OKA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4349,7 +2147,6 @@
     "officialSite": "",
     "begin": "2015-07-03T16:00:00.000Z",
     "end": "2015-07-10T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4358,22 +2155,12 @@
       {
         "site": "nicovideo",
         "id": "peepingk",
-        "begin": "2015-07-10T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-10T06:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3912",
-        "begin": "2015-07-09T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-09T16:00:01.000Z"
       }
     ]
   },
@@ -4385,7 +2172,6 @@
     "officialSite": "http://www.abekin.com/",
     "begin": "2015-07-04T16:00:00.000Z",
     "end": "2015-08-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4394,12 +2180,7 @@
       {
         "site": "nicovideo",
         "id": "kinyoru-abereiji",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4415,7 +2196,6 @@
     "officialSite": "",
     "begin": "2015-07-03T16:00:00.000Z",
     "end": "2015-12-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4424,12 +2204,7 @@
       {
         "site": "pptv",
         "id": "Ig3nZc0zoibFEwiao",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4445,7 +2220,6 @@
     "officialSite": "http://honeyworks.jp/release/06.html",
     "begin": "2015-07-15T16:00:00.000Z",
     "end": "2015-07-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4454,12 +2228,7 @@
       {
         "site": "bilibili",
         "id": "4140",
-        "begin": "2015-07-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-07-14T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2015/08.json
+++ b/data/items/2015/08.json
@@ -11,17 +11,11 @@
     "officialSite": "http://yuruyuri.com/nachup/",
     "begin": "2015-08-20T18:05:00.000Z",
     "end": "2015-09-17T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "YMyoJo70ZKIFgibs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "nicovideo",
         "id": "nachup",
-        "begin": "2015-08-28T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-28T12:00:00.000Z"
       }
     ]
   },
@@ -52,17 +41,11 @@
     "officialSite": "",
     "begin": "2015-08-22T16:00:00.000Z",
     "end": "2015-08-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb8evx",
-        "begin": "2016-04-27T15:15:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-27T15:15:23.000Z"
       },
       {
         "site": "bangumi",
@@ -82,41 +65,20 @@
     "officialSite": "",
     "begin": "2015-08-20T16:00:00.000Z",
     "end": "2016-08-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "y2RQzjacDEqtK5M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10033636",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "147365"
-      },
-      {
-        "site": "bilibili",
-        "id": "3468",
-        "begin": "2015-08-19T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -132,31 +94,15 @@
     "officialSite": "http://www.fujitv.co.jp/b_hp/150922osiris/index.html",
     "begin": "2015-08-01T16:00:00.000Z",
     "end": "2015-09-23T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "zV46uCCG9jSXFX0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "141588"
-      },
-      {
-        "site": "bilibili",
-        "id": "5425",
-        "begin": "2015-07-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -172,17 +118,11 @@
     "officialSite": "http://www.liverp.co.jp/ani_pu/gakuen-handsome/",
     "begin": "2015-08-28T16:00:00.000Z",
     "end": "2015-08-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "8Fo2tByC8jCTEXk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -191,12 +131,7 @@
       {
         "site": "letv",
         "id": "10014568",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -212,7 +147,6 @@
     "officialSite": "http://boruto-movie.com/",
     "begin": "2015-08-07T16:00:00.000Z",
     "end": "2015-08-07T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -221,22 +155,12 @@
       {
         "site": "nicovideo",
         "id": "boruto-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "1X1X1T2jE1G0Mpo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -252,7 +176,6 @@
     "officialSite": "http://www.aikatsu.com/event/ma2015/",
     "begin": "2015-08-22T16:00:00.000Z",
     "end": "2015-08-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -261,12 +184,7 @@
       {
         "site": "pptv",
         "id": "HQXvbdU7qiblMyjI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2015/09.json
+++ b/data/items/2015/09.json
@@ -14,45 +14,20 @@
     "officialSite": "http://anime-dialover.com/dlmb/",
     "begin": "2015-09-23T15:30:00.000Z",
     "end": "2015-12-09T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "n/ndd165x9imhawbd",
-        "begin": "2015-09-24T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "DIABOLIK%20LOVERS%20MORE,BLOOD",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-09-24T16:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "124778"
       },
       {
-        "site": "saraba1st",
-        "id": "1157747"
-      },
-      {
         "site": "nicovideo",
         "id": "dlmb",
-        "begin": "2015-10-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-11T03:00:00.000Z"
       }
     ]
   },
@@ -68,7 +43,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/tinny/",
     "begin": "2015-09-24T21:40:00.000Z",
     "end": "2016-03-24T21:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -88,27 +62,16 @@
     "officialSite": "http://www.kokosake.jp/",
     "begin": "2015-09-19T16:00:00.000Z",
     "end": "2015-09-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UffhX8ctndsibvCQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10020353",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -117,22 +80,12 @@
       {
         "site": "nicovideo",
         "id": "kokosake",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4032",
-        "begin": "2015-09-18T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-09-18T16:00:01.000Z"
       }
     ]
   },
@@ -148,7 +101,6 @@
     "officialSite": "http://wakeupgirls2.jp/",
     "begin": "2015-09-25T16:00:00.000Z",
     "end": "2015-09-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -157,22 +109,12 @@
       {
         "site": "nicovideo",
         "id": "wakeupgirls_seisilyun",
-        "begin": "2014-01-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2014-01-13T15:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "Vib7KSLAWhsQnpQ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -188,7 +130,6 @@
     "officialSite": "",
     "begin": "2015-09-18T16:00:00.000Z",
     "end": "2016-12-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -197,12 +138,7 @@
       {
         "site": "pptv",
         "id": "bcGrKZH3Z6UIhu4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2015/10.json
+++ b/data/items/2015/10.json
@@ -14,55 +14,25 @@
     "officialSite": "http://coco-tama.com/",
     "begin": "2015-10-01T09:00:00.000Z",
     "end": "2017-03-30T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ORLibfORKuvhb2UE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "见习神明%20秘密的COCOTAMA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3155",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "137894"
       },
       {
-        "site": "saraba1st",
-        "id": "1147280"
-      },
-      {
         "site": "nicovideo",
         "id": "cocotama",
-        "begin": "2015-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -82,35 +52,15 @@
     "officialSite": "http://www.aikatsu.net",
     "begin": "2015-10-01T09:30:00.000Z",
     "end": "2016-03-31T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbb1o9",
-        "begin": "2015-10-01T11:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "偶像活动",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-01T11:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "141616"
-      },
-      {
-        "site": "saraba1st",
-        "id": "930385"
       }
     ]
   },
@@ -130,105 +80,40 @@
     "officialSite": "http://www.tbs.co.jp/anime/lance/",
     "begin": "2015-10-01T16:46:00.000Z",
     "end": "2015-12-17T17:21:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2719",
-        "begin": "2015-10-02T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "qofDlUmBoxk",
-        "begin": "2015-10-02T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-02T04:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "1f9945d2d29f11e38b3f",
-        "begin": "2015-10-02T04:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-02T04:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10014178",
-        "begin": "2015-10-02T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-02T04:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbb445",
-        "begin": "2015-10-02T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-02T04:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "edKibPKQKergbmQE",
-        "begin": "2015-10-02T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470361",
-        "begin": "2015-10-02T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "枪与假面舞会",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-02T04:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "103023"
       },
       {
-        "site": "saraba1st",
-        "id": "1101013"
-      },
-      {
         "site": "nicovideo",
         "id": "lance",
-        "begin": "2015-10-08T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-08T13:30:00.000Z"
       }
     ]
   },
@@ -248,45 +133,20 @@
     "officialSite": "http://heavyobject.net/",
     "begin": "2015-10-02T15:30:00.000Z",
     "end": "2016-03-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2740",
-        "begin": "2015-10-02T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "重装武器",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-02T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "115008"
       },
       {
-        "site": "saraba1st",
-        "id": "1102877"
-      },
-      {
         "site": "nicovideo",
         "id": "heavyobject",
-        "begin": "2015-10-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-05T03:00:00.000Z"
       }
     ]
   },
@@ -306,45 +166,15 @@
     "officialSite": "http://lupin-new-season.jp/",
     "begin": "2015-10-01T17:50:00.000Z",
     "end": "2016-03-17T17:34:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "YLc8ApVAqoY",
-        "begin": "2015-10-01T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "鲁邦三世新系列",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "115661"
       },
       {
-        "site": "saraba1st",
-        "id": "1065326"
-      },
-      {
         "site": "nicovideo",
         "id": "lupin-new-season",
-        "begin": "2016-01-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-13T15:00:00.000Z"
       }
     ]
   },
@@ -363,105 +193,40 @@
     "officialSite": "http://hackadoll-anime.com/",
     "begin": "2015-10-02T14:00:00.000Z",
     "end": "2015-12-25T14:09:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ct23NZ0Dc7EUkvo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2721",
-        "begin": "2015-10-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "BX_pvExjOAQ",
-        "begin": "2015-10-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-02T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "413610aa569f11e59e2a",
-        "begin": "2015-10-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-02T15:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10014189",
-        "begin": "2015-10-02T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470362",
-        "begin": "2015-10-02T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Hacka%20Doll",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-02T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "132754"
       },
       {
-        "site": "saraba1st",
-        "id": "1146248"
-      },
-      {
         "site": "nicovideo",
         "id": "hackadoll",
-        "begin": "2015-10-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-04T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9i3il",
-        "begin": "2017-04-14T16:02:49.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-14T16:02:49.000Z"
       }
     ]
   },
@@ -480,27 +245,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/ybj/",
     "begin": "2015-10-01T17:16:00.000Z",
     "end": "2015-12-17T17:51:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2720",
-        "begin": "2015-10-02T07:24:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "青年黑杰克",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-02T07:24:00.000Z"
       },
       {
         "site": "bangumi",
@@ -524,85 +273,35 @@
     "officialSite": "http://kagewani.com/",
     "begin": "2015-10-02T14:17:00.000Z",
     "end": "2015-12-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "j59591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "uxRIDh_CxPw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "02007bfe55ec11e5b2ad",
-        "begin": "2015-10-14T07:05:10.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-14T07:05:10.000Z"
       },
       {
         "site": "letv",
         "id": "10014195",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "影鳄",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "145735"
       },
       {
-        "site": "saraba1st",
-        "id": "1159908"
-      },
-      {
         "site": "nicovideo",
         "id": "kagewani",
-        "begin": "2015-10-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-02T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "2848",
-        "begin": "2015-10-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-01T16:00:00.000Z"
       }
     ]
   },
@@ -621,27 +320,11 @@
     "officialSite": "http://www.starchild.co.jp/special/miss_monochrome_anime_2/",
     "begin": "2015-10-02T13:30:00.000Z",
     "end": "2015-12-25T13:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2791",
-        "begin": "2015-10-02T13:16:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "黑白小姐%20第三季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-02T13:16:00.000Z"
       },
       {
         "site": "bangumi",
@@ -650,12 +333,7 @@
       {
         "site": "nicovideo",
         "id": "miss-monochrome3",
-        "begin": "2015-10-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-04T16:30:00.000Z"
       }
     ]
   },
@@ -674,45 +352,20 @@
     "officialSite": "http://k-project-come-back.jpn.com/",
     "begin": "2015-10-02T16:55:00.000Z",
     "end": "2015-12-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2725",
-        "begin": "2015-10-02T18:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "K%20Return%20of%20Kings",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-02T18:40:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "115917"
       },
       {
-        "site": "saraba1st",
-        "id": "1096336"
-      },
-      {
         "site": "nicovideo",
         "id": "k-project02",
-        "begin": "2015-10-07T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T13:30:00.000Z"
       }
     ]
   },
@@ -732,95 +385,35 @@
     "officialSite": "http://www.ittoshura.com/",
     "begin": "2015-10-03T14:00:00.000Z",
     "end": "2015-12-19T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2743",
-        "begin": "2015-10-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "LOyw2nHROqI",
-        "begin": "2015-10-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-03T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "28181c0256a511e5b5ce",
-        "begin": "2015-10-03T15:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-03T15:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "Uv3XVb0jk9E0sho",
-        "begin": "2015-10-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470365",
-        "begin": "2015-10-03T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "落第骑士英雄谭",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-03T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "127724"
       },
       {
-        "site": "saraba1st",
-        "id": "1102738"
-      },
-      {
         "site": "nicovideo",
         "id": "ittoshura",
-        "begin": "2015-10-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-06T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh83ph1",
-        "begin": "2017-06-30T16:02:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:28.000Z"
       }
     ]
   },
@@ -839,45 +432,20 @@
     "officialSite": "http://noragami-anime.net/",
     "begin": "2015-10-02T16:05:00.000Z",
     "end": "2015-12-25T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2732",
-        "begin": "2015-10-02T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "野良神%20ARAGOTO",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-02T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "129988"
       },
       {
-        "site": "saraba1st",
-        "id": "1108706"
-      },
-      {
         "site": "nicovideo",
         "id": "noragami-anime2",
-        "begin": "2015-10-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T03:00:00.000Z"
       }
     ]
   },
@@ -896,25 +464,15 @@
     "officialSite": "http://fafner-exodus.jp",
     "begin": "2015-10-02T17:25:00.000Z",
     "end": "2015-12-25T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhax0et",
-        "begin": "2015-10-02T19:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-02T19:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "130230"
-      },
-      {
-        "site": "saraba1st",
-        "id": "905127"
       }
     ]
   },
@@ -935,45 +493,20 @@
     "officialSite": "http://asterisk-war.com/",
     "begin": "2015-10-03T11:30:00.000Z",
     "end": "2015-12-19T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2722",
-        "begin": "2015-10-03T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "学战都市Asterisk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-03T13:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "130250"
       },
       {
-        "site": "saraba1st",
-        "id": "1136086"
-      },
-      {
         "site": "nicovideo",
         "id": "asterisk-war",
-        "begin": "2015-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -993,27 +526,11 @@
     "officialSite": "http://www.anime-muco.com/",
     "begin": "2015-10-03T00:14:00.000Z",
     "end": "2016-03-26T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2794",
-        "begin": "2015-10-08T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "家有穆克",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-08T16:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1022,12 +539,7 @@
       {
         "site": "nicovideo",
         "id": "anime-muco",
-        "begin": "2015-11-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-11T03:00:00.000Z"
       }
     ]
   },
@@ -1046,45 +558,20 @@
     "officialSite": "http://www.monogatari-series.com/owarimonogatari/",
     "begin": "2015-10-03T15:00:00.000Z",
     "end": "2015-12-19T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2747",
-        "begin": "2015-10-09T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "终物语",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-09T06:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "138829"
       },
       {
-        "site": "saraba1st",
-        "id": "1130914"
-      },
-      {
         "site": "nicovideo",
         "id": "owarimonogatari",
-        "begin": "2015-10-07T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T14:30:00.000Z"
       }
     ]
   },
@@ -1103,27 +590,11 @@
     "officialSite": "http://www.ytv.co.jp/kindaichi_r/",
     "begin": "2015-10-03T08:30:00.000Z",
     "end": "2016-03-26T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb2729",
-        "begin": "2015-10-09T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "金田一少年事件簿R%20第二季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-09T00:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1132,12 +603,7 @@
       {
         "site": "nicovideo",
         "id": "kindaichi_r2",
-        "begin": "2015-10-05T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-05T06:00:00.000Z"
       }
     ]
   },
@@ -1156,55 +622,20 @@
     "officialSite": "http://www.j-haikyu.com/anime/",
     "begin": "2015-10-03T17:58:00.000Z",
     "end": "2016-03-26T18:28:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "AlsHvzonFNY",
-        "begin": "2015-10-03T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "8cc9553c560d11e5b432",
-        "begin": "2015-10-03T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "排球少年%20第二季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-03T18:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "120236"
       },
       {
-        "site": "saraba1st",
-        "id": "1157781"
-      },
-      {
         "site": "nicovideo",
         "id": "haikyu02",
-        "begin": "2015-10-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T03:00:00.000Z"
       }
     ]
   },
@@ -1223,45 +654,15 @@
     "officialSite": "http://utawarerumono.jp/",
     "begin": "2015-10-03T16:00:00.000Z",
     "end": "2016-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "2761",
-        "begin": "2015-10-03T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "传颂之物%20虚伪的假面",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "136336"
       },
       {
-        "site": "saraba1st",
-        "id": "1161732"
-      },
-      {
         "site": "nicovideo",
         "id": "utawarerumono02",
-        "begin": "2015-10-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T15:00:00.000Z"
       }
     ]
   },
@@ -1281,28 +682,7 @@
     "officialSite": "http://www.kbc.co.jp/kowabon/index.html",
     "begin": "2015-10-09T16:55:00.000Z",
     "end": "2016-01-01T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "2795",
-        "begin": "2015-10-03T16:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "KOWABON",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "136764"
@@ -1324,27 +704,11 @@
     "officialSite": "http://komori-anime.com/",
     "begin": "2015-10-04T13:27:00.000Z",
     "end": "2015-12-20T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2744",
-        "begin": "2015-10-04T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "小森同学拒绝不了",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-04T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1353,12 +717,7 @@
       {
         "site": "nicovideo",
         "id": "komori-anime",
-        "begin": "2015-10-11T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-11T13:00:00.000Z"
       }
     ]
   },
@@ -1378,27 +737,11 @@
     "officialSite": "http://rainycocoa.jp/anime/",
     "begin": "2015-10-04T13:15:00.000Z",
     "end": "2015-10-18T13:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2763",
-        "begin": "2015-10-04T15:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "雨色可可",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-04T15:15:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1407,12 +750,7 @@
       {
         "site": "nicovideo",
         "id": "rainycocoa2",
-        "begin": "2015-10-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-05T15:00:00.000Z"
       }
     ]
   },
@@ -1432,75 +770,30 @@
     "officialSite": "http://www.hakone-chan.jp/",
     "begin": "2015-10-04T11:55:00.000Z",
     "end": "2015-12-27T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2729",
-        "begin": "2015-10-04T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-04T16:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbax91",
-        "begin": "2015-10-04T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-04T16:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "26ba1dc456b911e5b432",
-        "begin": "2015-10-04T16:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "F7WYyzcLqp8",
-        "begin": "2015-10-04T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "温泉幼精小箱根",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-04T16:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "138960"
       },
       {
-        "site": "saraba1st",
-        "id": "1131595"
-      },
-      {
         "site": "nicovideo",
         "id": "hakone-chan",
-        "begin": "2015-10-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T03:00:00.000Z"
       }
     ]
   },
@@ -1519,75 +812,25 @@
     "officialSite": "http://concreterevolutio.com/",
     "begin": "2015-10-04T14:00:00.000Z",
     "end": "2015-12-27T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2741",
-        "begin": "2015-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "_qQRLVfjQsE",
-        "begin": "2015-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-04T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "189c428856bb11e5b432",
-        "begin": "2015-10-04T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470373",
-        "begin": "2015-10-04T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Concrete%20Revolutio%20超人幻想",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-04T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "139022"
       },
       {
-        "site": "saraba1st",
-        "id": "1131688"
-      },
-      {
         "site": "iqiyi",
         "id": "a_19rrh82u99",
-        "begin": "2017-06-30T16:02:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:42.000Z"
       }
     ]
   },
@@ -1607,65 +850,20 @@
     "officialSite": "http://g-tekketsu.com/1st/",
     "begin": "2015-10-04T08:00:00.000Z",
     "end": "2016-03-27T09:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "0cpgYEhhh8Y",
-        "begin": "2015-10-04T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "2c1e303055f011e5a080",
-        "begin": "2015-10-04T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-04T10:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "2723",
-        "begin": "2015-10-04T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470371",
-        "begin": "2015-10-04T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "机动战士高达：铁血的奥尔芬斯",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "id": "4310042",
+        "begin": "2015-10-04T10:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "139324"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1148153"
       }
     ]
   },
@@ -1684,75 +882,25 @@
     "officialSite": "http://comet-lucifer.jp/",
     "begin": "2015-10-04T13:30:00.000Z",
     "end": "2015-12-20T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2745",
-        "begin": "2015-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "HjdquAXsNdI",
-        "begin": "2015-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-04T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "a19a996458ef11e5b692",
-        "begin": "2015-10-04T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470372",
-        "begin": "2015-10-04T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "彗星·路西法",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-04T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "141225"
       },
       {
-        "site": "saraba1st",
-        "id": "1130468"
-      },
-      {
         "site": "iqiyi",
         "id": "a_19rrh84jt1",
-        "begin": "2017-06-30T16:02:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:42.000Z"
       }
     ]
   },
@@ -1773,85 +921,30 @@
     "officialSite": "http://kyojinchu.tv/",
     "begin": "2015-10-03T16:58:00.000Z",
     "end": "2015-12-19T17:28:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "I1vUTf9SSUg",
-        "begin": "2015-10-03T21:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "a29bac3c575e11e5b432",
-        "begin": "2015-10-03T21:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-03T21:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "jp56ibGDGNnTXVb0",
-        "begin": "2015-10-03T21:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470366",
-        "begin": "2015-10-03T21:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "进击！巨人中学校",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-03T21:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbb1sl",
-        "begin": "2015-10-03T21:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-03T21:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "141781"
       },
       {
-        "site": "saraba1st",
-        "id": "1139410"
-      },
-      {
         "site": "nicovideo",
         "id": "kyojinchu",
-        "begin": "2015-10-05T16:50:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-05T16:50:00.000Z"
       }
     ]
   },
@@ -1870,27 +963,11 @@
     "officialSite": "http://www.ntv.co.jp/pltv/",
     "begin": "2015-10-03T18:05:00.000Z",
     "end": "2015-12-19T18:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2872",
-        "begin": "2015-10-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Peeping%20Life",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-02T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1899,12 +976,7 @@
       {
         "site": "nicovideo",
         "id": "peeping_01",
-        "begin": "2015-10-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-04T03:00:00.000Z"
       }
     ]
   },
@@ -1924,65 +996,25 @@
     "officialSite": "http://onepunchman-anime.net/",
     "begin": "2015-10-04T16:05:00.000Z",
     "end": "2015-12-20T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "0ooe9ORrppg",
-        "begin": "2015-10-04T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "0b39c5b6569311e5b2ad",
-        "begin": "2015-10-04T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "一拳超人",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-04T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "127563"
       },
       {
-        "site": "saraba1st",
-        "id": "1105845"
-      },
-      {
         "site": "nicovideo",
         "id": "onepunchman",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80117291",
-        "begin": "2017-03-20T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-20T07:00:00.000Z"
       }
     ]
   },
@@ -2001,57 +1033,16 @@
     "officialSite": "http://hstar-mu.com/",
     "begin": "2015-10-05T15:00:00.000Z",
     "end": "2015-12-21T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2735",
-        "begin": "2015-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "W1KtYayxj5s",
-        "begin": "2015-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-05T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "5f9e34d6569111e5b5ce",
-        "begin": "2015-10-05T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470374",
-        "begin": "2015-10-05T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "高校星歌剧",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2060,22 +1051,12 @@
       {
         "site": "nicovideo",
         "id": "hstar-mu",
-        "begin": "2015-10-05T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-05T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh830n9",
-        "begin": "2017-06-30T16:02:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:37.000Z"
       }
     ]
   },
@@ -2095,45 +1076,20 @@
     "officialSite": "http://ariaaa.tv/",
     "begin": "2015-10-06T14:00:00.000Z",
     "end": "2015-12-22T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2764",
-        "begin": "2015-10-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "绯弹的亚里亚AA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-06T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "120224"
       },
       {
-        "site": "saraba1st",
-        "id": "1082745"
-      },
-      {
         "site": "nicovideo",
         "id": "ariaaa",
-        "begin": "2015-10-15T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-15T14:00:00.000Z"
       }
     ]
   },
@@ -2153,65 +1109,20 @@
     "officialSite": "http://yuruyuri.com/3hai/",
     "begin": "2015-10-05T17:05:00.000Z",
     "end": "2015-12-21T17:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "FhdeAF2OAAg",
-        "begin": "2015-10-05T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "3d7c3ba456a111e5b522",
-        "begin": "2015-10-05T18:05:00.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470376",
-        "begin": "2015-10-05T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "摇曳百合3☆hi!",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-05T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "127573"
       },
       {
-        "site": "saraba1st",
-        "id": "1102324"
-      },
-      {
         "site": "nicovideo",
         "id": "3hai",
-        "begin": "2015-10-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-12T03:00:00.000Z"
       }
     ]
   },
@@ -2232,87 +1143,31 @@
     "officialSite": "http://www.animax.co.jp/special/atashinchi/",
     "begin": "2015-10-06T10:00:00.000Z",
     "end": "2016-04-05T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XPHbWcEnl9U4th4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhary39",
-        "begin": "2016-07-13T08:52:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-13T08:52:11.000Z"
       },
       {
         "site": "bilibili",
         "id": "2771",
-        "begin": "2015-10-06T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "GPrAs2nnGug",
-        "begin": "2015-10-06T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-06T10:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "a68531045c1f11e5b522",
-        "begin": "2015-10-06T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-06T10:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10014256",
-        "begin": "2015-10-06T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470377",
-        "begin": "2015-10-06T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "新我们这一家",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-06T10:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2335,65 +1190,20 @@
     "officialSite": "http://osomatsusan.com/",
     "begin": "2015-10-05T16:35:00.000Z",
     "end": "2016-03-28T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "WXDaOez0dhE",
-        "begin": "2015-10-05T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "bd38b4fa58f711e5b5ce",
-        "begin": "2015-10-05T17:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470375",
-        "begin": "2015-10-05T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "阿松",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-05T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "139408"
       },
       {
-        "site": "saraba1st",
-        "id": "1160386"
-      },
-      {
         "site": "nicovideo",
         "id": "osomatsusan",
-        "begin": "2015-10-18T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-18T15:30:00.000Z"
       }
     ]
   },
@@ -2412,45 +1222,20 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2015-10-05T16:05:00.000Z",
     "end": "2015-12-21T16:08:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2792",
-        "begin": "2015-10-05T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "网球并不可笑嘛%20第六季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-05T16:15:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "143751"
       },
       {
-        "site": "saraba1st",
-        "id": "861754"
-      },
-      {
         "site": "nicovideo",
         "id": "ch2614800",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2471,27 +1256,11 @@
     "officialSite": "http://jkmeshi.jp/",
     "begin": "2015-10-05T16:00:00.000Z",
     "end": "2016-03-28T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2767",
-        "begin": "2015-10-05T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "女高中生给你做饭了",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-05T16:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2500,12 +1269,7 @@
       {
         "site": "nicovideo",
         "id": "jkmeshi",
-        "begin": "2015-10-27T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-27T03:00:00.000Z"
       }
     ]
   },
@@ -2525,95 +1289,30 @@
     "officialSite": "http://syominsample-anime.jp/",
     "begin": "2015-10-07T14:30:00.000Z",
     "end": "2015-12-23T14:55:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "2730",
-        "begin": "2015-10-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "9rxB7Ov1uZw",
-        "begin": "2015-10-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "c95ea86255fe11e5b522",
-        "begin": "2015-10-07T15:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470379",
-        "begin": "2015-10-07T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbb0ht",
-        "begin": "2015-10-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T15:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "eNO9O6MJebcamAA",
-        "begin": "2015-10-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "我被绑架到贵族学校当“庶民样本”",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-07T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "107671"
       },
       {
-        "site": "saraba1st",
-        "id": "1090721"
-      },
-      {
         "site": "nicovideo",
         "id": "syominsample",
-        "begin": "2015-10-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-08T14:30:00.000Z"
       }
     ]
   },
@@ -2632,95 +1331,35 @@
     "officialSite": "http://dwd-anime.com/",
     "begin": "2015-10-07T14:30:00.000Z",
     "end": "2015-12-23T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhatfop",
-        "begin": "2016-08-12T09:21:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-12T09:21:17.000Z"
       },
       {
         "site": "bilibili",
         "id": "2746",
-        "begin": "2015-10-07T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "mPxo5ld_aMA",
-        "begin": "2015-10-07T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-07T18:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "55a1743056d611e5b5ce",
-        "begin": "2015-10-07T18:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470389",
-        "begin": "2015-10-07T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T18:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "dtmzMZnicb60QjvY",
-        "begin": "2015-10-07T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Dance%20with%20Devils",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-07T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "125049"
       },
       {
-        "site": "saraba1st",
-        "id": "1161113"
-      },
-      {
         "site": "nicovideo",
         "id": "dwd-anime",
-        "begin": "2015-10-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T15:00:00.000Z"
       }
     ]
   },
@@ -2740,85 +1379,30 @@
     "officialSite": "http://sakurakosan.jp/",
     "begin": "2015-10-07T15:30:00.000Z",
     "end": "2015-12-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2742",
-        "begin": "2015-10-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "GJXVfDKvkC8",
-        "begin": "2015-10-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-07T17:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "f4ee6f02560411e5b2ad",
-        "begin": "2015-10-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470387",
-        "begin": "2015-10-07T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T17:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10014274",
-        "begin": "2015-10-07T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "樱子小姐的脚下埋藏着尸体",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-07T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "126461"
       },
       {
-        "site": "saraba1st",
-        "id": "1099195"
-      },
-      {
         "site": "nicovideo",
         "id": "sakurakosan",
-        "begin": "2015-10-28T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-28T03:00:00.000Z"
       }
     ]
   },
@@ -2837,37 +1421,16 @@
     "officialSite": "http://www9.nhk.or.jp/anime/kz/",
     "begin": "2015-10-07T09:45:00.000Z",
     "end": "2016-01-27T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2738",
-        "begin": "2015-10-07T13:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T13:05:00.000Z"
       },
       {
         "site": "qq",
         "id": "g/gmtenlj7zwylo7k",
-        "begin": "2015-10-07T13:05:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "侦探小队KZ事件簿",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-07T13:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2890,37 +1453,11 @@
     "officialSite": "http://www.hikanukobinukaeriminuteiounitousouhanainodaaaaa.com/",
     "begin": "2015-10-06T16:35:00.000Z",
     "end": "2015-12-22T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "oGBfX_OIyx8",
-        "begin": "2015-10-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "f45e2814669111e59e2a",
-        "begin": "2015-10-06T17:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470378",
-        "begin": "2015-10-06T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-06T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2929,12 +1466,7 @@
       {
         "site": "nicovideo",
         "id": "ddhokuto2",
-        "begin": "2015-10-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-11T15:00:00.000Z"
       }
     ]
   },
@@ -2954,105 +1486,40 @@
     "officialSite": "http://35shoutai.jp/",
     "begin": "2015-10-07T16:05:00.000Z",
     "end": "2015-12-23T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2724",
-        "begin": "2015-10-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "wU9iDDItFRI",
-        "begin": "2015-10-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-07T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "701b312855fc11e5b5ce",
-        "begin": "2015-10-07T17:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470388",
-        "begin": "2015-10-07T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10014273",
-        "begin": "2015-10-07T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-07T17:35:00.000Z"
       },
       {
         "site": "pptv",
         "id": "UPvVU7shkc8ysBg",
-        "begin": "2015-10-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "对魔导学园35试验小队",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-07T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "102140"
       },
       {
-        "site": "saraba1st",
-        "id": "1015519"
-      },
-      {
         "site": "nicovideo",
         "id": "35shoutai",
-        "begin": "2015-10-24T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-24T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh82xr9",
-        "begin": "2017-06-30T16:02:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:47.000Z"
       }
     ]
   },
@@ -3072,65 +1539,20 @@
     "officialSite": "http://www.f-noitamina.com/",
     "begin": "2015-10-08T16:00:00.000Z",
     "end": "2015-12-17T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2726",
-        "begin": "2015-10-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "IaSMVxGAj8k",
-        "begin": "2015-10-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-08T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "7d187dc855fb11e5b522",
-        "begin": "2015-10-08T17:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470360",
-        "begin": "2015-10-08T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "全部成为F",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-08T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "118783"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1161125"
       }
     ]
   },
@@ -3149,27 +1571,11 @@
     "officialSite": "http://www.dreamcreation.co.jp/somera/",
     "begin": "2015-10-07T14:55:00.000Z",
     "end": "2015-12-23T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2733",
-        "begin": "2015-10-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "不思议美眉",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-08T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3178,12 +1584,7 @@
       {
         "site": "nicovideo",
         "id": "somera",
-        "begin": "2015-10-12T12:00:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-12T12:00:01.000Z"
       }
     ]
   },
@@ -3203,95 +1604,40 @@
     "officialSite": "http://owarino-seraph.jp/",
     "begin": "2015-10-10T13:00:00.000Z",
     "end": "2015-12-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "158845",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "2760",
-        "begin": "2015-10-15T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-15T18:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "u/ux693onqc07q98h",
-        "begin": "2015-10-15T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-15T18:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "u5F7ibWHHN3XYVr4",
-        "begin": "2015-10-15T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-15T18:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10008808",
-        "begin": "2015-10-15T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "oGlXUbsk0Hw",
-        "begin": "2015-10-15T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-15T18:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "7b76708ad29111e49e2a",
-        "begin": "2015-10-15T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "终结的炽天使",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-15T18:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "120705"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1052660"
       }
     ]
   },
@@ -3312,45 +1658,20 @@
     "officialSite": "http://www.gochiusa.com/",
     "begin": "2015-10-10T12:30:00.000Z",
     "end": "2015-12-26T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2762",
-        "begin": "2015-10-15T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "请问要来点兔子吗？？",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-15T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "123568"
       },
       {
-        "site": "saraba1st",
-        "id": "1014071"
-      },
-      {
         "site": "nicovideo",
         "id": "gochiusa2",
-        "begin": "2015-10-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-17T03:00:00.000Z"
       }
     ]
   },
@@ -3370,45 +1691,20 @@
     "officialSite": "http://anime-shinmaimaou.com/",
     "begin": "2015-10-09T16:40:00.000Z",
     "end": "2015-12-11T17:10:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "新妹魔王的契约者BURST",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "128885"
       },
       {
-        "site": "saraba1st",
-        "id": "1047900"
-      },
-      {
         "site": "nicovideo",
         "id": "shinmaimaou",
-        "begin": "2015-10-22T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-22T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "6288",
-        "begin": "2015-10-08T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-08T16:00:01.000Z"
       }
     ]
   },
@@ -3429,35 +1725,15 @@
     "officialSite": "http://valkyriedrive.jp/anime/",
     "begin": "2015-10-10T14:30:00.000Z",
     "end": "2015-12-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "Valkyrie%20Drive%20-Mermaid-",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "129091"
       },
       {
-        "site": "saraba1st",
-        "id": "1105939"
-      },
-      {
         "site": "nicovideo",
         "id": "valky_ied_ive",
-        "begin": "2015-10-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-13T15:30:00.000Z"
       }
     ]
   },
@@ -3476,87 +1752,31 @@
     "officialSite": "http://anime.monster-strike.com/",
     "begin": "2015-10-10T10:00:00.000Z",
     "end": "2016-01-02T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "166526",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "_YQwYxIgG6k",
-        "begin": "2015-10-14T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "ef37dd98560211e5b2ad",
-        "begin": "2015-10-14T12:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470402",
-        "begin": "2015-10-14T12:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-14T12:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2015/dhpgwdz",
-        "begin": "2015-10-14T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-14T12:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10014412",
-        "begin": "2015-10-14T12:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-14T12:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "6EQwrhZ87CqNC3M",
-        "begin": "2015-10-14T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "怪物弹珠",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-14T12:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3579,85 +1799,30 @@
     "officialSite": "http://garo-project.jp/ANIME2/",
     "begin": "2015-10-09T16:23:00.000Z",
     "end": "2016-04-01T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "2774",
-        "begin": "2015-10-09T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "lMHQ6VRSQx4",
-        "begin": "2015-10-09T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2015-10-09T17:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "0ba98662579c11e5a080",
-        "begin": "2015-10-09T17:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T17:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbb219",
-        "begin": "2015-10-09T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470395",
-        "begin": "2015-10-09T17:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "牙狼%20红莲之月",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-09T17:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "141078"
       },
       {
-        "site": "saraba1st",
-        "id": "1150733"
-      },
-      {
         "site": "nicovideo",
         "id": "garo-project2",
-        "begin": "2015-10-16T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-16T15:30:00.000Z"
       }
     ]
   },
@@ -3673,18 +1838,7 @@
     "officialSite": "http://etononeko.jp/",
     "begin": "2015-10-11T00:20:00.000Z",
     "end": "2016-01-10T00:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470396",
-        "begin": "2015-10-11T00:25:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "145912"
@@ -3707,15 +1861,10 @@
     "officialSite": "http://www.bravebeats.net/",
     "begin": "2015-10-10T22:00:00.000Z",
     "end": "2016-03-26T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "146402"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1156214"
       }
     ]
   },
@@ -3734,7 +1883,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cf-vanguard-g2/",
     "begin": "2015-10-11T01:00:00.000Z",
     "end": "2016-04-10T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3758,85 +1906,30 @@
     "officialSite": "http://anime-training.com/",
     "begin": "2015-10-12T16:11:00.000Z",
     "end": "2015-12-28T16:16:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "292433",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "2765",
-        "begin": "2015-10-12T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10014451",
-        "begin": "2015-10-12T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-12T19:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "a5fd9966560611e5b522",
-        "begin": "2015-10-12T19:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "5TV1Hxb6BTA",
-        "begin": "2015-10-12T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "动画锻炼！EX",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2015-10-12T19:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "145129"
       },
       {
-        "site": "saraba1st",
-        "id": "1167779"
-      },
-      {
         "site": "nicovideo",
         "id": "ch2614797",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3856,27 +1949,11 @@
     "officialSite": "http://ketsuekigatakun.com/",
     "begin": "2015-10-12T16:08:00.000Z",
     "end": "2015-12-28T16:11:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tucao",
-        "id": "血型君%20第三季",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "10014386",
-        "begin": "2015-10-12T17:08:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-12T17:08:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3885,12 +1962,7 @@
       {
         "site": "nicovideo",
         "id": "ch2614799",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3910,85 +1982,40 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_xyz/index2.html",
     "begin": "2015-10-29T10:00:00.000Z",
     "end": "2016-11-10T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ib1M9uyOJibTeaGIA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10024046",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "宠物小精灵XY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "146408"
       },
       {
-        "site": "saraba1st",
-        "id": "964044"
-      },
-      {
         "site": "mgtv",
         "id": "316942",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "o/o638xbha5jz73ya",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1mkud",
-        "begin": "2017-11-06T10:05:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-06T10:05:08.000Z"
       },
       {
         "site": "bilibili",
         "id": "5692",
-        "begin": "2015-10-28T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-28T16:00:01.000Z"
       }
     ]
   },
@@ -4000,7 +2027,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/dochamon/",
     "begin": "2015-10-05T09:45:00.000Z",
     "end": "2016-02-22T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4023,7 +2049,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/oshiri/",
     "begin": "2015-10-05T09:25:00.000Z",
     "end": "2015-12-07T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4043,7 +2068,6 @@
     "officialSite": "http://www.tv-osaka.co.jp/nekoyon/",
     "begin": "2015-10-02T15:54:00.000Z",
     "end": "2015-12-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4052,12 +2076,7 @@
       {
         "site": "bilibili",
         "id": "4106",
-        "begin": "2015-10-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-01T16:00:01.000Z"
       }
     ]
   },
@@ -4073,17 +2092,11 @@
     "officialSite": "http://www.aokihagane.com/",
     "begin": "2015-10-03T16:00:00.000Z",
     "end": "2015-10-03T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10010542",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4103,17 +2116,11 @@
     "officialSite": "http://www.precure-movie.com/",
     "begin": "2015-10-31T16:00:00.000Z",
     "end": "2015-10-31T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       },
       {
         "site": "bangumi",
@@ -4133,17 +2140,11 @@
     "officialSite": "http://project-itoh.com/",
     "begin": "2015-10-02T16:00:00.000Z",
     "end": "2015-10-02T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "TuHLSbEXh8Uopg4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4152,12 +2153,7 @@
       {
         "site": "bilibili",
         "id": "4098",
-        "begin": "2015-10-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-01T16:00:01.000Z"
       }
     ]
   },
@@ -4173,17 +2169,11 @@
     "officialSite": "",
     "begin": "2015-10-19T16:00:00.000Z",
     "end": "2017-04-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wmpGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4192,12 +2182,7 @@
       {
         "site": "bilibili",
         "id": "3421",
-        "begin": "2015-10-18T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-18T16:00:01.000Z"
       }
     ]
   },
@@ -4213,17 +2198,11 @@
     "officialSite": "",
     "begin": "2015-10-28T16:00:00.000Z",
     "end": "2015-10-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "GjQgngZs3Bp9ib2M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4243,7 +2222,6 @@
     "officialSite": "http://www.asread.net/bo.html",
     "begin": "2015-10-03T16:00:00.000Z",
     "end": "2015-10-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4252,22 +2230,12 @@
       {
         "site": "pptv",
         "id": "dMKuLJT6aqgLiafE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "4093",
-        "begin": "2015-10-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-02T16:00:01.000Z"
       }
     ]
   },
@@ -4279,7 +2247,6 @@
     "officialSite": "http://anime-dayan.com/",
     "begin": "2015-10-17T16:00:00.000Z",
     "end": "2016-01-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4288,12 +2255,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh5n9sd",
-        "begin": "2018-08-24T09:59:15.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-24T09:59:15.000Z"
       }
     ]
   }

--- a/data/items/2015/11.json
+++ b/data/items/2015/11.json
@@ -11,17 +11,11 @@
     "officialSite": "http://hamatorapj.com/minihama/",
     "begin": "2015-11-02T12:24:00.000Z",
     "end": "2016-01-04T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MRz4dt5EtPJV0zs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "2978",
-        "begin": "2015-11-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-11-01T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "http://www.nhk.or.jp/daisuki-tohoku/kakera/",
     "begin": "2015-11-27T16:00:00.000Z",
     "end": "2015-11-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10021758",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -82,17 +65,11 @@
     "officialSite": "http://digimon-adventure.net/",
     "begin": "2015-11-21T16:00:00.000Z",
     "end": "2015-11-21T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbcjih",
-        "begin": "2016-02-15T09:09:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-15T09:09:13.000Z"
       },
       {
         "site": "bangumi",
@@ -101,12 +78,7 @@
       {
         "site": "nicovideo",
         "id": "digimon-matome",
-        "begin": "2016-04-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-01T15:00:00.000Z"
       }
     ]
   },
@@ -126,17 +98,11 @@
     "officialSite": "http://project-itoh.com/",
     "begin": "2015-11-13T16:00:00.000Z",
     "end": "2015-11-13T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "UiczYVr4klNI1sxs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -156,31 +122,15 @@
     "officialSite": "http://www.durarara.com/ova/",
     "begin": "2015-11-14T16:00:00.000Z",
     "end": "2015-11-14T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PwnjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "145745"
-      },
-      {
-        "site": "bilibili",
-        "id": "3539",
-        "begin": "2015-11-13T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -196,7 +146,6 @@
     "officialSite": "http://www.strike-the-blood.com/",
     "begin": "2015-11-25T16:00:00.000Z",
     "end": "2015-12-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -205,12 +154,7 @@
       {
         "site": "nicovideo",
         "id": "strike-the-blood-ova",
-        "begin": "2016-11-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-17T15:00:00.000Z"
       }
     ]
   },
@@ -226,7 +170,6 @@
     "officialSite": "http://www.ajin.net/",
     "begin": "2015-11-27T16:00:00.000Z",
     "end": "2015-11-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -235,12 +178,7 @@
       {
         "site": "pptv",
         "id": "lruVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -259,7 +197,6 @@
     "officialSite": "http://009vsdevilman.com/",
     "begin": "2015-11-10T16:00:00.000Z",
     "end": "2015-11-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -269,10 +206,6 @@
         "site": "netflix",
         "id": "80094557",
         "begin": "2016-04-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
         "comment": "分割为 TV 放送"
       }
     ]
@@ -285,7 +218,6 @@
     "officialSite": "",
     "begin": "2015-11-07T16:00:00.000Z",
     "end": "2015-12-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -294,12 +226,7 @@
       {
         "site": "nicovideo",
         "id": "memetan-anime",
-        "begin": "2016-04-29T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-29T01:00:00.000Z"
       }
     ]
   }

--- a/data/items/2015/12.json
+++ b/data/items/2015/12.json
@@ -7,87 +7,41 @@
     "officialSite": "http://v.qq.com/vplus/shiguang",
     "begin": "2015-12-15T12:00:00.000Z",
     "end": "2016-03-08T12:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470410",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "3217",
-        "begin": "2015-12-15T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-15T16:00:01.000Z"
       },
       {
         "site": "pptv",
         "id": "5Ugkogpw4B6Bic2c",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "c/c1ld829macro80v",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbfrox",
-        "begin": "2015-12-15T01:53:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-15T01:53:23.000Z"
       },
       {
         "site": "letv",
         "id": "10016723",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2015/dhpsggyu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "168876",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -103,87 +57,36 @@
     "officialSite": "http://ac.qq.com/event/index1127.html",
     "begin": "2015-12-02T12:00:00.000Z",
     "end": "2016-03-16T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470409",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3160",
-        "begin": "2015-12-01T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "oYxo5k60JGLFQ6s",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "m/mw04ctse4gj4syj",
-        "begin": "2015-12-02T12:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-02T12:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbh6vt",
-        "begin": "2015-12-02T01:48:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-02T01:48:52.000Z"
       },
       {
         "site": "letv",
         "id": "10016275",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2015/dhpaqqkl",
-        "begin": "2015-12-02T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-02T06:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "168507",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -199,87 +102,41 @@
     "officialSite": "http://v.qq.com/vplus/tongzhizhe",
     "begin": "2015-12-31T12:00:00.000Z",
     "end": "2016-03-17T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470433",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "3270",
-        "begin": "2015-12-30T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-30T16:00:01.000Z"
       },
       {
         "site": "pptv",
         "id": "jXdn5EyyImDDQY0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "4/45gt081jkx8xv1n",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhbfwo5",
-        "begin": "2015-12-31T02:05:29.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-31T02:05:29.000Z"
       },
       {
         "site": "letv",
         "id": "10017262",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2015/dhptzz",
-        "begin": "2015-12-31T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-31T06:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "290286",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -299,17 +156,11 @@
     "officialSite": "http://gundam-tb.net/",
     "begin": "2015-12-25T16:00:00.000Z",
     "end": "2016-04-08T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6006",
-        "begin": "2015-12-24T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-24T16:00:01.000Z"
       },
       {
         "site": "bangumi",
@@ -330,17 +181,11 @@
     "officialSite": "https://one-piece.com/news/detail/20151109_2963",
     "begin": "2015-12-19T16:00:00.000Z",
     "end": "2015-12-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbguo1",
-        "begin": "2016-04-27T15:14:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-27T15:14:50.000Z"
       },
       {
         "site": "bangumi",
@@ -360,17 +205,11 @@
     "officialSite": "http://chibimaru-movie.com/",
     "begin": "2015-12-23T16:00:00.000Z",
     "end": "2015-12-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rr96zhhk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -390,17 +229,11 @@
     "officialSite": "http://www.ariacompany.net/",
     "begin": "2015-12-24T16:00:00.000Z",
     "end": "2016-06-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pohk4kqwIF7BP6c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -420,17 +253,11 @@
     "officialSite": "",
     "begin": "2015-12-04T16:00:00.000Z",
     "end": "2015-12-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xmdRzzedDUuuLJQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -450,7 +277,6 @@
     "officialSite": "http://movie-highspeed.com/",
     "begin": "2015-12-05T16:00:00.000Z",
     "end": "2015-12-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -459,32 +285,17 @@
       {
         "site": "nicovideo",
         "id": "movie-highspeed",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "speBic2fNPXveXMQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5239",
-        "begin": "2015-12-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-12-04T16:00:01.000Z"
       }
     ]
   },
@@ -500,7 +311,6 @@
     "officialSite": "http://wakeupgirls2.jp/",
     "begin": "2015-12-11T16:00:00.000Z",
     "end": "2015-12-11T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -509,12 +319,7 @@
       {
         "site": "pptv",
         "id": "Vib7KSLAWhsQnpQ0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2016/01.json
+++ b/data/items/2016/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www9.nhk.or.jp/anime/sushi/",
     "begin": "2016-01-01T13:00:00.000Z",
     "end": "2016-01-01T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3237",
-        "begin": "2016-01-01T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-01T16:00:01.000Z"
       },
       {
         "site": "bangumi",
@@ -45,65 +39,20 @@
     "officialSite": "http://pos-a.jp/",
     "begin": "2016-01-05T14:00:00.000Z",
     "end": "2016-03-22T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470413",
-        "begin": "2016-01-05T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "lSWn_fylZ2I",
-        "begin": "2016-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "3f75af0ea88011e5b692",
-        "begin": "2016-01-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "疾走王子",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "145781"
       },
       {
-        "site": "saraba1st",
-        "id": "1152318"
-      },
-      {
         "site": "nicovideo",
         "id": "pos-a",
-        "begin": "2016-01-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-06T16:30:00.000Z"
       }
     ]
   },
@@ -119,45 +68,20 @@
     "officialSite": "http://phantom-world.com/",
     "begin": "2016-01-06T15:00:00.000Z",
     "end": "2016-03-30T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "Qss__Gky9ts",
-        "begin": "2016-01-06T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "b75123f6a85211e5be16",
-        "begin": "2016-01-06T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-06T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "94040"
       },
       {
-        "site": "saraba1st",
-        "id": "1146412"
-      },
-      {
         "site": "nicovideo",
         "id": "phantom-world",
-        "begin": "2016-01-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T03:00:00.000Z"
       }
     ]
   },
@@ -176,45 +100,20 @@
     "officialSite": "http://norn9-nonet.com/",
     "begin": "2016-01-07T12:30:00.000Z",
     "end": "2016-03-24T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nqibJB2icVRYPmZMw",
-        "begin": "2016-01-07T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "NORN9",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-07T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "98638"
       },
       {
-        "site": "saraba1st",
-        "id": "1003386"
-      },
-      {
         "site": "nicovideo",
         "id": "norn9-nonet",
-        "begin": "2016-01-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-14T15:00:00.000Z"
       }
     ]
   },
@@ -230,65 +129,20 @@
     "officialSite": "http://haruchika-anime.jp/",
     "begin": "2016-01-06T16:35:00.000Z",
     "end": "2016-03-23T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470416",
-        "begin": "2016-01-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "CkSvtickrys",
-        "begin": "2016-01-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "3c4dc504a85411e59e2a",
-        "begin": "2016-01-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "春&夏推理事件簿",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-06T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "136213"
       },
       {
-        "site": "saraba1st",
-        "id": "1125193"
-      },
-      {
         "site": "nicovideo",
         "id": "haruchika",
-        "begin": "2016-01-20T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-20T14:00:00.000Z"
       }
     ]
   },
@@ -304,45 +158,15 @@
     "officialSite": "http://bokumachi-anime.com/",
     "begin": "2016-01-07T16:50:00.000Z",
     "end": "2016-03-24T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "a6j9-qsLInI",
-        "begin": "2016-01-07T17:45:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "17a6b178a85111e5be16",
-        "begin": "2016-01-07T17:45:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "只有我不在的街道",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-07T17:45:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "137722"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1203202"
       }
     ]
   },
@@ -361,65 +185,20 @@
     "officialSite": "http://activeraid.net/",
     "begin": "2016-01-07T13:00:00.000Z",
     "end": "2016-03-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470417",
-        "begin": "2016-01-07T13:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "gzuf2x7EDOk",
-        "begin": "2016-01-07T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "503b58c0a88a11e5a080",
-        "begin": "2016-01-07T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Active%20Raid%20机动强袭室第八组",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-07T13:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "148233"
       },
       {
-        "site": "saraba1st",
-        "id": "1160803"
-      },
-      {
         "site": "iqiyi",
         "id": "a_19rrhepzkd",
-        "begin": "2018-08-16T16:00:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-16T16:00:35.000Z"
       }
     ]
   },
@@ -438,25 +217,15 @@
     "officialSite": "http://shokomeza.com/",
     "begin": "2016-01-07T13:30:00.000Z",
     "end": "2016-03-24T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3119",
-        "begin": "2016-01-07T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-07T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "149993"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1165195"
       }
     ]
   },
@@ -476,35 +245,20 @@
     "officialSite": "http://sushi-police.com/",
     "begin": "2016-01-06T16:00:00.000Z",
     "end": "2016-03-30T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3235",
-        "begin": "2016-01-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-06T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "162792"
       },
       {
-        "site": "saraba1st",
-        "id": "1205247"
-      },
-      {
         "site": "nicovideo",
         "id": "sushi-police",
-        "begin": "2016-01-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -523,18 +277,7 @@
     "officialSite": "http://www.ansatsu-anime.com/",
     "begin": "2016-01-07T17:20:00.000Z",
     "end": "2016-06-30T16:55:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "3271",
-        "begin": "2016-01-07T20:50:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "131891"
@@ -556,45 +299,20 @@
     "officialSite": "http://www.marv.jp/special/divinegate/",
     "begin": "2016-01-08T13:30:00.000Z",
     "end": "2016-03-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "n66KCHDWRoTnZc0",
-        "begin": "2016-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Divine%20Gate",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-08T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "135816"
       },
       {
-        "site": "saraba1st",
-        "id": "1123915"
-      },
-      {
         "site": "nicovideo",
         "id": "divinegate",
-        "begin": "2016-01-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-09T03:00:00.000Z"
       }
     ]
   },
@@ -610,17 +328,11 @@
     "officialSite": "http://www.dreamcreation.co.jp/ojimasyu/",
     "begin": "2016-01-07T16:00:00.000Z",
     "end": "2016-03-24T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3213",
-        "begin": "2016-01-07T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-07T16:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -629,12 +341,7 @@
       {
         "site": "nicovideo",
         "id": "ojimasyu",
-        "begin": "2016-01-05T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-05T12:00:00.000Z"
       }
     ]
   },
@@ -653,35 +360,20 @@
     "officialSite": "http://www.tbs.co.jp/anime/pso2/",
     "begin": "2016-01-07T17:11:00.000Z",
     "end": "2016-03-31T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3097",
-        "begin": "2016-01-08T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T11:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "139830"
       },
       {
-        "site": "saraba1st",
-        "id": "1141055"
-      },
-      {
         "site": "nicovideo",
         "id": "phantasystar",
-        "begin": "2016-01-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T03:00:00.000Z"
       }
     ]
   },
@@ -697,17 +389,11 @@
     "officialSite": "http://sekkoboys.com/",
     "begin": "2016-01-08T14:09:00.000Z",
     "end": "2016-03-25T14:17:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3100",
-        "begin": "2016-01-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -716,12 +402,7 @@
       {
         "site": "nicovideo",
         "id": "sekkoboys",
-        "begin": "2016-01-25T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-25T14:30:00.000Z"
       }
     ]
   },
@@ -737,115 +418,45 @@
     "officialSite": "http://reikenzan.net/",
     "begin": "2016-01-08T15:00:00.000Z",
     "end": "2016-03-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3042",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470428",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "64zs6hiwahE",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "b38198c8a87f11e5a080",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "XuicJR68VhcMmpAw",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhab1el",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10015978",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "6/6x0u5d1a30t9jw9",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "从前有座灵剑山",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "146861"
       },
       {
-        "site": "saraba1st",
-        "id": "1202066"
-      },
-      {
         "site": "mgtv",
         "id": "168359",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       }
     ]
   },
@@ -862,7 +473,6 @@
     "officialSite": "http://reikenzan.net/",
     "begin": "2016-01-08T15:00:00.000Z",
     "end": "2016-03-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -871,92 +481,42 @@
       {
         "site": "bilibili",
         "id": "3614",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470428_2",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "672f94e0ba8411e59e2a",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "q5lz8VmicL23QTrY",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha987l",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "u/ubup3ru3ecypyw6",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "290970",
-        "begin": "2016-01-08T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T02:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "reikenzan",
-        "begin": "2016-01-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-15T03:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2018/cqyzljsdhpian",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -972,35 +532,20 @@
     "officialSite": "http://www.tbs.co.jp/anime/dagashi/",
     "begin": "2016-01-07T17:41:00.000Z",
     "end": "2016-03-31T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3120",
-        "begin": "2016-01-08T07:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T07:25:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "146994"
       },
       {
-        "site": "saraba1st",
-        "id": "1203335"
-      },
-      {
         "site": "nicovideo",
         "id": "dagashi",
-        "begin": "2018-01-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-15T03:00:00.000Z"
       }
     ]
   },
@@ -1016,45 +561,20 @@
     "officialSite": "http://galko.jp/",
     "begin": "2016-01-08T13:30:00.000Z",
     "end": "2016-03-25T13:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SicnTUbkfj80wrhY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470429",
-        "begin": "2016-01-08T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "153140"
       },
       {
-        "site": "saraba1st",
-        "id": "1169902"
-      },
-      {
         "site": "nicovideo",
         "id": "galko",
-        "begin": "2016-01-25T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-25T14:30:00.000Z"
       }
     ]
   },
@@ -1070,35 +590,15 @@
     "officialSite": "http://k-pandora.com/",
     "begin": "2016-01-08T14:00:00.000Z",
     "end": "2016-03-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "3114",
-        "begin": "2016-01-08T16:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "159269"
       },
       {
-        "site": "saraba1st",
-        "id": "1165508"
-      },
-      {
         "site": "nicovideo",
         "id": "k-pandora",
-        "begin": "2016-01-21T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-21T14:00:00.000Z"
       }
     ]
   },
@@ -1115,105 +615,40 @@
     "officialSite": "http://www.durarara.com/",
     "begin": "2016-01-09T14:30:00.000Z",
     "end": "2016-03-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3101",
-        "begin": "2016-01-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470302",
-        "begin": "2016-01-09T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Se7oGWDr_GA",
-        "begin": "2016-01-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-09T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "2c9c7552acd811e38b3f",
-        "begin": "2016-01-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-09T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhab9ch",
-        "begin": "2016-01-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-09T15:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "4/4gmobofw9fltve9",
-        "begin": "2016-01-09T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "无头骑士异闻录×2%20结",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-09T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "114968"
       },
       {
-        "site": "saraba1st",
-        "id": "1047071"
-      },
-      {
         "site": "nicovideo",
         "id": "durarara04",
-        "begin": "2016-01-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-14T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80040119",
-        "begin": "2015-10-09T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-09T07:00:00.000Z"
       }
     ]
   },
@@ -1229,65 +664,20 @@
     "officialSite": "http://rakugo-shinju-anime.jp/",
     "begin": "2016-01-08T17:35:00.000Z",
     "end": "2016-03-18T17:55:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "VIyDR422FN4",
-        "begin": "2016-01-08T19:10:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "faedb5a4a86911e5be16",
-        "begin": "2016-01-08T19:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470420",
-        "begin": "2016-01-08T19:10:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "昭和元禄落语心中",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-08T19:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "119394"
       },
       {
-        "site": "saraba1st",
-        "id": "1203831"
-      },
-      {
         "site": "nicovideo",
         "id": "rakugo-shinju",
-        "begin": "2016-10-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-11T15:00:00.000Z"
       }
     ]
   },
@@ -1303,45 +693,20 @@
     "officialSite": "http://www.monogatari-series.com/koyomimonogatari/",
     "begin": "2016-01-08T16:00:00.000Z",
     "end": "2016-03-26T16:20:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470425",
-        "begin": "2016-01-08T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "3297",
-        "begin": "2016-01-08T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T16:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "146104"
       },
       {
-        "site": "saraba1st",
-        "id": "1130914"
-      },
-      {
         "site": "nicovideo",
         "id": "koyomimonogatari",
-        "begin": "2018-10-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-31T15:00:00.000Z"
       }
     ]
   },
@@ -1359,85 +724,30 @@
     "officialSite": "http://gate-anime.com/",
     "begin": "2016-01-08T16:05:00.000Z",
     "end": "2016-03-25T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhabc71",
-        "begin": "2016-04-11T04:08:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470419",
-        "begin": "2016-01-08T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "feg_0TypFDg",
-        "begin": "2016-01-08T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-11T04:08:11.000Z"
       },
       {
         "site": "youku",
         "id": "50360a00a88a11e5b432",
-        "begin": "2016-01-08T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-08T17:05:00.000Z"
       },
       {
         "site": "pptv",
         "id": "WObSULgejswvrRU",
-        "begin": "2016-01-08T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-08T17:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10017684",
-        "begin": "2016-01-08T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "GATE奇幻自卫队",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-08T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "147036"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1083120"
       }
     ]
   },
@@ -1456,85 +766,30 @@
     "officialSite": "http://bbkbrnk.com/",
     "begin": "2016-01-09T13:00:00.000Z",
     "end": "2016-03-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3128",
-        "begin": "2016-01-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470421",
-        "begin": "2016-01-09T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "pi4ipKnd2pw",
-        "begin": "2016-01-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-09T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "ae8ad3aea87d11e5be16",
-        "begin": "2016-01-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-09T14:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10017690",
-        "begin": "2016-01-09T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "舞武器舞乱伎",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-09T14:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "153214"
       },
       {
-        "site": "saraba1st",
-        "id": "1167483"
-      },
-      {
         "site": "nicovideo",
         "id": "bbkbrnk",
-        "begin": "2016-01-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-20T15:00:00.000Z"
       }
     ]
   },
@@ -1553,45 +808,15 @@
     "officialSite": "http://luckandlogic-animation.com/",
     "begin": "2016-01-09T13:30:00.000Z",
     "end": "2016-03-26T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "ix8tVAT43vY",
-        "begin": "2016-01-14T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "41103584a9f011e5b432",
-        "begin": "2016-01-14T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Luck&Logic",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-14T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "155281"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1172890"
       }
     ]
   },
@@ -1608,65 +833,20 @@
     "officialSite": "http://dimension-w.net/",
     "begin": "2016-01-10T13:30:00.000Z",
     "end": "2016-03-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "0UrcKHBl2HY",
-        "begin": "2016-01-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "eb430c68a87211e5b432",
-        "begin": "2016-01-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470424",
-        "begin": "2016-01-10T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Dimension%20W",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-10T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "139221"
       },
       {
-        "site": "saraba1st",
-        "id": "1132335"
-      },
-      {
         "site": "nicovideo",
         "id": "dimension-w",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1685,65 +865,20 @@
     "officialSite": "http://rainbow-days.tv/",
     "begin": "2016-01-10T13:00:00.000Z",
     "end": "2016-06-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470430",
-        "begin": "2016-01-10T16:15:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "QwwPp1afn80",
-        "begin": "2016-01-10T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "d14f951ca84d11e5b2ad",
-        "begin": "2016-01-10T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "虹色Days",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-10T16:15:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "142990"
       },
       {
-        "site": "saraba1st",
-        "id": "936074"
-      },
-      {
         "site": "nicovideo",
         "id": "rainbow-days",
-        "begin": "2016-01-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-12T15:00:00.000Z"
       }
     ]
   },
@@ -1759,37 +894,16 @@
     "officialSite": "http://ooyasan-anime.com/",
     "begin": "2016-01-10T13:27:00.000Z",
     "end": "2016-03-27T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3116",
-        "begin": "2016-01-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-10T14:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "294216",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "房东妹子青春期",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1798,12 +912,7 @@
       {
         "site": "nicovideo",
         "id": "ooyasan-anime",
-        "begin": "2016-01-11T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T13:00:00.000Z"
       }
     ]
   },
@@ -1819,65 +928,30 @@
     "officialSite": "http://grimgar.com/",
     "begin": "2016-01-10T15:30:00.000Z",
     "end": "2016-03-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oI1n5U2zI2HEQqo",
-        "begin": "2016-01-10T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "灰与幻想的格林姆迦尔",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-10T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "148726"
       },
       {
-        "site": "saraba1st",
-        "id": "1159645"
-      },
-      {
         "site": "nicovideo",
         "id": "grimgar",
-        "begin": "2016-01-16T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-16T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrheq40t",
-        "begin": "2018-04-30T16:02:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-30T16:02:04.000Z"
       },
       {
         "site": "bilibili",
-        "id": "3103",
-        "begin": "2016-01-09T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "106512",
+        "begin": "2016-01-09T16:00:01.000Z"
       }
     ]
   },
@@ -1893,95 +967,35 @@
     "officialSite": "http://www.ntv.co.jp/komugir/",
     "begin": "2016-01-09T17:25:00.000Z",
     "end": "2016-03-26T19:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3102",
-        "begin": "2016-01-09T20:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470423",
-        "begin": "2016-01-09T20:55:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "_pbs2Od9T8c",
-        "begin": "2016-01-09T20:55:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-09T20:55:00.000Z"
       },
       {
         "site": "youku",
         "id": "130a2680a85711e5b2ad",
-        "begin": "2016-01-09T20:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-09T20:55:00.000Z"
       },
       {
         "site": "letv",
         "id": "10017692",
-        "begin": "2016-01-09T20:55:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "魔法护士小麦R",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-09T20:55:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "149412"
       },
       {
-        "site": "saraba1st",
-        "id": "1164380"
-      },
-      {
         "site": "nicovideo",
         "id": "komugir",
-        "begin": "2016-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-10T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh82z2d",
-        "begin": "2017-06-30T16:02:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:40.000Z"
       }
     ]
   },
@@ -2000,45 +1014,20 @@
     "officialSite": "http://saijaku.jp/",
     "begin": "2016-01-11T13:30:00.000Z",
     "end": "2016-03-28T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "JwrmZMwyouBDwSk",
-        "begin": "2016-01-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "最弱无败的神装机龙",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-11T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "133387"
       },
       {
-        "site": "saraba1st",
-        "id": "1204564"
-      },
-      {
         "site": "nicovideo",
         "id": "saijaku",
-        "begin": "2016-01-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-12T03:00:00.000Z"
       }
     ]
   },
@@ -2057,95 +1046,35 @@
     "officialSite": "http://schwarzesmarken-anime.jp/",
     "begin": "2016-01-10T16:05:00.000Z",
     "end": "2016-01-24T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhab9ad",
-        "begin": "2016-01-10T17:05:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470411",
-        "begin": "2016-01-10T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "NSndTtRMro4",
-        "begin": "2016-01-10T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-10T17:05:45.000Z"
       },
       {
         "site": "youku",
         "id": "70512f7aa88711e5b2ad",
-        "begin": "2016-01-10T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-10T17:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3115",
-        "begin": "2016-01-10T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-10T17:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10017698",
-        "begin": "2016-01-10T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Muv-Luv%20黑色标记",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-10T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "134390"
       },
       {
-        "site": "saraba1st",
-        "id": "1121043"
-      },
-      {
         "site": "nicovideo",
         "id": "schwarzesmarken",
-        "begin": "2016-01-15T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-15T16:00:00.000Z"
       }
     ]
   },
@@ -2164,105 +1093,40 @@
     "officialSite": "http://clarines-kingdom.com/",
     "begin": "2016-01-11T15:00:00.000Z",
     "end": "2016-03-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3107",
-        "begin": "2016-01-11T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "StDyVAcEEkA",
-        "begin": "2016-01-11T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-11T18:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "389e1aea197e11e5b5ce",
-        "begin": "2016-01-11T18:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T18:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhb5pv5",
-        "begin": "2016-01-11T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T18:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "2/2hndczgdvkpzff5",
-        "begin": "2016-01-11T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470431",
-        "begin": "2016-01-11T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "赤发白雪姬",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-11T18:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "g6aSEHjeTozvbdU",
-        "begin": "2016-01-11T18:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T18:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "145407"
       },
       {
-        "site": "saraba1st",
-        "id": "1098643"
-      },
-      {
         "site": "nicovideo",
         "id": "clarines-kingdom02",
-        "begin": "2016-01-23T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-23T14:00:00.000Z"
       }
     ]
   },
@@ -2278,37 +1142,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yamishibai/",
     "begin": "2016-01-10T17:35:00.000Z",
     "end": "2016-04-03T18:45:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470412",
-        "begin": "2016-01-10T19:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "WfOtiYJt8c4",
-        "begin": "2016-01-10T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "fb2fd7eaa86911e59e2a",
-        "begin": "2016-01-10T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-10T19:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2317,12 +1155,7 @@
       {
         "site": "nicovideo",
         "id": "yamishibai3",
-        "begin": "2016-01-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T03:00:00.000Z"
       }
     ]
   },
@@ -2338,35 +1171,20 @@
     "officialSite": "http://aokana-anime.com/",
     "begin": "2016-01-11T17:05:00.000Z",
     "end": "2016-03-28T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3106",
-        "begin": "2016-01-11T19:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T19:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "117601"
       },
       {
-        "site": "saraba1st",
-        "id": "1204590"
-      },
-      {
         "site": "nicovideo",
         "id": "aokana",
-        "begin": "2016-01-18T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-18T14:00:00.000Z"
       }
     ]
   },
@@ -2382,35 +1200,20 @@
     "officialSite": "http://mouiidesukara.com/",
     "begin": "2016-01-11T16:11:00.000Z",
     "end": "2016-03-28T16:16:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3126",
-        "begin": "2016-01-11T16:11:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T16:11:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "148241"
       },
       {
-        "site": "saraba1st",
-        "id": "1161426"
-      },
-      {
         "site": "nicovideo",
         "id": "mahoii",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2426,35 +1229,20 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2016-01-11T16:05:00.000Z",
     "end": "2016-03-28T16:08:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3234",
-        "begin": "2016-01-11T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T16:15:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "159365"
       },
       {
-        "site": "saraba1st",
-        "id": "861754"
-      },
-      {
         "site": "nicovideo",
         "id": "te-kyu7",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2471,17 +1259,11 @@
     "officialSite": "http://ketsuekigatakun.com/",
     "begin": "2016-01-11T16:08:00.000Z",
     "end": "2016-03-28T16:11:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10017725",
-        "begin": "2016-01-11T17:08:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-11T17:08:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2490,12 +1272,7 @@
       {
         "site": "nicovideo",
         "id": "ketsuekigata-kun3",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2511,55 +1288,20 @@
     "officialSite": "http://konosuba.com/",
     "begin": "2016-01-13T16:05:00.000Z",
     "end": "2016-03-16T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "VHKPUrStCkk",
-        "begin": "2016-01-13T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "2040dc8aa86c11e59e2a",
-        "begin": "2016-01-13T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "为美好的世界献上祝福",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-13T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "135275"
       },
       {
-        "site": "saraba1st",
-        "id": "1122532"
-      },
-      {
         "site": "nicovideo",
         "id": "konosuba",
-        "begin": "2016-01-23T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-23T03:00:00.000Z"
       }
     ]
   },
@@ -2578,85 +1320,25 @@
     "officialSite": "http://www.ajin.net/",
     "begin": "2016-01-15T17:10:00.000Z",
     "end": "2016-04-08T18:10:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470432",
-        "begin": "2016-01-16T03:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3105",
-        "begin": "2016-01-16T03:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "d8eb7ab6a88411e5b432",
-        "begin": "2016-01-16T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "hPSoTYCAUoY",
-        "begin": "2016-01-16T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-01-16T03:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "FiaQQjvZczApt61M",
-        "begin": "2016-01-16T03:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "亚人",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-01-16T03:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "146093"
       },
       {
-        "site": "saraba1st",
-        "id": "1153236"
-      },
-      {
         "site": "netflix",
         "id": "80043576",
-        "begin": "2016-04-12T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-12T07:00:00.000Z"
       }
     ]
   },
@@ -2675,7 +1357,6 @@
     "officialSite": "http://www.cwfilms.jp/tabimachi/",
     "begin": "2016-01-08T14:17:00.000Z",
     "end": "2016-01-29T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2684,12 +1365,7 @@
       {
         "site": "nicovideo",
         "id": "tabimachi",
-        "begin": "2016-01-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T15:00:00.000Z"
       }
     ]
   },
@@ -2708,7 +1384,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/lululolo/",
     "begin": "2016-01-20T21:40:00.000Z",
     "end": "2016-03-23T21:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2728,7 +1403,6 @@
     "officialSite": "http://lupin-new-season.jp/",
     "begin": "2016-01-08T12:00:00.000Z",
     "end": "2016-01-08T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2748,27 +1422,11 @@
     "officialSite": "http://www.kizumonogatari-movie.com/",
     "begin": "2016-01-08T16:00:00.000Z",
     "end": "2016-01-08T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "58708bb2e36f11e5b2ad",
-        "begin": "2016-08-09T11:42:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "T6pfZJIY0Lg",
-        "begin": "2016-08-09T11:42:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-08-09T11:42:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2784,17 +1442,11 @@
     "officialSite": "http://kinpri.com/",
     "begin": "2016-01-09T16:00:00.000Z",
     "end": "2016-01-09T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IxQAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2803,12 +1455,7 @@
       {
         "site": "nicovideo",
         "id": "kinpri01",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2824,17 +1471,11 @@
     "officialSite": "http://garakowa.jp/",
     "begin": "2016-01-09T16:00:00.000Z",
     "end": "2016-01-09T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VPvVU7shkc8ysBg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2843,22 +1484,12 @@
       {
         "site": "nicovideo",
         "id": "garakowa",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3589",
-        "begin": "2016-01-08T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-08T16:00:01.000Z"
       }
     ]
   },
@@ -2874,7 +1505,6 @@
     "officialSite": "http://www.p3m.jp/",
     "begin": "2016-01-23T16:00:00.000Z",
     "end": "2016-01-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2883,12 +1513,7 @@
       {
         "site": "nicovideo",
         "id": "p3m",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2904,7 +1529,6 @@
     "officialSite": "",
     "begin": "2016-01-05T16:00:00.000Z",
     "end": "2016-01-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2913,12 +1537,7 @@
       {
         "site": "pptv",
         "id": "YcyoJo70ZKIFgibs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2016/02.json
+++ b/data/items/2016/02.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.konodan.com/wizard",
     "begin": "2016-02-05T14:17:00.000Z",
     "end": "2016-02-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "konodan-wizard",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -44,17 +38,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/rilurilufairilu/",
     "begin": "2016-02-06T00:30:00.000Z",
     "end": "2017-03-25T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "s4lj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -63,12 +51,7 @@
       {
         "site": "bilibili",
         "id": "3574",
-        "begin": "2016-02-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-05T16:00:01.000Z"
       }
     ]
   },
@@ -88,25 +71,15 @@
     "officialSite": "http://asahi.co.jp/precure/maho/",
     "begin": "2016-02-06T23:30:00.000Z",
     "end": "2017-01-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhadt7x",
-        "begin": "2016-02-07T04:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-07T04:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "159826"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1164173"
       }
     ]
   },
@@ -122,27 +95,16 @@
     "officialSite": "http://www.dou-kyu-sei.com/",
     "begin": "2016-02-20T16:00:00.000Z",
     "end": "2016-02-20T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4Ucxrxd97SuODHQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10022758",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -151,12 +113,7 @@
       {
         "site": "nicovideo",
         "id": "dou-kyu-sei",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -172,37 +129,21 @@
     "officialSite": "http://www.geass.jp/akito/",
     "begin": "2016-02-06T16:00:00.000Z",
     "end": "2016-02-06T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "otmjIYnvX50AfuY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9mhz9",
-        "begin": "2016-08-31T16:02:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-31T16:02:16.000Z"
       },
       {
         "site": "letv",
         "id": "82177",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -218,7 +159,6 @@
     "officialSite": "http://zeushi-kun.jp/",
     "begin": "2016-02-10T16:00:00.000Z",
     "end": "2016-02-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -238,7 +178,6 @@
     "officialSite": "http://www.mh-movie.com/",
     "begin": "2016-02-27T16:00:00.000Z",
     "end": "2016-02-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -247,12 +186,7 @@
       {
         "site": "pptv",
         "id": "TicbiaYMguntwicvSU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -268,7 +202,6 @@
     "officialSite": "http://selector-wixoss.com/movie/",
     "begin": "2016-02-13T16:00:00.000Z",
     "end": "2016-02-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -277,12 +210,7 @@
       {
         "site": "pptv",
         "id": "kbqWFHziaUpDzcdk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -298,7 +226,6 @@
     "officialSite": "http://initiald-movie.com",
     "begin": "2016-02-06T16:00:00.000Z",
     "end": "2016-02-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -307,22 +234,12 @@
       {
         "site": "pptv",
         "id": "cOzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5126",
-        "begin": "2016-02-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-05T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2016/03.json
+++ b/data/items/2016/03.json
@@ -11,35 +11,20 @@
     "officialSite": "http://www.kanoneko.com/",
     "begin": "2016-03-04T14:17:00.000Z",
     "end": "2016-03-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3375",
-        "begin": "2016-03-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-04T15:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "164649"
       },
       {
-        "site": "saraba1st",
-        "id": "1203752"
-      },
-      {
         "site": "nicovideo",
         "id": "kanoneko",
-        "begin": "2016-03-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-04T15:00:00.000Z"
       }
     ]
   },
@@ -58,77 +43,26 @@
     "officialSite": "http://anime.monster-strike.com/",
     "begin": "2016-03-26T10:00:00.000Z",
     "end": "2016-12-03T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "293305",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "rK0nYZTowwE",
-        "begin": "2016-03-26T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "40654fa2f09511e59e2a",
-        "begin": "2016-03-26T10:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470402",
-        "begin": "2016-03-26T10:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-26T10:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2016/dhpgwdz2",
-        "begin": "2016-03-26T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-26T10:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10014412",
-        "begin": "2016-03-26T10:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "怪物弹珠",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-03-26T10:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -144,87 +78,41 @@
     "officialSite": "http://ac.qq.com/event/index0321.html",
     "begin": "2016-03-25T02:00:00.000Z",
     "end": "2016-10-14T02:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470443",
-        "begin": "2016-03-25T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "3506",
-        "begin": "2016-03-25T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-25T02:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "2WdRzzedDUuuLJQ",
-        "begin": "2016-03-25T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-25T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "q/qkqu2uoheupjd48",
-        "begin": "2016-03-25T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-25T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhadq6l",
-        "begin": "2016-03-25T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-25T02:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10018933",
-        "begin": "2016-03-25T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-25T02:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2016/yzdmx2",
-        "begin": "2016-03-25T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-25T02:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "291228",
-        "begin": "2016-03-25T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-25T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -244,27 +132,16 @@
     "officialSite": "http://doraeiga.com/2016/",
     "begin": "2016-03-05T16:00:00.000Z",
     "end": "2016-03-05T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrm3ae54",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10035148",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -284,17 +161,11 @@
     "officialSite": "http://digimon-adventure.net/",
     "begin": "2016-03-12T16:00:00.000Z",
     "end": "2016-03-12T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbcjih",
-        "begin": "2016-02-15T09:09:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-15T09:09:13.000Z"
       },
       {
         "site": "bangumi",
@@ -303,12 +174,7 @@
       {
         "site": "nicovideo",
         "id": "digimon-matome",
-        "begin": "2016-04-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-01T15:00:00.000Z"
       }
     ]
   },
@@ -324,17 +190,11 @@
     "officialSite": "http://www.precure-allstars.com/",
     "begin": "2016-03-19T16:00:00.000Z",
     "end": "2016-03-19T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       },
       {
         "site": "bangumi",
@@ -343,12 +203,7 @@
       {
         "site": "pptv",
         "id": "0l85txibF9TOWFHw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -364,17 +219,11 @@
     "officialSite": "http://www.jp.square-enix.com/ff15/brotherhood/",
     "begin": "2016-03-31T16:00:00.000Z",
     "end": "2016-09-17T16:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xHNd20OpGVe6OKA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -383,12 +232,7 @@
       {
         "site": "bilibili",
         "id": "5454",
-        "begin": "2016-03-30T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-30T16:00:01.000Z"
       }
     ]
   },
@@ -404,17 +248,11 @@
     "officialSite": "http://animetamago.jp/piece/buemon/",
     "begin": "2016-03-19T16:00:00.000Z",
     "end": "2016-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WibfRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -434,17 +272,11 @@
     "officialSite": "http://animetamago.jp/piece/studio4c/",
     "begin": "2016-03-19T16:00:00.000Z",
     "end": "2016-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WibfRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -464,17 +296,11 @@
     "officialSite": "http://animetamago.jp/piece/signal/",
     "begin": "2016-03-19T16:00:00.000Z",
     "end": "2016-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WibfRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -494,7 +320,6 @@
     "officialSite": "http://animetamago.jp/piece/tezuka/",
     "begin": "2016-03-19T16:00:00.000Z",
     "end": "2016-03-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -514,17 +339,11 @@
     "officialSite": "http://www.bakuon-anime.com/",
     "begin": "2016-03-18T16:00:00.000Z",
     "end": "2016-12-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "cribZF3iclVZP2dNw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -533,12 +352,7 @@
       {
         "site": "bilibili",
         "id": "5921",
-        "begin": "2016-03-17T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-03-17T16:00:01.000Z"
       }
     ]
   },
@@ -554,7 +368,6 @@
     "officialSite": "http://pp-movie.com/",
     "begin": "2016-03-12T16:00:00.000Z",
     "end": "2016-03-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -563,12 +376,7 @@
       {
         "site": "nicovideo",
         "id": "pp-movie03",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -584,7 +392,6 @@
     "officialSite": "http://www.flyingwitch.jp/",
     "begin": "2016-03-18T16:00:00.000Z",
     "end": "2016-09-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -593,12 +400,7 @@
       {
         "site": "pptv",
         "id": "hLqWFHziaUpDzcdk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -614,21 +416,10 @@
     "officialSite": "http://www.cucuri.co.jp/kushimitama.html",
     "begin": "2016-03-28T16:00:00.000Z",
     "end": "2016-03-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "176164"
-      },
-      {
-        "site": "bilibili",
-        "id": "5865",
-        "begin": "2016-03-27T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   }

--- a/data/items/2016/04.json
+++ b/data/items/2016/04.json
@@ -11,45 +11,15 @@
     "officialSite": "http://ushitora.tv/",
     "begin": "2016-04-01T13:30:00.000Z",
     "end": "2016-06-24T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "UW8uUaXCUQg",
-        "begin": "2016-04-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "58f52458197611e5b432",
-        "begin": "2016-04-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "潮与虎",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-04-01T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "143740"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1128233"
       }
     ]
   },
@@ -68,55 +38,20 @@
     "officialSite": "http://jojo-animation.com/",
     "begin": "2016-04-01T15:30:00.000Z",
     "end": "2016-12-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "920pL7eTryw",
-        "begin": "2016-04-01T16:59:50.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "1730efb4f4c911e5b522",
-        "begin": "2016-04-01T16:59:50.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470445",
-        "begin": "2016-04-01T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-01T16:59:50.000Z"
       },
       {
         "site": "bangumi",
         "id": "150490"
       },
       {
-        "site": "saraba1st",
-        "id": "1243404"
-      },
-      {
         "site": "bilibili",
-        "id": "5398",
-        "begin": "2016-04-01T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "140552",
+        "begin": "2016-04-01T15:30:00.000Z"
       }
     ]
   },
@@ -135,35 +70,20 @@
     "officialSite": "http://mayoiga.tv/",
     "begin": "2016-04-01T13:30:00.000Z",
     "end": "2016-06-17T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3451",
-        "begin": "2016-04-02T01:30:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T01:30:02.000Z"
       },
       {
         "site": "bangumi",
         "id": "163046"
       },
       {
-        "site": "saraba1st",
-        "id": "1200945"
-      },
-      {
         "site": "nicovideo",
         "id": "mayoiga",
-        "begin": "2016-04-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-09T16:00:00.000Z"
       }
     ]
   },
@@ -179,35 +99,20 @@
     "officialSite": "http://luluco.tv/",
     "begin": "2016-04-01T13:30:00.000Z",
     "end": "2016-06-24T13:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3459",
-        "begin": "2016-04-01T14:00:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-01T14:00:02.000Z"
       },
       {
         "site": "bangumi",
         "id": "168204"
       },
       {
-        "site": "saraba1st",
-        "id": "1203304"
-      },
-      {
         "site": "nicovideo",
         "id": "luluco",
-        "begin": "2016-04-01T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-01T14:30:00.000Z"
       }
     ]
   },
@@ -226,35 +131,20 @@
     "officialSite": "http://kagewani.com/",
     "begin": "2016-04-01T14:09:00.000Z",
     "end": "2016-06-24T14:17:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3499",
-        "begin": "2016-04-01T14:09:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-01T14:09:01.000Z"
       },
       {
         "site": "bangumi",
         "id": "168559"
       },
       {
-        "site": "saraba1st",
-        "id": "1159908"
-      },
-      {
         "site": "nicovideo",
         "id": "kagewani02",
-        "begin": "2016-04-01T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-01T14:30:00.000Z"
       }
     ]
   },
@@ -270,45 +160,15 @@
     "officialSite": "http://www.terraformars.tv/",
     "begin": "2016-04-01T16:05:00.000Z",
     "end": "2016-06-24T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "3529",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "8T8Zlic9l1RN29Fw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470450",
-        "begin": "2016-06-05T10:10:26.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "143558"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1060590"
       }
     ]
   },
@@ -324,115 +184,50 @@
     "officialSite": "http://www.ytv.co.jp/animegyakuten/",
     "begin": "2016-04-02T08:30:00.000Z",
     "end": "2016-09-10T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2016/dhpnzcp",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T11:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "292379",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "rEbbsqzQVVU",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-02T11:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "c306dcc2e59711e5a080",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T11:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "cLibZF3iclVZP2dNw",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T11:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3527",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T11:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10020524",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T11:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaix5t",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470446",
-        "begin": "2016-04-02T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T11:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "146737"
       },
       {
-        "site": "saraba1st",
-        "id": "1188195"
-      },
-      {
         "site": "qq",
         "id": "q/qf4sw58dkmn70hz",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -451,25 +246,15 @@
     "officialSite": "http://asterisk-war.com/",
     "begin": "2016-04-02T13:30:00.000Z",
     "end": "2016-06-18T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3464",
-        "begin": "2016-04-02T15:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T15:00:01.000Z"
       },
       {
         "site": "bangumi",
         "id": "147613"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1136086"
       }
     ]
   },
@@ -489,7 +274,6 @@
     "officialSite": "http://www.tv-aichi.co.jp/fc-buddyfightDDD/",
     "begin": "2016-04-01T23:00:00.000Z",
     "end": "2017-03-24T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -513,27 +297,11 @@
     "officialSite": "http://anime.endride.jp/",
     "begin": "2016-04-02T17:30:00.000Z",
     "end": "2016-10-09T16:55:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "j7O8sSBa7Co",
-        "begin": "2016-04-02T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "70bdb166e36711e5b2ad",
-        "begin": "2016-04-02T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T20:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -542,12 +310,7 @@
       {
         "site": "nicovideo",
         "id": "endride",
-        "begin": "2016-04-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T03:00:00.000Z"
       }
     ]
   },
@@ -566,65 +329,30 @@
     "officialSite": "http://macross.jp/",
     "begin": "2016-04-03T13:30:00.000Z",
     "end": "2016-09-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3530",
-        "begin": "2016-04-04T10:02:24.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T10:02:24.000Z"
       },
       {
         "site": "pptv",
         "id": "TvzYVr4klNI1sxs",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10020552",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470448",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "100858"
       },
       {
-        "site": "saraba1st",
-        "id": "1066605"
-      },
-      {
         "site": "nicovideo",
         "id": "macrossdelta",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -643,17 +371,11 @@
     "officialSite": "http://pandepeace.com/",
     "begin": "2016-04-03T11:55:00.000Z",
     "end": "2016-06-26T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3460",
-        "begin": "2016-04-03T11:55:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T11:55:02.000Z"
       },
       {
         "site": "bangumi",
@@ -662,12 +384,7 @@
       {
         "site": "nicovideo",
         "id": "pandepeace",
-        "begin": "2016-04-05T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T13:00:00.000Z"
       }
     ]
   },
@@ -683,65 +400,30 @@
     "officialSite": "http://kmmk.tv/",
     "begin": "2016-04-03T14:30:00.000Z",
     "end": "2016-06-19T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "krKFWeKKSvY",
-        "begin": "2016-04-03T16:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "994a2206e4eb11e5a2a2",
-        "begin": "2016-04-03T16:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T16:58:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "148361"
       },
       {
-        "site": "saraba1st",
-        "id": "1161409"
-      },
-      {
         "site": "nicovideo",
         "id": "kmmk",
-        "begin": "2016-04-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-10T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhevm65",
-        "begin": "2018-04-30T16:01:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-30T16:01:59.000Z"
       },
       {
         "site": "bilibili",
-        "id": "5402",
-        "begin": "2016-04-02T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "98612",
+        "begin": "2016-04-02T16:00:01.000Z"
       }
     ]
   },
@@ -760,105 +442,45 @@
     "officialSite": "http://heroaca.com/",
     "begin": "2016-04-03T08:00:00.000Z",
     "end": "2016-06-26T08:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "pEFBZGfERLo",
-        "begin": "2016-04-03T09:28:01.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "af361582e59c11e5b32f",
-        "begin": "2016-04-03T09:28:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T09:28:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh8h9at",
-        "begin": "2016-04-03T09:28:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470447",
-        "begin": "2016-04-03T09:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T09:28:01.000Z"
       },
       {
         "site": "bilibili",
-        "id": "5394",
-        "begin": "2016-04-03T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "7452",
+        "begin": "2016-04-03T09:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "150955"
       },
       {
-        "site": "saraba1st",
-        "id": "1204121"
-      },
-      {
         "site": "nicovideo",
         "id": "heroaca",
-        "begin": "2016-04-10T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-10T07:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "u/u8lo72y7utap84t",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "294323",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80135674",
-        "begin": "2017-08-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-31T16:00:00.000Z"
       }
     ]
   },
@@ -875,75 +497,25 @@
     "officialSite": "http://concreterevolutio.com/",
     "begin": "2016-04-10T14:00:00.000Z",
     "end": "2016-06-19T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3465",
-        "begin": "2016-04-10T14:30:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "_qQRLVfjQsE",
-        "begin": "2016-04-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-10T14:30:01.000Z"
       },
       {
         "site": "youku",
         "id": "189c428856bb11e5b432",
-        "begin": "2016-04-10T14:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470463",
-        "begin": "2016-04-10T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "Concrete%20Revolutio%20超人幻想",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-04-10T14:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "160271"
       },
       {
-        "site": "saraba1st",
-        "id": "1217331"
-      },
-      {
         "site": "nicovideo",
         "id": "concreterevolutio",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -960,25 +532,15 @@
     "officialSite": "http://www.gundam-unicorn.net/",
     "begin": "2016-04-02T22:00:00.000Z",
     "end": "2016-09-10T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
-        "id": "3496",
-        "begin": "2016-04-02T22:30:02.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "id": "122732",
+        "begin": "2016-04-02T22:30:02.000Z"
       },
       {
         "site": "bangumi",
         "id": "169917"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1214083"
       }
     ]
   },
@@ -997,35 +559,20 @@
     "officialSite": "http://www.ninjaslayer-animation.com",
     "begin": "2016-04-02T16:00:00.000Z",
     "end": "2016-06-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3456",
-        "begin": "2016-04-03T09:23:27.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T09:23:27.000Z"
       },
       {
         "site": "bangumi",
         "id": "175137"
       },
       {
-        "site": "saraba1st",
-        "id": "1038832"
-      },
-      {
         "site": "nicovideo",
         "id": "ninjaslayer_animation",
-        "begin": "2015-04-16T14:15:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-04-16T14:15:00.000Z"
       }
     ]
   },
@@ -1044,7 +591,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/duelmastersvsrf/",
     "begin": "2016-04-02T23:30:00.000Z",
     "end": "2017-03-26T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1053,12 +599,7 @@
       {
         "site": "nicovideo",
         "id": "duelmastersvsrf",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1074,45 +615,20 @@
     "officialSite": "http://bakuon-anime.com/",
     "begin": "2016-04-04T15:00:00.000Z",
     "end": "2016-06-20T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "MTTFlTZ-PqE",
-        "begin": "2016-04-04T15:28:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "1b821afce4de11e5b2ad",
-        "begin": "2016-04-04T15:28:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T15:28:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "134204"
       },
       {
-        "site": "saraba1st",
-        "id": "1164363"
-      },
-      {
         "site": "nicovideo",
         "id": "bakuon-anime",
-        "begin": "2016-04-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T15:30:00.000Z"
       }
     ]
   },
@@ -1132,57 +648,21 @@
     "officialSite": "http://www.beyblade.tv/",
     "begin": "2016-04-04T08:55:00.000Z",
     "end": "2017-03-27T09:25:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "9OzlvAD4rqw",
-        "begin": "2016-04-04T16:28:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "1f114782e66f11e5b432",
-        "begin": "2016-04-04T16:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T16:28:00.000Z"
       },
       {
         "site": "pptv",
         "id": "x3Rg3kasHFq9O6M",
-        "begin": "2016-04-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T16:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10020564",
-        "begin": "2016-04-04T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470452",
-        "begin": "2016-04-04T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1205,95 +685,40 @@
     "officialSite": "http://re-zero-anime.jp/",
     "begin": "2016-04-03T16:35:00.000Z",
     "end": "2016-09-18T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3461",
-        "begin": "2016-04-03T18:05:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "iF2R9jBUhso",
-        "begin": "2016-04-03T17:33:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-03T18:05:02.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaer39",
-        "begin": "2016-04-03T17:43:49.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T17:43:49.000Z"
       },
       {
         "site": "youku",
         "id": "1b7c90e0e4df11e59e2a",
-        "begin": "2016-04-03T17:33:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T17:33:00.000Z"
       },
       {
         "site": "letv",
         "id": "10020322",
-        "begin": "2016-04-03T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470449",
-        "begin": "2016-04-03T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T17:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "140001"
       },
       {
-        "site": "saraba1st",
-        "id": "1136113"
-      },
-      {
         "site": "nicovideo",
         "id": "re-zero-anime",
-        "begin": "2016-04-09T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-09T14:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80131659",
-        "begin": "2018-12-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-31T16:00:00.000Z"
       }
     ]
   },
@@ -1309,85 +734,35 @@
     "officialSite": "http://s.mxtv.jp/joker/",
     "begin": "2016-04-04T10:00:00.000Z",
     "end": "2016-06-27T10:29:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "QhVq9_HDEl4",
-        "begin": "2016-04-04T10:57:51.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "587b825ce59e11e5b432",
-        "begin": "2016-04-04T10:57:51.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T10:57:51.000Z"
       },
       {
         "site": "pptv",
         "id": "atmzMZnicb60QjvY",
-        "begin": "2016-04-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T11:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10021113",
-        "begin": "2016-04-04T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T11:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "3528",
-        "begin": "2016-04-04T11:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470453",
-        "begin": "2016-04-04T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T11:00:01.000Z"
       },
       {
         "site": "bangumi",
         "id": "147085"
       },
       {
-        "site": "saraba1st",
-        "id": "1062960"
-      },
-      {
         "site": "qq",
         "id": "v/vp6vlv7unf3wklf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1407,35 +782,20 @@
     "officialSite": "http://sailormoon-official.com/animation/",
     "begin": "2016-04-04T14:00:00.000Z",
     "end": "2016-06-27T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhaj2vd",
-        "begin": "2016-04-04T16:58:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T16:58:31.000Z"
       },
       {
         "site": "bangumi",
         "id": "147683"
       },
       {
-        "site": "saraba1st",
-        "id": "1247750"
-      },
-      {
         "site": "nicovideo",
         "id": "sailormoon-Crystal3",
-        "begin": "2016-04-15T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-15T08:00:00.000Z"
       }
     ]
   },
@@ -1451,25 +811,10 @@
     "officialSite": "http://www.shogakukan.co.jp/pr/12sai/",
     "begin": "2016-04-04T10:30:00.000Z",
     "end": "2016-06-20T11:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "3493",
-        "begin": "2016-04-04T10:30:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "167235"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1208485"
       }
     ]
   },
@@ -1489,85 +834,35 @@
     "officialSite": "http://hundred-anime.jp/",
     "begin": "2016-04-04T17:05:00.000Z",
     "end": "2016-06-20T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3463",
-        "begin": "2016-04-04T18:05:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "_s4Rzz-KIEw",
-        "begin": "2016-04-04T16:03:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-04T18:05:02.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhafm1h",
-        "begin": "2016-04-04T18:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T18:00:10.000Z"
       },
       {
         "site": "youku",
         "id": "8b841e46e4d811e5b432",
-        "begin": "2016-04-04T16:03:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T16:03:00.000Z"
       },
       {
         "site": "letv",
         "id": "10020554",
-        "begin": "2016-04-04T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470451",
-        "begin": "2016-04-04T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T18:05:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "133403"
       },
       {
-        "site": "saraba1st",
-        "id": "1118680"
-      },
-      {
         "site": "nicovideo",
         "id": "hundred-anime",
-        "begin": "2016-04-05T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T15:30:00.000Z"
       }
     ]
   },
@@ -1588,75 +883,25 @@
     "officialSite": "http://jokergame.jp/",
     "begin": "2016-04-05T14:00:00.000Z",
     "end": "2016-06-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470454",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "3537",
-        "begin": "2016-04-06T02:47:04.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "79f5e89ce4da11e5a2a2",
-        "begin": "2016-04-06T01:32:41.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "-Ea_ESJ-e2M",
-        "begin": "2016-04-06T01:32:41.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-06T01:32:41.000Z"
       },
       {
         "site": "pptv",
         "id": "TibDMSrIYiaMYppw8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "142812"
       },
       {
-        "site": "saraba1st",
-        "id": "1247950"
-      },
-      {
         "site": "nicovideo",
         "id": "jokergame",
-        "begin": "2016-04-21T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-21T14:00:00.000Z"
       }
     ]
   },
@@ -1672,17 +917,11 @@
     "officialSite": "http://www.hakuoki-otogi.com/",
     "begin": "2016-04-05T12:55:00.000Z",
     "end": "2016-06-28T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3377",
-        "begin": "2016-04-05T12:55:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T12:55:01.000Z"
       },
       {
         "site": "bangumi",
@@ -1691,12 +930,7 @@
       {
         "site": "nicovideo",
         "id": "hakuoki-otogi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1712,85 +946,35 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pripara/",
     "begin": "2016-04-05T08:55:00.000Z",
     "end": "2017-03-28T08:55:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "hpupBLJCbtk",
-        "begin": "2016-04-05T09:53:11.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhaj3bp",
-        "begin": "2016-04-05T09:50:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T09:50:12.000Z"
       },
       {
         "site": "bilibili",
         "id": "3532",
-        "begin": "2016-04-05T13:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T13:00:01.000Z"
       },
       {
         "site": "youku",
         "id": "2cc2fb60e4ed11e59e2a",
-        "begin": "2016-04-05T09:53:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T09:53:11.000Z"
       },
       {
         "site": "letv",
         "id": "10020453",
-        "begin": "2016-04-05T09:55:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470456",
-        "begin": "2016-04-05T09:55:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T09:55:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "162802"
       },
       {
-        "site": "saraba1st",
-        "id": "1006534"
-      },
-      {
         "site": "nicovideo",
         "id": "pripara03",
-        "begin": "2016-04-15T12:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-15T12:30:00.000Z"
       }
     ]
   },
@@ -1807,45 +991,20 @@
     "officialSite": "http://cerberus-anime.jp/",
     "begin": "2016-04-04T16:35:00.000Z",
     "end": "2016-06-27T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470441",
-        "begin": "2016-04-04T16:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhaffbt",
-        "begin": "2016-04-04T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T16:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "167028"
       },
       {
-        "site": "saraba1st",
-        "id": "1219236"
-      },
-      {
         "site": "nicovideo",
         "id": "cerberus",
-        "begin": "2016-04-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T03:00:00.000Z"
       }
     ]
   },
@@ -1862,47 +1021,16 @@
     "officialSite": "http://www6.nhk.or.jp/anime/program/detail.html?i=gomachan",
     "begin": "2016-04-05T09:45:00.000Z",
     "end": "2017-02-21T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhajtmx",
-        "begin": "2016-04-12T10:15:51.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470455",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "qiBO_bk7hZY",
-        "begin": "2016-04-05T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-12T10:15:51.000Z"
       },
       {
         "site": "youku",
         "id": "410affe6e5d311e5b32f",
-        "begin": "2016-04-05T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-05T11:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1911,22 +1039,12 @@
       {
         "site": "nicovideo",
         "id": "gomachan_animation",
-        "begin": "2016-04-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "4771",
-        "begin": "2016-04-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-04T16:00:01.000Z"
       }
     ]
   },
@@ -1943,77 +1061,31 @@
     "officialSite": "http://superlovers-anime.com/",
     "begin": "2016-04-06T14:30:00.000Z",
     "end": "2016-06-08T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470458",
-        "begin": "2016-04-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0At_ddWfzlY",
-        "begin": "2016-04-06T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "qq",
         "id": "9/9ecz5xa7658m72d",
-        "begin": "2016-04-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T18:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "037cd3e6e66611e5b2ad",
-        "begin": "2016-04-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-06T18:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10020432",
-        "begin": "2016-04-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T18:05:00.000Z"
       },
       {
         "site": "pptv",
         "id": "NwTwbtY8rOpNyzM",
-        "begin": "2016-04-06T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-04-06T18:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhak5s9",
-        "begin": "2016-04-06T18:00:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T18:00:07.000Z"
       },
       {
         "site": "bangumi",
@@ -2022,12 +1094,7 @@
       {
         "site": "nicovideo",
         "id": "superlovers",
-        "begin": "2017-01-09T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T06:00:00.000Z"
       }
     ]
   },
@@ -2046,94 +1113,40 @@
     "officialSite": "http://www.sousei-anime.jp/",
     "begin": "2016-04-06T09:25:00.000Z",
     "end": "2017-03-29T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3462",
-        "begin": "2016-04-06T10:25:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "6YUIGawleII",
-        "begin": "2016-04-06T10:23:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-06T10:25:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaeqtd",
-        "begin": "2016-04-06T10:20:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T10:20:12.000Z"
       },
       {
         "site": "youku",
         "id": "31c53954e34c11e5a2a2",
-        "begin": "2016-04-06T10:23:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T10:23:00.000Z"
       },
       {
         "site": "letv",
         "id": "10020446",
-        "begin": "2016-04-06T10:25:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470457",
-        "begin": "2016-04-06T10:25:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T10:25:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "155778"
       },
       {
-        "site": "saraba1st",
-        "id": "1173603"
-      },
-      {
         "site": "nicovideo",
         "id": "sousei",
-        "begin": "2016-04-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-12T16:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80219261",
         "begin": "2018-01-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
         "comment": "港区可见"
       }
     ]
@@ -2150,17 +1163,11 @@
     "officialSite": "http://neco-neco.jp/",
     "begin": "2016-04-06T09:45:00.000Z",
     "end": "2017-02-22T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "7l03tR2D8zGUEno",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2183,17 +1190,11 @@
     "officialSite": "http://cranegale.com/",
     "begin": "2016-04-06T13:00:00.000Z",
     "end": "2016-06-29T13:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3478",
-        "begin": "2016-04-06T15:20:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T15:20:01.000Z"
       },
       {
         "site": "bangumi",
@@ -2202,12 +1203,7 @@
       {
         "site": "nicovideo",
         "id": "cranegale",
-        "begin": "2016-04-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-08T15:00:00.000Z"
       }
     ]
   },
@@ -2223,7 +1219,6 @@
     "officialSite": "http://xn--u9j429qiq1a.jp/",
     "begin": "2016-04-07T10:00:00.000Z",
     "end": "2017-04-06T10:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2232,12 +1227,7 @@
       {
         "site": "nicovideo",
         "id": "takanotsume_gt",
-        "begin": "2016-04-08T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-08T10:00:00.000Z"
       }
     ]
   },
@@ -2256,25 +1246,15 @@
     "officialSite": "http://kabaneri.com/",
     "begin": "2016-04-07T15:25:00.000Z",
     "end": "2016-06-30T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "118781"
       },
       {
-        "site": "saraba1st",
-        "id": "1180903"
-      },
-      {
         "site": "bilibili",
         "id": "3494",
-        "begin": "2016-04-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T16:00:01.000Z"
       }
     ]
   },
@@ -2295,85 +1275,35 @@
     "officialSite": "http://anne-happy.com/",
     "begin": "2016-04-07T12:30:00.000Z",
     "end": "2016-06-23T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3498",
-        "begin": "2016-04-07T15:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "pbj-DtjHwtk",
-        "begin": "2016-04-07T15:06:09.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-07T15:00:01.000Z"
       },
       {
         "site": "youku",
         "id": "40d31318e43611e5b32f",
-        "begin": "2016-04-07T15:06:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1470459",
-        "begin": "2016-04-07T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T15:06:09.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhak5wl",
-        "begin": "2016-04-07T14:50:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T14:50:10.000Z"
       },
       {
         "site": "pptv",
         "id": "9EIurBR66iaiaLCXE",
-        "begin": "2016-04-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T15:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "138053"
       },
       {
-        "site": "saraba1st",
-        "id": "1248704"
-      },
-      {
         "site": "nicovideo",
         "id": "anne-happy",
-        "begin": "2016-04-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-10T03:00:00.000Z"
       }
     ]
   },
@@ -2389,95 +1319,40 @@
     "officialSite": "http://netogenoyome.com/",
     "begin": "2016-04-07T14:00:00.000Z",
     "end": "2016-06-23T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470460",
-        "begin": "2016-04-07T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "3495",
-        "begin": "2016-04-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "eJcUnm1hNF8",
-        "begin": "2016-04-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-07T17:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "3/3llbhhwzykl7in7",
-        "begin": "2016-04-07T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T17:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "450caa42e66711e5b432",
-        "begin": "2016-04-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T17:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhajw3h",
-        "begin": "2016-04-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T17:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "XerGRKwSgsAjoQk",
-        "begin": "2016-04-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-07T17:00:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "142758"
       },
       {
-        "site": "saraba1st",
-        "id": "1208226"
-      },
-      {
         "site": "nicovideo",
         "id": "netogenoyome",
-        "begin": "2016-04-16T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-16T16:30:00.000Z"
       }
     ]
   },
@@ -2496,35 +1371,20 @@
     "officialSite": "http://bungo-stray-dogs.jp/",
     "begin": "2016-04-06T16:05:00.000Z",
     "end": "2016-06-22T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Fjchnwdt3RtibicGQ",
-        "begin": "2016-04-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T17:35:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "144357"
       },
       {
-        "site": "saraba1st",
-        "id": "1147834"
-      },
-      {
         "site": "nicovideo",
         "id": "bungo-stray-dogs",
-        "begin": "2016-04-15T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-15T14:30:00.000Z"
       }
     ]
   },
@@ -2544,75 +1404,35 @@
     "officialSite": "http://kuromukuro.com/",
     "begin": "2016-04-07T12:00:00.000Z",
     "end": "2016-09-29T12:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1470464",
-        "begin": "2016-04-08T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "3551",
-        "begin": "2016-04-08T10:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-08T10:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10020777",
-        "begin": "2016-04-08T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-08T10:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "7103tR2D8zGUEno",
-        "begin": "2016-04-08T10:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-08T10:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "159661"
       },
       {
-        "site": "saraba1st",
-        "id": "1178359"
-      },
-      {
         "site": "nicovideo",
         "id": "kuromukuro",
-        "begin": "2017-01-18T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-18T06:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80103318",
-        "begin": "2016-07-04T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T07:00:00.000Z"
       }
     ]
   },
@@ -2628,17 +1448,11 @@
     "officialSite": "http://www.onigiri-anime.com/",
     "begin": "2016-04-06T16:00:00.000Z",
     "end": "2016-06-29T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3454",
-        "begin": "2016-04-06T16:05:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-06T16:05:02.000Z"
       },
       {
         "site": "bangumi",
@@ -2647,12 +1461,7 @@
       {
         "site": "nicovideo",
         "id": "onigiri-anime",
-        "begin": "2016-04-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T03:00:00.000Z"
       }
     ]
   },
@@ -2673,25 +1482,15 @@
     "officialSite": "http://www.aikatsu.net/aikatsustars.html",
     "begin": "2016-04-07T09:25:00.000Z",
     "end": "2017-03-30T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhajuwx",
-        "begin": "2016-04-07T11:25:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T11:25:10.000Z"
       },
       {
         "site": "bangumi",
         "id": "169274"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1212602"
       }
     ]
   },
@@ -2707,45 +1506,20 @@
     "officialSite": "http://www.tbs.co.jp/anime/meido/",
     "begin": "2016-04-07T16:58:00.000Z",
     "end": "2016-06-30T17:28:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "ZJWyTGRjdTI",
-        "begin": "2016-04-08T14:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "735de270e37011e5b32f",
-        "begin": "2016-04-08T14:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-08T14:58:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "145355"
       },
       {
-        "site": "saraba1st",
-        "id": "1248769"
-      },
-      {
         "site": "nicovideo",
         "id": "anime_meido",
-        "begin": "2016-04-21T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-21T15:30:00.000Z"
       }
     ]
   },
@@ -2761,45 +1535,25 @@
     "officialSite": "http://www.tbs.co.jp/anime/sakamoto/",
     "begin": "2016-04-07T17:28:00.000Z",
     "end": "2016-06-30T17:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3450",
-        "begin": "2016-04-08T03:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-08T03:00:01.000Z"
       },
       {
         "site": "mgtv",
         "id": "292564",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "165829"
       },
       {
-        "site": "saraba1st",
-        "id": "1248524"
-      },
-      {
         "site": "nicovideo",
         "id": "sakamoto-anime",
-        "begin": "2016-04-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-14T15:00:00.000Z"
       }
     ]
   },
@@ -2815,7 +1569,6 @@
     "officialSite": "http://meisakukun.com/",
     "begin": "2016-04-08T09:20:00.000Z",
     "end": "2017-02-17T14:59:45.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2838,35 +1591,15 @@
     "officialSite": "http://www.cartoonnetwork.jp/cn_programs/microsite/00125",
     "begin": "2016-04-04T01:00:00.000Z",
     "end": "2016-12-24T01:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "3550",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "fcqmJIzyYqADgek",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "106264"
-      },
-      {
-        "site": "saraba1st",
-        "id": "1220107"
       }
     ]
   },
@@ -2886,25 +1619,15 @@
     "officialSite": "http://www.hai-furi.com/",
     "begin": "2016-04-09T15:00:00.000Z",
     "end": "2016-06-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "144843"
       },
       {
-        "site": "saraba1st",
-        "id": "1148786"
-      },
-      {
         "site": "nicovideo",
         "id": "hai-furi",
-        "begin": "2016-04-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-16T15:00:00.000Z"
       }
     ]
   },
@@ -2920,37 +1643,11 @@
     "officialSite": "http://anime-rinne.com/",
     "begin": "2016-04-09T08:30:00.000Z",
     "end": "2016-09-24T08:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "498c224cf7b411e59e2a",
-        "begin": "2016-04-09T11:12:50.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "AdJ3cLCWYTw",
-        "begin": "2016-04-09T11:12:50.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tucao",
-        "id": "境界之轮回",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-04-09T11:12:50.000Z"
       },
       {
         "site": "bangumi",
@@ -2959,12 +1656,7 @@
       {
         "site": "nicovideo",
         "id": "rinne_anime2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2983,45 +1675,20 @@
     "officialSite": "http://kiznaiver.jp/",
     "begin": "2016-04-09T14:30:00.000Z",
     "end": "2016-06-25T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "DW_RuUDhmw4",
-        "begin": "2016-04-09T14:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "73e55cbee35c11e5b32f",
-        "begin": "2016-04-09T14:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-09T14:58:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "148281"
       },
       {
-        "site": "saraba1st",
-        "id": "1159425"
-      },
-      {
         "site": "nicovideo",
         "id": "kiznaiver",
-        "begin": "2016-04-10T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-10T14:00:00.000Z"
       }
     ]
   },
@@ -3037,17 +1704,11 @@
     "officialSite": "http://tanakakun.tv",
     "begin": "2016-04-09T13:00:00.000Z",
     "end": "2016-06-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "6lg0shqA8C6RD3c",
-        "begin": "2016-04-09T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-09T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3067,65 +1728,30 @@
     "officialSite": "http://www.flyingwitch.jp",
     "begin": "2016-04-09T17:25:00.000Z",
     "end": "2016-06-29T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "x2MhV5ieFWE",
-        "begin": "2016-04-09T20:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "7a70fd3ee66a11e5b522",
-        "begin": "2016-04-09T20:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-09T20:58:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "141799"
       },
       {
-        "site": "saraba1st",
-        "id": "1203079"
-      },
-      {
         "site": "nicovideo",
         "id": "flyingwitch",
-        "begin": "2016-04-10T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-10T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrheyz0d",
-        "begin": "2018-04-30T16:02:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-30T16:02:02.000Z"
       },
       {
         "site": "bilibili",
-        "id": "5617",
-        "begin": "2016-04-08T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "98632",
+        "begin": "2016-04-08T16:00:01.000Z"
       }
     ]
   },
@@ -3141,27 +1767,11 @@
     "officialSite": "http://tonkatsudj.tokyo/",
     "begin": "2016-04-10T13:15:00.000Z",
     "end": "2016-06-26T13:27:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "t3Y7sM8bNh0",
-        "begin": "2016-04-10T15:15:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "b21f9e66e4ee11e5a2a2",
-        "begin": "2016-04-10T15:15:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-10T15:15:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3170,12 +1780,7 @@
       {
         "site": "nicovideo",
         "id": "tonkatsudj",
-        "begin": "2016-04-20T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-20T03:00:00.000Z"
       }
     ]
   },
@@ -3191,17 +1796,11 @@
     "officialSite": "http://sansyasanyou.com/",
     "begin": "2016-04-10T15:00:00.000Z",
     "end": "2016-06-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3452",
-        "begin": "2016-04-10T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-10T16:00:01.000Z"
       },
       {
         "site": "bangumi",
@@ -3210,12 +1809,7 @@
       {
         "site": "nicovideo",
         "id": "sansyasanyou",
-        "begin": "2016-04-11T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-11T12:00:00.000Z"
       }
     ]
   },
@@ -3232,18 +1826,7 @@
     "officialSite": "http://namepara.com/sekainotomodachi/",
     "begin": "2016-04-10T08:00:00.000Z",
     "end": "2017-02-12T08:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480016",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "171297"
@@ -3251,12 +1834,7 @@
       {
         "site": "nicovideo",
         "id": "sekainotomodachi",
-        "begin": "2017-02-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-14T03:00:00.000Z"
       }
     ]
   },
@@ -3275,18 +1853,7 @@
     "officialSite": "http://whanime.com/",
     "begin": "2016-04-11T16:10:00.000Z",
     "end": "2016-06-27T16:15:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "3497",
-        "begin": "2016-04-11T16:10:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "143753"
@@ -3294,12 +1861,7 @@
       {
         "site": "nicovideo",
         "id": "whanime",
-        "begin": "2016-04-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-12T03:00:00.000Z"
       }
     ]
   },
@@ -3318,17 +1880,11 @@
     "officialSite": "http://nemumi.com/",
     "begin": "2016-04-11T16:05:00.000Z",
     "end": "2016-06-27T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3457",
-        "begin": "2016-04-11T16:15:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-11T16:15:02.000Z"
       },
       {
         "site": "bangumi",
@@ -3337,12 +1893,7 @@
       {
         "site": "nicovideo",
         "id": "nemumi",
-        "begin": "2016-04-03T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-03T04:00:00.000Z"
       }
     ]
   },
@@ -3359,85 +1910,40 @@
     "officialSite": "http://www.project-magi.com/sinbad/",
     "begin": "2016-04-16T15:30:00.000Z",
     "end": "2016-09-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhahwrh",
-        "begin": "2016-04-15T18:55:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-15T18:55:04.000Z"
       },
       {
         "site": "letv",
         "id": "10021111",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "3466",
-        "begin": "2016-04-15T19:00:02.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "27etU3pqjNs",
-        "begin": "2016-04-15T19:28:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-15T19:00:02.000Z"
       },
       {
         "site": "youku",
         "id": "24da262ce4dd11e5b432",
-        "begin": "2016-04-15T19:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-15T19:28:00.000Z"
       },
       {
         "site": "pptv",
         "id": "7Vs1sxuB8SibSEHg",
-        "begin": "2016-04-15T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-15T19:30:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "147780"
       },
       {
-        "site": "saraba1st",
-        "id": "1158991"
-      },
-      {
         "site": "netflix",
         "id": "80103331",
-        "begin": "2016-07-14T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-14T07:00:00.000Z"
       }
     ]
   },
@@ -3456,35 +1962,20 @@
     "officialSite": "http://www.future-diary.tv/bo/",
     "begin": "2016-04-15T16:40:00.000Z",
     "end": "2016-06-17T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0HlT0TmfD02wLpY",
-        "begin": "2016-04-15T18:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-15T18:10:00.000Z"
       },
       {
         "site": "bangumi",
         "id": "149959"
       },
       {
-        "site": "saraba1st",
-        "id": "1164947"
-      },
-      {
         "site": "nicovideo",
         "id": "asread-net",
-        "begin": "2016-04-16T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-16T15:30:00.000Z"
       }
     ]
   },
@@ -3504,17 +1995,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/kamiwaza_wanda/",
     "begin": "2016-04-22T22:00:00.000Z",
     "end": "2017-03-24T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10020758",
-        "begin": "2016-04-16T00:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-16T00:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3537,7 +2022,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cf-vanguard-g2/",
     "begin": "2016-04-17T01:00:00.000Z",
     "end": "2016-09-25T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3546,12 +2030,7 @@
       {
         "site": "nicovideo",
         "id": "cf-vanguard-g2",
-        "begin": "2015-10-13T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-10-13T12:00:00.000Z"
       }
     ]
   },
@@ -3570,27 +2049,16 @@
     "officialSite": "http://www.sunrise-inc.co.jp/battlespirits8/",
     "begin": "2016-04-06T08:55:00.000Z",
     "end": "2017-03-29T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "csGrKZH3Z6UIhu4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5119",
-        "begin": "2016-07-07T05:53:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T05:53:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3613,17 +2081,11 @@
     "officialSite": "http://ragst.jp/",
     "begin": "2016-04-02T15:56:00.000Z",
     "end": "2016-06-18T15:57:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "4762",
-        "begin": "2016-06-13T09:28:30.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-13T09:28:30.000Z"
       },
       {
         "site": "bangumi",
@@ -3632,12 +2094,7 @@
       {
         "site": "nicovideo",
         "id": "ch2620539",
-        "begin": "2016-04-02T15:56:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-02T15:56:00.000Z"
       }
     ]
   },
@@ -3656,27 +2113,16 @@
     "officialSite": "http://www.bonoanime.jp/",
     "begin": "2016-04-01T19:52:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9d749",
-        "begin": "2017-03-03T02:00:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-03T02:00:21.000Z"
       },
       {
         "site": "bilibili",
         "id": "5615",
-        "begin": "2016-10-22T00:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-22T00:00:10.000Z"
       },
       {
         "site": "bangumi",
@@ -3696,7 +2142,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/wasimo/",
     "begin": "2016-04-04T09:00:00.000Z",
     "end": "2016-08-30T09:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3716,77 +2161,41 @@
     "officialSite": "http://v.qq.com/vplus/tongzhizhe",
     "begin": "2016-04-27T12:00:00.000Z",
     "end": "2016-07-27T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "3859",
-        "begin": "2016-04-27T03:41:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-27T03:41:07.000Z"
       },
       {
         "site": "pptv",
         "id": "HysFgibtRwf9ia4Eg",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "y/yyymlllcpion441",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaiev5",
-        "begin": "2016-04-27T04:06:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-27T04:06:21.000Z"
       },
       {
         "site": "letv",
         "id": "10021232",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2016/dhpmojier",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "292938",
-        "begin": "2016-04-27T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-27T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3806,17 +2215,11 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2016-04-16T16:00:00.000Z",
     "end": "2016-04-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rr9s27c0",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3837,17 +2240,11 @@
     "officialSite": "http://shinchan-movie.com/",
     "begin": "2016-04-16T16:00:00.000Z",
     "end": "2016-04-16T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rra274mg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3867,7 +2264,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/",
     "begin": "2016-04-04T08:35:00.000Z",
     "end": "2016-07-01T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3887,17 +2283,11 @@
     "officialSite": "http://re-zero-anime.jp/",
     "begin": "2016-04-08T16:00:00.000Z",
     "end": "2016-06-17T16:03:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IBLibfORKuvhb2UE",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3906,12 +2296,7 @@
       {
         "site": "bilibili",
         "id": "4026",
-        "begin": "2016-04-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-07T16:00:01.000Z"
       }
     ]
   },
@@ -3927,7 +2312,6 @@
     "officialSite": "http://www.panpaka.com/",
     "begin": "2016-04-02T16:00:00.000Z",
     "end": "2016-10-15T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3936,12 +2320,7 @@
       {
         "site": "nicovideo",
         "id": "panpaka02",
-        "begin": "2017-05-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-05-31T15:00:00.000Z"
       }
     ]
   },
@@ -3957,7 +2336,6 @@
     "officialSite": "https://twitter.com/datenikuru",
     "begin": "2016-04-24T16:00:00.000Z",
     "end": "2017-02-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3966,12 +2344,7 @@
       {
         "site": "nicovideo",
         "id": "datenikuru",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3987,7 +2360,6 @@
     "officialSite": "http://www.ntv.co.jp/zip/kaishain/",
     "begin": "2016-04-04T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3996,12 +2368,7 @@
       {
         "site": "nicovideo",
         "id": "kaishain",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4017,7 +2384,6 @@
     "officialSite": "http://www.yugioh20th.com/",
     "begin": "2016-04-23T16:00:00.000Z",
     "end": "2016-04-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4026,12 +2392,7 @@
       {
         "site": "pptv",
         "id": "mZ56ibGDGNnTXVb0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4047,7 +2408,6 @@
     "officialSite": "http://movie.anime-eupho.com",
     "begin": "2016-04-23T16:00:00.000Z",
     "end": "2016-04-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4056,22 +2416,12 @@
       {
         "site": "pptv",
         "id": "SfbiaYMguntwicvSU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "006e1befbfbdefbfbd7b",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4087,7 +2437,6 @@
     "officialSite": "http://tanakakun.tv/",
     "begin": "2016-04-07T16:00:00.000Z",
     "end": "2016-07-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4096,12 +2445,7 @@
       {
         "site": "pptv",
         "id": "BDQgngZs3Bp9ib2M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4117,7 +2461,6 @@
     "officialSite": "http://www.honeyworks-movie.jp/1st/",
     "begin": "2016-04-23T16:00:00.000Z",
     "end": "2016-04-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4126,22 +2469,12 @@
       {
         "site": "nicovideo",
         "id": "zuttomaekarasukideshita",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5575",
-        "begin": "2016-04-22T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-22T16:00:01.000Z"
       }
     ]
   },
@@ -4157,7 +2490,6 @@
     "officialSite": "",
     "begin": "2016-04-01T16:00:00.000Z",
     "end": "2016-06-17T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2016/05.json
+++ b/data/items/2016/05.json
@@ -11,17 +11,11 @@
     "officialSite": "http://roosterteeth.com/show/rwby-chibi",
     "begin": "2016-05-07T16:00:00.000Z",
     "end": "2016-10-15T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10027882",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "bilibili",
         "id": "4033",
-        "begin": "2016-05-07T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-05-07T16:00:00.000Z"
       }
     ]
   },
@@ -51,17 +40,11 @@
     "officialSite": "",
     "begin": "2016-05-02T16:00:00.000Z",
     "end": "2017-07-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "RvLeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -81,31 +64,15 @@
     "officialSite": "http://owarino-seraph.jp/bd/ova1.html",
     "begin": "2016-05-02T16:00:00.000Z",
     "end": "2016-05-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "XOzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "148096"
-      },
-      {
-        "site": "bilibili",
-        "id": "4008",
-        "begin": "2016-05-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -121,7 +88,6 @@
     "officialSite": "http://ribon.shueisha.co.jp/ohasta/",
     "begin": "2016-05-10T16:00:00.000Z",
     "end": "2016-05-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -141,7 +107,6 @@
     "officialSite": "http://www.arslan.jp/",
     "begin": "2016-05-09T16:00:00.000Z",
     "end": "2016-12-09T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -150,22 +115,12 @@
       {
         "site": "pptv",
         "id": "qZlz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5695",
-        "begin": "2016-05-08T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-05-08T16:00:01.000Z"
       }
     ]
   },
@@ -181,7 +136,6 @@
     "officialSite": "",
     "begin": "2016-05-06T16:00:00.000Z",
     "end": "2017-04-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -190,12 +144,7 @@
       {
         "site": "pptv",
         "id": "8j4amABm1hR39V0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -211,7 +160,6 @@
     "officialSite": "http://www.j-haikyu.com/jc21_limited/index.html",
     "begin": "2016-05-02T16:00:00.000Z",
     "end": "2016-05-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -220,12 +168,7 @@
       {
         "site": "pptv",
         "id": "ppJibicGTKOnjbWcE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -241,7 +184,6 @@
     "officialSite": "http://www.ajin.net/",
     "begin": "2016-05-06T16:00:00.000Z",
     "end": "2016-05-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -250,12 +192,7 @@
       {
         "site": "pptv",
         "id": "lruVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2016/06.json
+++ b/data/items/2016/06.json
@@ -14,27 +14,16 @@
     "officialSite": "http://rsproject.jp/",
     "begin": "2016-06-25T17:20:00.000Z",
     "end": "2016-06-25T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "iarehH4ftXZvibfOQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10024292",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -58,17 +47,11 @@
     "officialSite": "http://mononokean.tv/",
     "begin": "2016-06-28T14:30:00.000Z",
     "end": "2016-09-20T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "oZF7ibWHHN3XYVr4",
-        "begin": "2016-06-30T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-30T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -77,32 +60,17 @@
       {
         "site": "nicovideo",
         "id": "mononokean",
-        "begin": "2016-07-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-09T15:30:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "303751",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "5678",
-        "begin": "2019-01-04T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8061448",
+        "begin": "2019-01-04T16:00:01.000Z"
       }
     ]
   },
@@ -122,17 +90,11 @@
     "officialSite": "http://www6.nhk.or.jp/anime/program/detail.html?i=honobono",
     "begin": "2016-06-06T15:08:00.000Z",
     "end": "2016-06-17T15:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "h7KeHITqWpj7eeE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -141,12 +103,7 @@
       {
         "site": "bilibili",
         "id": "5125",
-        "begin": "2016-06-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-05T16:00:01.000Z"
       }
     ]
   },
@@ -158,27 +115,11 @@
     "officialSite": "http://ac.qq.com/event/95e64748a08b6c2c0c56f15fbbb4f91b.html",
     "begin": "2016-06-21T04:00:00.000Z",
     "end": "2016-11-08T04:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5102",
-        "begin": "2016-06-21T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "qq",
         "id": "v/v18x0bara3c1msb",
-        "begin": "2016-06-21T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-21T04:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -194,17 +135,11 @@
     "officialSite": "http://ac.qq.com/event/mashen/",
     "begin": "2016-06-29T02:00:00.000Z",
     "end": "2016-10-19T02:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "g/g1l5z0cndggpfja",
-        "begin": "2016-06-29T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-29T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -224,17 +159,11 @@
     "officialSite": "",
     "begin": "2016-06-24T16:00:00.000Z",
     "end": "2016-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "xm5KyDCWBkSnJY0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -243,12 +172,7 @@
       {
         "site": "bilibili",
         "id": "6036",
-        "begin": "2016-06-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-23T16:00:01.000Z"
       }
     ]
   },
@@ -264,17 +188,11 @@
     "officialSite": "http://re-zero-anime.jp/",
     "begin": "2016-06-24T16:00:00.000Z",
     "end": "2016-09-23T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IBLibfORKuvhb2UE",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -294,31 +212,15 @@
     "officialSite": "",
     "begin": "2016-06-24T16:00:00.000Z",
     "end": "2017-07-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eciakIorwYJ4Bfibc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
         "id": "162771"
-      },
-      {
-        "site": "bilibili",
-        "id": "5495",
-        "begin": "2016-06-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
       }
     ]
   },
@@ -330,7 +232,6 @@
     "officialSite": "",
     "begin": "2016-06-01T16:00:00.000Z",
     "end": "2016-06-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -339,12 +240,7 @@
       {
         "site": "nicovideo",
         "id": "ippou-mukashibanashi",
-        "begin": "2017-07-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-16T15:00:00.000Z"
       }
     ]
   },
@@ -360,7 +256,6 @@
     "officialSite": "",
     "begin": "2016-06-03T16:00:00.000Z",
     "end": "2016-06-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -369,12 +264,7 @@
       {
         "site": "pptv",
         "id": "HC0Hhe1TwwFk4ko",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2016/07.json
+++ b/data/items/2016/07.json
@@ -14,27 +14,11 @@
     "officialSite": "http://relife-anime.com/",
     "begin": "2016-07-01T15:00:00.000Z",
     "end": "2016-09-23T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "OPJx69vRv0U",
-        "begin": "2016-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "8ccb75fa3a7411e69e2a",
-        "begin": "2016-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-01T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -43,12 +27,7 @@
       {
         "site": "nicovideo",
         "id": "relife",
-        "begin": "2016-09-23T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-23T06:00:00.000Z"
       }
     ]
   },
@@ -67,17 +46,11 @@
     "officialSite": "http://berserk-anime.com/",
     "begin": "2016-07-01T13:30:00.000Z",
     "end": "2016-09-16T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rJx49l7ENHLVU7s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -97,7 +70,6 @@
     "officialSite": "http://www.grap-rodeo.net/",
     "begin": "2016-07-01T12:55:00.000Z",
     "end": "2016-12-30T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -117,57 +89,21 @@
     "officialSite": "http://www.momokuri-anime.jp/",
     "begin": "2016-07-01T13:30:00.000Z",
     "end": "2016-09-23T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480010",
-        "begin": "2016-07-01T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5016",
-        "begin": "2016-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "r0kk6sNDaN4",
-        "begin": "2016-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-01T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "8f0b15313e8a11e69c81",
-        "begin": "2016-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-01T15:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "a9bCQKgOfrwfnQU",
-        "begin": "2016-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-01T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -192,77 +128,31 @@
     "officialSite": "http://hatsukoimonster.jp/",
     "begin": "2016-07-02T14:00:00.000Z",
     "end": "2016-09-17T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480012",
-        "begin": "2016-07-02T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5018",
-        "begin": "2016-07-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0NUaHqCk_5M",
-        "begin": "2016-07-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-02T15:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "r5t181vBMWicSULg",
-        "begin": "2016-07-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanqsp",
-        "begin": "2016-07-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T15:30:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "294422",
-        "begin": "2016-07-02T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "87db18ba3a7a11e69e2a",
-        "begin": "2016-07-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -271,12 +161,7 @@
       {
         "site": "nicovideo",
         "id": "hatsukoimonster",
-        "begin": "2016-07-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-09T03:00:00.000Z"
       }
     ]
   },
@@ -295,17 +180,11 @@
     "officialSite": "http://www.rewrite-anime.tv/",
     "begin": "2016-07-02T14:30:00.000Z",
     "end": "2016-09-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5020",
-        "begin": "2016-07-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -314,12 +193,7 @@
       {
         "site": "nicovideo",
         "id": "ch2623420",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:00:00.000Z"
       }
     ]
   },
@@ -337,47 +211,26 @@
     "officialSite": "http://shokugekinosoma.com/",
     "begin": "2016-07-02T13:00:00.000Z",
     "end": "2016-09-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5017",
-        "begin": "2016-07-02T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanqz5",
-        "begin": "2016-07-02T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T14:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "oo5q6FC2JmTHRa0",
-        "begin": "2016-07-02T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T14:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024389",
-        "begin": "2016-07-02T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -386,22 +239,12 @@
       {
         "site": "mgtv",
         "id": "294534",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jnsdmju32u93uuk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -421,37 +264,21 @@
     "officialSite": "http://www.lovelive-anime.jp/uranohoshi/",
     "begin": "2016-07-02T13:30:00.000Z",
     "end": "2016-09-24T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5062",
-        "begin": "2016-07-02T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanr91",
-        "begin": "2016-07-02T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T14:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "g/g6jw8dxf8zg5x88",
-        "begin": "2016-07-02T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -460,12 +287,7 @@
       {
         "site": "nicovideo",
         "id": "lovelive-anime-uranohoshi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -481,27 +303,11 @@
     "officialSite": "http://bpro-anime.com/",
     "begin": "2016-07-02T15:30:00.000Z",
     "end": "2016-09-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "xJSWm_tqvgE",
-        "begin": "2016-07-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "edb852fe3a7c11e6a080",
-        "begin": "2016-07-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -510,22 +316,12 @@
       {
         "site": "nicovideo",
         "id": "bpro-anime",
-        "begin": "2016-06-25T12:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-25T12:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5019",
-        "begin": "2016-07-02T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T17:00:00.000Z"
       }
     ]
   },
@@ -541,17 +337,11 @@
     "officialSite": "http://www.onaragoro.jp/",
     "begin": "2016-07-01T16:57:00.000Z",
     "end": "2016-09-24T16:57:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5066",
-        "begin": "2016-07-01T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-01T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -577,97 +367,41 @@
     "officialSite": "http://toz-thex-anime.tales-ch.jp/",
     "begin": "2016-07-03T14:00:00.000Z",
     "end": "2016-09-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2016/dhprccshx",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480003",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5022",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "HljTWXqPSSI",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-03T14:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "n6uFA2vRQXiciaYMg",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanqu9",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "z/zb9kc4rtijwlcja",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024401",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "8d4e6f8a3e9f11e6b32f",
-        "begin": "2016-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -676,22 +410,12 @@
       {
         "site": "nicovideo",
         "id": "toz-thex-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "312831",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -712,87 +436,36 @@
     "officialSite": "http://arslan.jp/2/",
     "begin": "2016-07-03T08:00:00.000Z",
     "end": "2016-08-21T08:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480005",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5021",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "vJsUJiGt0AI",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-03T14:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "CDkTkflfzw1w7lY",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanqpx",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "9bc613a23a7f11e69e2a",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024398",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "294389",
-        "begin": "2016-07-03T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -801,12 +474,7 @@
       {
         "site": "nicovideo",
         "id": "arslan02",
-        "begin": "2016-07-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-13T03:00:00.000Z"
       }
     ]
   },
@@ -826,67 +494,26 @@
     "officialSite": "http://days-project.jp/",
     "begin": "2016-07-02T18:28:00.000Z",
     "end": "2016-12-17T18:28:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480006",
-        "begin": "2016-07-02T18:58:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5063",
-        "begin": "2016-07-02T18:58:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "sOPuEwC9oKM",
-        "begin": "2016-07-02T18:58:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-02T18:58:00.000Z"
       },
       {
         "site": "pptv",
         "id": "Ys6qKJD2ZqQHhe0",
-        "begin": "2016-07-02T18:58:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T18:58:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024397",
-        "begin": "2016-07-02T18:58:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-02T18:58:00.000Z"
       },
       {
         "site": "youku",
         "id": "806966103a7d11e6b32f",
-        "begin": "2016-07-02T18:58:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-02T18:58:00.000Z"
       },
       {
         "site": "bangumi",
@@ -895,12 +522,7 @@
       {
         "site": "nicovideo",
         "id": "days-project",
-        "begin": "2016-07-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T03:00:00.000Z"
       }
     ]
   },
@@ -920,17 +542,11 @@
     "officialSite": "http://orange-anime.com/",
     "begin": "2016-07-03T15:00:00.000Z",
     "end": "2016-09-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhanqmt",
-        "begin": "2016-07-03T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -939,12 +555,7 @@
       {
         "site": "mgtv",
         "id": "294547",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -960,87 +571,36 @@
     "officialSite": "http://newgame-anime.com/",
     "begin": "2016-07-04T13:30:00.000Z",
     "end": "2016-09-19T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480004",
-        "begin": "2016-07-05T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5027",
-        "begin": "2016-07-05T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "uGqEOjd4Wd4",
-        "begin": "2016-07-05T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-05T17:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanpqp",
-        "begin": "2016-07-05T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T17:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "Z9O9O6MJebcamAA",
-        "begin": "2016-07-05T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-07-05T17:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2018/dhpnewgame",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "c9b2f1283cd611e6abda",
-        "begin": "2016-07-05T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T17:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024415",
-        "begin": "2016-07-05T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1049,22 +609,12 @@
       {
         "site": "nicovideo",
         "id": "newgame",
-        "begin": "2016-06-28T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-28T06:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "h/hdk2c5cvu5nlhaa",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1081,57 +631,26 @@
     "officialSite": "http://www.bananya-anime.com/",
     "begin": "2016-07-04T11:55:00.000Z",
     "end": "2016-09-26T12:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "7Ufpcw4Fiz4",
-        "begin": "2016-07-04T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrhanq3d",
-        "begin": "2016-07-04T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T13:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "gbGbGYHnV5X4dt4",
-        "begin": "2016-07-04T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T13:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "ea3b7d353cd511e6bdbb",
-        "begin": "2016-07-04T13:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T13:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "294436",
-        "begin": "2016-07-04T13:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T13:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1140,22 +659,12 @@
       {
         "site": "nicovideo",
         "id": "bananya",
-        "begin": "2016-07-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-09T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5026",
-        "begin": "2016-07-03T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-03T16:00:01.000Z"
       }
     ]
   },
@@ -1174,57 +683,26 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pad-x/",
     "begin": "2016-07-04T09:25:00.000Z",
     "end": "2018-03-26T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5025",
-        "begin": "2016-07-04T10:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "7g-yj9B8I5c",
-        "begin": "2016-07-04T10:25:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-04T10:25:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanq81",
-        "begin": "2016-07-04T10:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T10:25:00.000Z"
       },
       {
         "site": "youku",
         "id": "76105a7e3cd911e6bdbb",
-        "begin": "2016-07-04T10:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T10:25:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024413",
-        "begin": "2016-07-04T10:25:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-04T10:25:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1233,12 +711,7 @@
       {
         "site": "nicovideo",
         "id": "pad-x",
-        "begin": "2016-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -1254,57 +727,26 @@
     "officialSite": "http://www.saikikusuo.com/",
     "begin": "2016-07-10T17:05:00.000Z",
     "end": "2016-12-25T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10024422",
-        "begin": "2016-07-04T00:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-04T00:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5070",
-        "begin": "2016-07-04T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T00:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanq6h",
-        "begin": "2016-07-04T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "vW8S6PLn8Qk",
-        "begin": "2016-07-04T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-04T00:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "6431c5ca3cd311e6a080",
-        "begin": "2016-07-04T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T00:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1313,22 +755,12 @@
       {
         "site": "nicovideo",
         "id": "saikikusuo",
-        "begin": "2016-08-25T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-25T15:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80117781",
-        "begin": "2018-04-01T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-01T07:00:00.000Z"
       }
     ]
   },
@@ -1348,57 +780,26 @@
     "officialSite": "http://tabootattoo-anime.com/",
     "begin": "2016-07-04T17:05:00.000Z",
     "end": "2016-09-19T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5031",
-        "begin": "2016-07-04T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "9knc6VFQTkM",
-        "begin": "2016-07-04T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-04T18:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhans3t",
-        "begin": "2016-07-04T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T18:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024417",
-        "begin": "2016-07-04T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-04T18:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "3b0e74e83cd011e69b6d",
-        "begin": "2016-07-04T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T18:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1407,12 +808,7 @@
       {
         "site": "nicovideo",
         "id": "tabootattoo-anime",
-        "begin": "2016-07-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T03:00:00.000Z"
       }
     ]
   },
@@ -1431,27 +827,11 @@
     "officialSite": "http://www.servamp.jp/",
     "begin": "2016-07-05T14:00:00.000Z",
     "end": "2016-09-20T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "qB4qXUbS6NM",
-        "begin": "2016-07-05T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "caa6e1e63da011e69b6d",
-        "begin": "2016-07-05T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1460,12 +840,7 @@
       {
         "site": "nicovideo",
         "id": "servamp",
-        "begin": "2016-07-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T15:00:00.000Z"
       }
     ]
   },
@@ -1484,18 +859,7 @@
     "officialSite": "http://www.masou-hh.com/",
     "begin": "2016-07-05T15:30:00.000Z",
     "end": "2016-09-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5036",
-        "begin": "2016-07-05T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "147438"
@@ -1503,12 +867,7 @@
       {
         "site": "nicovideo",
         "id": "masou-hh",
-        "begin": "2016-07-20T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-20T16:30:00.000Z"
       }
     ]
   },
@@ -1524,57 +883,26 @@
     "officialSite": "http://dgrayman-anime.com/",
     "begin": "2016-07-04T16:35:00.000Z",
     "end": "2016-09-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5030",
-        "begin": "2016-07-04T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "syjFVGHvOLM",
-        "begin": "2016-07-04T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-04T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhansmx",
-        "begin": "2016-07-04T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "0a27cd323cd211e6abda",
-        "begin": "2016-07-04T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024416",
-        "begin": "2016-07-04T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-04T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1594,17 +922,11 @@
     "officialSite": "http://showbyrock-anime.com/short/",
     "begin": "2016-07-04T16:00:00.000Z",
     "end": "2016-09-19T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5028",
-        "begin": "2016-07-04T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T16:15:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1613,12 +935,7 @@
       {
         "site": "nicovideo",
         "id": "showbyrock-short",
-        "begin": "2016-07-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T03:00:00.000Z"
       }
     ]
   },
@@ -1637,57 +954,31 @@
     "officialSite": "http://www.amaama.jp/",
     "begin": "2016-07-04T16:05:00.000Z",
     "end": "2016-09-19T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5029",
-        "begin": "2016-07-04T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T17:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanpu5",
-        "begin": "2016-07-04T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T17:05:00.000Z"
       },
       {
         "site": "pptv",
         "id": "sYFr6VG3J2XIRq4",
-        "begin": "2016-07-04T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T17:05:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "293716",
-        "begin": "2016-07-04T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T17:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024414",
-        "begin": "2016-07-04T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-04T17:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1696,12 +987,7 @@
       {
         "site": "nicovideo",
         "id": "amaama-anime",
-        "begin": "2016-07-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T03:00:00.000Z"
       }
     ]
   },
@@ -1720,27 +1006,11 @@
     "officialSite": "http://www.cheer-boys.com/",
     "begin": "2016-07-05T14:00:00.000Z",
     "end": "2016-09-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "QI9_lX3BegM",
-        "begin": "2016-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "c87eb8763d9b11e69b6d",
-        "begin": "2016-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1749,12 +1019,7 @@
       {
         "site": "nicovideo",
         "id": "cheer-boys",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1774,17 +1039,11 @@
     "officialSite": "http://www.dreamcreation.co.jp/fudanshi/",
     "begin": "2016-07-05T13:55:00.000Z",
     "end": "2016-09-20T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5033",
-        "begin": "2016-07-05T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T13:55:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1793,12 +1052,7 @@
       {
         "site": "nicovideo",
         "id": "fudanshi",
-        "begin": "2016-07-05T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T12:00:00.000Z"
       }
     ]
   },
@@ -1817,87 +1071,36 @@
     "officialSite": "http://www.tsukiani.com/",
     "begin": "2016-07-06T14:00:00.000Z",
     "end": "2016-09-28T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480007",
-        "begin": "2016-07-06T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5038",
-        "begin": "2016-07-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Qa4Wr_jDxB8",
-        "begin": "2016-07-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-06T14:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "FSQQjvZczApt61M",
-        "begin": "2016-07-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T14:30:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2018/dhpyuege",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "f/fh9qxmu1x4631aj",
-        "begin": "2016-07-06T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "9c2736e63d9f11e69e2a",
-        "begin": "2016-07-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T14:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024418",
-        "begin": "2016-07-06T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1906,32 +1109,17 @@
       {
         "site": "nicovideo",
         "id": "tsukiani",
-        "begin": "2016-07-20T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-20T14:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "294605",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhf5m79",
-        "begin": "2018-04-30T16:00:43.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-30T16:00:43.000Z"
       }
     ]
   },
@@ -1951,17 +1139,11 @@
     "officialSite": "http://anime.prisma-illya.jp/3rei/",
     "begin": "2016-07-06T14:00:00.000Z",
     "end": "2016-09-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhanrv5",
-        "begin": "2016-07-06T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1970,22 +1152,7 @@
       {
         "site": "nicovideo",
         "id": "prisma-illya03",
-        "begin": "2016-07-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5835",
-        "begin": "2016-07-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-16T16:00:00.000Z"
       }
     ]
   },
@@ -2004,17 +1171,11 @@
     "officialSite": "http://anime.ozmafia.com/",
     "begin": "2016-07-06T15:00:00.000Z",
     "end": "2016-09-21T15:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5039",
-        "begin": "2016-07-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2023,12 +1184,7 @@
       {
         "site": "nicovideo",
         "id": "ozmafia",
-        "begin": "2016-07-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-12T03:00:00.000Z"
       }
     ]
   },
@@ -2044,17 +1200,11 @@
     "officialSite": "http://planetarian-project.com/",
     "begin": "2016-07-06T15:00:00.000Z",
     "end": "2016-08-03T15:26:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5045",
-        "begin": "2016-07-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2063,12 +1213,7 @@
       {
         "site": "nicovideo",
         "id": "planetarian",
-        "begin": "2016-07-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T15:00:00.000Z"
       }
     ]
   },
@@ -2087,57 +1232,26 @@
     "officialSite": "http://anime.scared-rider-xechs.jp/",
     "begin": "2016-07-05T16:35:00.000Z",
     "end": "2016-09-20T17:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "rUzNKGU_ffQ",
-        "begin": "2016-07-05T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "6a5bd68c3da211e6b432",
-        "begin": "2016-07-05T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhans3h",
-        "begin": "2016-07-05T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T17:35:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5037",
-        "begin": "2016-07-05T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-05T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024420",
-        "begin": "2016-07-05T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-05T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2146,12 +1260,7 @@
       {
         "site": "nicovideo",
         "id": "scared-rider-xechs",
-        "begin": "2016-07-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-15T03:00:00.000Z"
       }
     ]
   },
@@ -2167,17 +1276,11 @@
     "officialSite": "http://www.nariagirls.com/",
     "begin": "2016-07-06T15:05:00.000Z",
     "end": "2016-09-21T15:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5040",
-        "begin": "2016-07-06T15:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T15:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2186,12 +1289,7 @@
       {
         "site": "nicovideo",
         "id": "nariagirls",
-        "begin": "2016-07-06T15:14:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T15:14:00.000Z"
       }
     ]
   },
@@ -2211,37 +1309,21 @@
     "officialSite": "http://regalia-anime.com/",
     "begin": "2016-07-07T13:00:00.000Z",
     "end": "2016-11-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5041",
-        "begin": "2016-07-07T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T14:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "rpp29FzCMnDTUbk",
-        "begin": "2016-07-07T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T14:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024419",
-        "begin": "2016-07-07T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-07T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2250,12 +1332,7 @@
       {
         "site": "nicovideo",
         "id": "regalia",
-        "begin": "2016-09-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-05T03:00:00.000Z"
       }
     ]
   },
@@ -2272,67 +1349,26 @@
     "officialSite": "http://boueibu.com/",
     "begin": "2016-07-07T18:05:00.000Z",
     "end": "2016-09-22T18:41:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480014",
-        "begin": "2016-07-07T18:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5044",
-        "begin": "2016-07-07T18:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "eAzP6qKWn3A",
-        "begin": "2016-07-07T18:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-07T18:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanrkd",
-        "begin": "2016-07-07T18:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T18:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "8fc3b3903dc011e69c81",
-        "begin": "2016-07-07T18:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T18:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024421",
-        "begin": "2016-07-07T18:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-07T18:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2341,12 +1377,7 @@
       {
         "site": "nicovideo",
         "id": "boueibu02",
-        "begin": "2016-07-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-14T03:00:00.000Z"
       }
     ]
   },
@@ -2362,27 +1393,11 @@
     "officialSite": "http://amanchu-anime.com/",
     "begin": "2016-07-08T14:00:00.000Z",
     "end": "2016-09-23T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "K0VnyPoc-74",
-        "begin": "2016-07-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "eb1d7b003e7311e6a080",
-        "begin": "2016-07-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2391,12 +1406,7 @@
       {
         "site": "nicovideo",
         "id": "amanchu-anime",
-        "begin": "2016-07-06T22:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-06T22:00:00.000Z"
       }
     ]
   },
@@ -2413,67 +1423,26 @@
     "officialSite": "http://www.tbs.co.jp/anime/konobi/",
     "begin": "2016-07-07T17:28:00.000Z",
     "end": "2016-09-22T17:58:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480011",
-        "begin": "2016-07-07T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5043",
-        "begin": "2016-07-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "0OeVUUcClM0",
-        "begin": "2016-07-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-07T19:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "3a67f7f63dbd11e6b522",
-        "begin": "2016-07-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T19:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanrop",
-        "begin": "2016-07-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T19:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "FCUPjfVbywls6lI",
-        "begin": "2016-07-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T19:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2482,12 +1451,7 @@
       {
         "site": "nicovideo",
         "id": "konobi",
-        "begin": "2016-06-24T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-06-24T03:00:00.000Z"
       }
     ]
   },
@@ -2506,27 +1470,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/handaanime/",
     "begin": "2016-07-07T16:58:00.000Z",
     "end": "2016-09-22T17:28:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "4Izz8YNGVVI",
-        "begin": "2016-07-08T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "7c5cb5243e7211e69b6d",
-        "begin": "2016-07-08T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T13:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2535,12 +1483,7 @@
       {
         "site": "nicovideo",
         "id": "handaanime",
-        "begin": "2016-07-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-17T15:00:00.000Z"
       }
     ]
   },
@@ -2556,17 +1499,11 @@
     "officialSite": "http://www.thunderboltfantasy.com/",
     "begin": "2016-07-08T14:00:00.000Z",
     "end": "2016-09-30T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5064",
-        "begin": "2016-07-08T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2575,12 +1512,7 @@
       {
         "site": "nicovideo",
         "id": "thunderboltfantasy",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2599,67 +1531,26 @@
     "officialSite": "http://alderamin.net/",
     "begin": "2016-07-08T16:05:00.000Z",
     "end": "2016-09-30T16:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480009",
-        "begin": "2016-07-08T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5047",
-        "begin": "2016-07-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "t1M2fyb0N_E",
-        "begin": "2016-07-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-08T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "8c2ed5803dbe11e69c81",
-        "begin": "2016-07-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanrc1",
-        "begin": "2016-07-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T17:35:00.000Z"
       },
       {
         "site": "pptv",
         "id": "gLCcGoLoWJb5d98",
-        "begin": "2016-07-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2668,12 +1559,7 @@
       {
         "site": "nicovideo",
         "id": "alderamin",
-        "begin": "2016-07-18T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-18T15:30:00.000Z"
       }
     ]
   },
@@ -2693,27 +1579,11 @@
     "officialSite": "http://qualidea.jp/",
     "begin": "2016-07-09T15:00:00.000Z",
     "end": "2016-09-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "5zduRm348DE",
-        "begin": "2016-07-14T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "f387c01e3db711e6b32f",
-        "begin": "2016-07-14T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-14T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2722,12 +1592,7 @@
       {
         "site": "nicovideo",
         "id": "qualidea",
-        "begin": "2016-07-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-14T03:00:00.000Z"
       }
     ]
   },
@@ -2746,17 +1611,11 @@
     "officialSite": "http://91days.family/",
     "begin": "2016-07-08T17:10:00.000Z",
     "end": "2016-09-30T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Y8ibpJ4ic1ZaMGhOw",
-        "begin": "2016-07-08T17:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T17:55:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2765,12 +1624,7 @@
       {
         "site": "nicovideo",
         "id": "91days",
-        "begin": "2016-07-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-17T03:00:00.000Z"
       }
     ]
   },
@@ -2790,67 +1644,36 @@
     "officialSite": "http://hitorinoshita.com/",
     "begin": "2016-07-02T12:00:00.000Z",
     "end": "2016-09-24T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "wm9JxyibVBUOmJIw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "o/ozvao2u23k1nf9o",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10024378",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "295078",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5210",
-        "begin": "2016-07-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T16:00:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhaqfsd",
-        "begin": "2016-07-08T02:33:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T02:33:01.000Z"
       },
       {
         "site": "bangumi",
@@ -2859,12 +1682,7 @@
       {
         "site": "nicovideo",
         "id": "hitorinoshita",
-        "begin": "2016-09-14T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-14T06:00:00.000Z"
       }
     ]
   },
@@ -2883,7 +1701,6 @@
     "officialSite": "http://hitorinoshita.com/",
     "begin": "2016-07-02T12:00:00.000Z",
     "end": "2016-09-24T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2892,62 +1709,32 @@
       {
         "site": "pptv",
         "id": "9kIurBR66iaiaLCXE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "0/0vjw392pdevdan3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10022999",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "294102",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5050",
-        "begin": "2016-07-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-07T16:00:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhal2yd",
-        "begin": "2016-07-08T02:33:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T02:33:01.000Z"
       }
     ]
   },
@@ -2967,17 +1754,11 @@
     "officialSite": "http://mariwaka.com/",
     "begin": "2016-07-08T22:00:00.000Z",
     "end": "2016-09-23T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5049",
-        "begin": "2016-07-08T22:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-08T22:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2986,12 +1767,7 @@
       {
         "site": "nicovideo",
         "id": "mariwaka",
-        "begin": "2016-07-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-11T03:00:00.000Z"
       }
     ]
   },
@@ -3011,27 +1787,16 @@
     "officialSite": "http://ange-vierge-anime.com/",
     "begin": "2016-07-09T16:30:00.000Z",
     "end": "2016-09-24T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5053",
-        "begin": "2016-07-09T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-09T18:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "gq6KCHDWRoTnZc0",
-        "begin": "2016-07-09T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-09T18:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3040,12 +1805,7 @@
       {
         "site": "nicovideo",
         "id": "ange-vierge-anime",
-        "begin": "2016-07-22T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-22T16:30:00.000Z"
       }
     ]
   },
@@ -3064,27 +1824,11 @@
     "officialSite": "http://activeraid.net/",
     "begin": "2016-07-10T15:30:00.000Z",
     "end": "2016-09-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "gzuf2x7EDOk",
-        "begin": "2016-07-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "503b58c0a88a11e5a080",
-        "begin": "2016-07-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-10T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3093,22 +1837,12 @@
       {
         "site": "nicovideo",
         "id": "activeraid",
-        "begin": "2016-01-18T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-01-18T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhf5ndp",
-        "begin": "2018-08-16T16:00:35.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-16T16:00:35.000Z"
       }
     ]
   },
@@ -3124,67 +1858,26 @@
     "officialSite": "http://mobpsycho100.com/",
     "begin": "2016-07-11T15:00:00.000Z",
     "end": "2016-09-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480002",
-        "begin": "2016-07-11T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5058",
-        "begin": "2016-07-11T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "FXN0uiGkM8I",
-        "begin": "2016-07-11T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-11T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "e4541dac3dbe11e6abda",
-        "begin": "2016-07-11T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-11T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhantvl",
-        "begin": "2016-07-11T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-11T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "qpaCAGjOPnzfXcU",
-        "begin": "2016-07-11T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-11T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3193,22 +1886,12 @@
       {
         "site": "qq",
         "id": "j/j74t36ys0phnqqp",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "294676",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3227,57 +1910,21 @@
     "officialSite": "http://www.nbcuni.co.jp/anime/danganronpa3/",
     "begin": "2016-07-11T14:00:00.000Z",
     "end": "2016-09-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480001",
-        "begin": "2016-07-11T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5056",
-        "begin": "2016-07-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "3C6tg-J53ro",
-        "begin": "2016-07-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-11T15:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "hbWfHYXrW5n8euI",
-        "begin": "2016-07-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-11T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "844de4983dba11e6bdbb",
-        "begin": "2016-07-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-11T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3286,12 +1933,7 @@
       {
         "site": "nicovideo",
         "id": "cdanganronpa3_miraihen",
-        "begin": "2016-08-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-09T03:00:00.000Z"
       }
     ]
   },
@@ -3310,27 +1952,16 @@
     "officialSite": "http://battery-anime.com/",
     "begin": "2016-07-14T16:05:00.000Z",
     "end": "2016-09-22T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "o49p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10025131",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3353,57 +1984,21 @@
     "officialSite": "http://www.nbcuni.co.jp/anime/danganronpa3/",
     "begin": "2016-07-14T14:30:00.000Z",
     "end": "2016-09-22T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480013",
-        "begin": "2016-07-14T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5057",
-        "begin": "2016-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "QP8EAY0esqI",
-        "begin": "2016-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-07-14T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "hrKeHITqWpj7eeE",
-        "begin": "2016-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-14T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "f90460183db911e6b432",
-        "begin": "2016-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-14T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3412,12 +2007,7 @@
       {
         "site": "nicovideo",
         "id": "danganronpa3-zetubouhen",
-        "begin": "2016-08-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-12T03:00:00.000Z"
       }
     ]
   },
@@ -3434,17 +2024,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/onep/",
     "begin": "2016-07-16T12:00:00.000Z",
     "end": "2016-07-16T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhaqhpp",
-        "begin": "2016-07-17T11:15:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-17T11:15:57.000Z"
       },
       {
         "site": "bangumi",
@@ -3464,17 +2048,11 @@
     "officialSite": "http://www.onepiece-film2016.com/",
     "begin": "2016-07-23T16:00:00.000Z",
     "end": "2016-07-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rr9tounc",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3483,12 +2061,7 @@
       {
         "site": "pptv",
         "id": "uIhk4kqwIF7BP6c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3504,17 +2077,11 @@
     "officialSite": "",
     "begin": "2016-07-27T16:00:00.000Z",
     "end": "2016-09-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dsCsKpL4aKYJhib8",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3523,22 +2090,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh836f9",
-        "begin": "2017-06-30T16:02:50.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:50.000Z"
       },
       {
         "site": "bilibili",
         "id": "5469",
-        "begin": "2016-07-26T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-26T16:00:01.000Z"
       }
     ]
   },
@@ -3554,17 +2111,11 @@
     "officialSite": "http://www.durarara.com/ova/",
     "begin": "2016-07-27T16:00:00.000Z",
     "end": "2016-07-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "PwnjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3573,12 +2124,7 @@
       {
         "site": "bilibili",
         "id": "5424",
-        "begin": "2016-05-20T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-05-20T16:00:01.000Z"
       }
     ]
   },
@@ -3594,7 +2140,6 @@
     "officialSite": "http://www.accel-world.net/",
     "begin": "2016-07-23T16:00:00.000Z",
     "end": "2016-07-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3603,32 +2148,17 @@
       {
         "site": "nicovideo",
         "id": "accel-world_IB",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "uYlj4UmvH13APqY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5076",
-        "begin": "2016-07-22T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-22T16:00:01.000Z"
       }
     ]
   },
@@ -3644,7 +2174,6 @@
     "officialSite": "http://kingsglaive-jp.com/",
     "begin": "2016-07-09T16:00:00.000Z",
     "end": "2016-07-09T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3653,12 +2182,7 @@
       {
         "site": "nicovideo",
         "id": "kingsglaive-jp",
-        "begin": "2016-08-29T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-29T15:00:00.000Z"
       }
     ]
   },
@@ -3674,7 +2198,6 @@
     "officialSite": "http://www.pokemon-sun-moon.cn/movie/m19/",
     "begin": "2016-07-16T16:00:00.000Z",
     "end": "2016-07-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3683,22 +2206,12 @@
       {
         "site": "pptv",
         "id": "a9ia0MpoAcK4Rjicc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "322203",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2016/08.json
+++ b/data/items/2016/08.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.7-taizai.net/",
     "begin": "2016-08-28T08:30:00.000Z",
     "end": "2016-09-18T08:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,12 +22,7 @@
       {
         "site": "nicovideo",
         "id": "7-taizai02",
-        "begin": "2016-08-28T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-28T09:00:00.000Z"
       }
     ]
   },
@@ -40,27 +34,16 @@
     "officialSite": "http://ac.qq.com/event/835d044d6dd88a012ef06a244da6d3a6.html",
     "begin": "2016-08-25T12:00:00.000Z",
     "end": "2017-01-12T12:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dbibZF3iclVZP2dNw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "9/9fan764zm5pe3m8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -80,27 +63,11 @@
     "officialSite": "http://www.kizumonogatari-movie.com/",
     "begin": "2016-08-19T16:00:00.000Z",
     "end": "2016-08-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "383c6440a6d611e0a046",
-        "begin": "2017-02-23T05:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "jEqiWcizq8A",
-        "begin": "2017-02-23T05:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-02-23T05:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -120,17 +87,11 @@
     "officialSite": "",
     "begin": "2016-08-05T16:00:00.000Z",
     "end": "2016-10-21T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lZ9591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -139,12 +100,7 @@
       {
         "site": "bilibili",
         "id": "5437",
-        "begin": "2016-08-04T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-08-04T16:00:01.000Z"
       }
     ]
   },
@@ -161,17 +117,11 @@
     "officialSite": "http://gundam-bf.net/try_special/",
     "begin": "2016-08-21T16:00:00.000Z",
     "end": "2016-08-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "q5139V3DM3HUUro",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -191,17 +141,11 @@
     "officialSite": "http://under-the-dog.com/",
     "begin": "2016-08-01T16:00:00.000Z",
     "end": "2016-08-01T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VN66OKAGdrQXlf0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -210,12 +154,7 @@
       {
         "site": "bilibili",
         "id": "6071",
-        "begin": "2016-07-31T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-31T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2016/09.json
+++ b/data/items/2016/09.json
@@ -14,47 +14,21 @@
     "officialSite": "http://www.heybot.net/",
     "begin": "2016-09-17T22:00:00.000Z",
     "end": "2017-09-24T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh91o7h",
-        "begin": "2017-01-05T07:00:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-05T07:00:13.000Z"
       },
       {
         "site": "letv",
         "id": "10029958",
-        "begin": "2016-09-17T22:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-17T22:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "lJ9591icFNXPWVLw",
-        "begin": "2016-09-17T22:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "dvEjGKzG2Dw",
-        "begin": "2016-10-10T03:00:37.000Z",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-09-17T22:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -78,27 +52,16 @@
     "officialSite": "http://www6.nhk.or.jp/anime/program/detail.html?i=nyanbo",
     "begin": "2016-09-26T21:40:00.000Z",
     "end": "2017-03-28T21:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9zat9",
-        "begin": "2017-02-07T03:09:56.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-07T03:09:56.000Z"
       },
       {
         "site": "bilibili",
         "id": "5504",
-        "begin": "2016-09-26T22:45:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-26T22:45:10.000Z"
       },
       {
         "site": "bangumi",
@@ -107,12 +70,7 @@
       {
         "site": "nicovideo",
         "id": "nyanbo",
-        "begin": "2016-09-29T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-29T03:00:00.000Z"
       }
     ]
   },
@@ -132,17 +90,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/appmon/",
     "begin": "2016-09-30T22:00:00.000Z",
     "end": "2017-09-30T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9to4d",
-        "begin": "2016-09-30T22:55:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-30T22:55:09.000Z"
       },
       {
         "site": "bangumi",
@@ -151,12 +103,7 @@
       {
         "site": "nicovideo",
         "id": "appmon",
-        "begin": "2016-10-08T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T04:00:00.000Z"
       }
     ]
   },
@@ -168,7 +115,6 @@
     "officialSite": "http://www.scp.co.jp/Tama/",
     "begin": "2016-09-30T22:00:00.000Z",
     "end": "2018-11-17T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -177,12 +123,7 @@
       {
         "site": "nicovideo",
         "id": "Tama-anime",
-        "begin": "2017-01-26T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-26T15:00:00.000Z"
       }
     ]
   },
@@ -198,17 +139,11 @@
     "officialSite": "http://anime.dream-fes.com/",
     "begin": "2016-09-23T13:00:00.000Z",
     "end": "2016-12-16T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5512",
-        "begin": "2016-09-23T12:30:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-23T12:30:09.000Z"
       },
       {
         "site": "bangumi",
@@ -229,37 +164,21 @@
     "officialSite": "http://kaiju-gk.jp/",
     "begin": "2016-09-27T09:00:00.000Z",
     "end": "2016-12-13T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10029740",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9uqjh",
-        "begin": "2016-09-27T10:00:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-27T10:00:13.000Z"
       },
       {
         "site": "qq",
         "id": "u/ujosn0cmd203mxa",
-        "begin": "2016-09-26T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-26T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -268,12 +187,7 @@
       {
         "site": "nicovideo",
         "id": "kaiju-gk",
-        "begin": "2016-10-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T03:00:00.000Z"
       }
     ]
   },
@@ -289,7 +203,6 @@
     "officialSite": "http://www.fujitv.co.jp/kochikame2016/",
     "begin": "2016-09-18T16:00:00.000Z",
     "end": "2016-09-18T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -298,12 +211,7 @@
       {
         "site": "bilibili",
         "id": "5499",
-        "begin": "2016-09-18T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-18T01:00:00.000Z"
       }
     ]
   },
@@ -322,7 +230,6 @@
     "officialSite": "http://www.aniplex.co.jp/p5a/",
     "begin": "2016-09-03T16:00:00.000Z",
     "end": "2016-09-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -331,22 +238,12 @@
       {
         "site": "nicovideo",
         "id": "PERSONA5",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5482",
-        "begin": "2016-09-02T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-02T16:00:01.000Z"
       }
     ]
   },
@@ -363,37 +260,21 @@
     "officialSite": "http://movie.kurobas.com/",
     "begin": "2016-09-23T16:00:00.000Z",
     "end": "2016-09-23T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "1F85txibF9TOWFHw",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9arix",
-        "begin": "2017-02-28T16:00:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-28T16:00:59.000Z"
       },
       {
         "site": "letv",
         "id": "10035150",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -413,17 +294,11 @@
     "officialSite": "http://digimon-adventure.net/",
     "begin": "2016-09-24T16:00:00.000Z",
     "end": "2016-09-24T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbcjih",
-        "begin": "2016-02-15T09:09:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-15T09:09:13.000Z"
       },
       {
         "site": "bangumi",
@@ -432,12 +307,7 @@
       {
         "site": "nicovideo",
         "id": "digimon-adventure-tri",
-        "begin": "2016-11-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-01T15:00:00.000Z"
       }
     ]
   },
@@ -453,17 +323,11 @@
     "officialSite": "",
     "begin": "2016-09-16T16:00:00.000Z",
     "end": "2016-12-23T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ia7GbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -483,7 +347,6 @@
     "officialSite": "",
     "begin": "2016-09-23T16:00:00.000Z",
     "end": "2016-09-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -492,22 +355,12 @@
       {
         "site": "pptv",
         "id": "sIRw7la8LGrNS7M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5709",
-        "begin": "2016-09-22T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-22T16:00:01.000Z"
       }
     ]
   },
@@ -523,7 +376,6 @@
     "officialSite": "http://www.ajin.net/",
     "begin": "2016-09-23T16:00:00.000Z",
     "end": "2016-09-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -532,12 +384,7 @@
       {
         "site": "pptv",
         "id": "lruVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -553,7 +400,6 @@
     "officialSite": "http://koenokatachi-movie.com/",
     "begin": "2016-09-17T16:00:00.000Z",
     "end": "2016-09-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -562,22 +408,12 @@
       {
         "site": "nicovideo",
         "id": "koenokatachi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "12116",
-        "begin": "2016-09-17T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-17T16:00:00.000Z"
       }
     ]
   }

--- a/data/items/2016/10.json
+++ b/data/items/2016/10.json
@@ -11,18 +11,7 @@
     "officialSite": "http://www.dreamcreation.co.jp/okusama/",
     "begin": "2016-10-02T13:30:00.000Z",
     "end": "2016-12-18T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5524",
-        "begin": "2016-10-02T16:33:10.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "167348"
@@ -30,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "okusama02",
-        "begin": "2016-09-20T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-20T11:00:00.000Z"
       }
     ]
   },
@@ -54,27 +38,11 @@
     "officialSite": "http://anime-eupho.com/",
     "begin": "2016-10-05T15:00:00.000Z",
     "end": "2016-12-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "uu4R6eeDa8Q",
-        "begin": "2016-10-05T15:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "4d8cce35815111e6b16e",
-        "begin": "2016-10-05T15:58:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T15:58:00.000Z"
       },
       {
         "site": "bangumi",
@@ -83,12 +51,7 @@
       {
         "site": "nicovideo",
         "id": "anime-eupho02",
-        "begin": "2016-10-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T15:00:00.000Z"
       }
     ]
   },
@@ -104,17 +67,11 @@
     "officialSite": "http://www.nbcuni.co.jp/rondorobe/anime/drifters/",
     "begin": "2016-10-07T14:00:00.000Z",
     "end": "2016-12-23T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Mia4KiaPBWxgRn5U0",
-        "begin": "2016-10-07T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2016-10-07T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -123,12 +80,7 @@
       {
         "site": "nicovideo",
         "id": "drifters",
-        "begin": "2019-04-30T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-30T15:00:00.000Z"
       }
     ]
   },
@@ -145,57 +97,26 @@
     "officialSite": "http://working-www.com/",
     "begin": "2016-10-01T14:30:00.000Z",
     "end": "2016-12-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5507",
-        "begin": "2016-10-01T16:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T16:00:10.000Z"
       },
       {
         "site": "letv",
         "id": "10029954",
-        "begin": "2016-10-01T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "adq2NJwCcrATkfk",
-        "begin": "2016-10-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "e02f40e9795311e69e06",
-        "begin": "2016-10-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "VoqOZ-snzLc",
-        "begin": "2016-10-01T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-01T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -204,12 +125,7 @@
       {
         "site": "nicovideo",
         "id": "working-www",
-        "begin": "2016-10-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T03:00:00.000Z"
       }
     ]
   },
@@ -226,47 +142,21 @@
     "officialSite": "http://w-witch.jp/",
     "begin": "2016-10-05T16:35:00.000Z",
     "end": "2016-12-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5562",
-        "begin": "2016-10-05T18:05:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T18:05:10.000Z"
       },
       {
         "site": "pptv",
         "id": "AjQgngZs3Bp9ib2M",
-        "begin": "2016-10-05T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T18:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "36c3bfdf815d11e69c81",
-        "begin": "2016-10-05T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "eTEHrp1eiUw",
-        "begin": "2016-10-05T18:05:00.000Z",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-05T18:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -275,12 +165,7 @@
       {
         "site": "nicovideo",
         "id": "w-witch",
-        "begin": "2016-10-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-20T15:00:00.000Z"
       }
     ]
   },
@@ -297,57 +182,21 @@
     "officialSite": "http://lostorage-wixoss.com/",
     "begin": "2016-10-07T15:30:00.000Z",
     "end": "2016-12-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5530",
-        "begin": "2016-10-07T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T16:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9ugpd",
-        "begin": "2016-10-07T16:30:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "LntUQRWbcDQ",
-        "begin": "2016-10-07T16:33:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-07T16:30:18.000Z"
       },
       {
         "site": "youku",
         "id": "5ced7c15845a11e6b9bb",
-        "begin": "2016-10-07T16:33:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480036",
-        "begin": "2016-10-07T16:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T16:33:00.000Z"
       },
       {
         "site": "bangumi",
@@ -367,77 +216,31 @@
     "officialSite": "http://occultic-nine.com/",
     "begin": "2016-10-08T15:00:00.000Z",
     "end": "2016-12-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5526",
-        "begin": "2016-10-08T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9uq4p",
-        "begin": "2016-10-08T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "WevFQ6sRgb8iaoAg",
-        "begin": "2016-10-08T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "D0EBlEC_PmE",
-        "begin": "2016-10-08T16:28:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-08T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "d5ecc9e77edf11e69e06",
-        "begin": "2016-10-08T16:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T16:28:00.000Z"
       },
       {
         "site": "letv",
         "id": "10030160",
-        "begin": "2016-10-08T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480039",
-        "begin": "2016-10-08T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -446,12 +249,7 @@
       {
         "site": "nicovideo",
         "id": "Occultic_Nine",
-        "begin": "2016-10-13T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-13T14:30:00.000Z"
       }
     ]
   },
@@ -470,57 +268,26 @@
     "officialSite": "http://izetta.jp/",
     "begin": "2016-10-01T14:00:00.000Z",
     "end": "2016-12-17T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5513",
-        "begin": "2016-10-01T15:00:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T15:00:09.000Z"
       },
       {
         "site": "pptv",
         "id": "ic0ompAxy4iaCDAWk",
-        "begin": "2016-10-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T15:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10029955",
-        "begin": "2016-10-01T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "eKTeVUJ2IOI",
-        "begin": "2016-10-10T03:11:38.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-01T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "364894a478c911e6b32f",
-        "begin": "2016-10-10T03:11:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-10T03:11:38.000Z"
       },
       {
         "site": "bangumi",
@@ -529,12 +296,7 @@
       {
         "site": "nicovideo",
         "id": "izetta",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -550,87 +312,36 @@
     "officialSite": "http://touken-hanamaru.jp/",
     "begin": "2016-10-02T15:00:00.000Z",
     "end": "2016-12-18T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5515",
-        "begin": "2016-10-02T16:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T16:00:10.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9tlph",
-        "begin": "2016-10-02T15:55:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T15:55:16.000Z"
       },
       {
         "site": "pptv",
         "id": "TicvVU7shkc8ysBg",
-        "begin": "2016-10-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T16:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "6/6v4gdmsxw4o6rx3",
-        "begin": "2016-10-02T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "HeB3ycdgbtI",
-        "begin": "2016-10-02T15:58:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-02T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "2317cca2795811e6bdbb",
-        "begin": "2016-10-02T15:58:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T15:58:00.000Z"
       },
       {
         "site": "letv",
         "id": "10029969",
-        "begin": "2016-10-02T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480026",
-        "begin": "2016-10-02T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -639,12 +350,7 @@
       {
         "site": "nicovideo",
         "id": "touken-hanamaru",
-        "begin": "2016-10-10T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-10T01:00:00.000Z"
       }
     ]
   },
@@ -660,17 +366,11 @@
     "officialSite": "http://mouiidesukara.com/",
     "begin": "2016-10-05T13:38:00.000Z",
     "end": "2016-12-21T13:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5560",
-        "begin": "2016-10-05T13:38:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T13:38:09.000Z"
       },
       {
         "site": "bangumi",
@@ -679,12 +379,7 @@
       {
         "site": "nicovideo",
         "id": "mahoii2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -704,67 +399,26 @@
     "officialSite": "http://3lion-anime.com/",
     "begin": "2016-10-08T14:00:00.000Z",
     "end": "2017-03-18T14:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5523",
-        "begin": "2016-10-08T16:30:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T16:30:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9uq0d",
-        "begin": "2016-10-08T16:30:27.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T16:30:27.000Z"
       },
       {
         "site": "pptv",
         "id": "FR76eOBGtvRX1T0",
-        "begin": "2016-10-08T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "JA-0VT2hjxY",
-        "begin": "2016-10-08T16:28:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-08T16:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "c8d8052c814c11e6b16e",
-        "begin": "2016-10-08T16:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480038",
-        "begin": "2016-10-08T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T16:28:00.000Z"
       },
       {
         "site": "bangumi",
@@ -773,12 +427,7 @@
       {
         "site": "nicovideo",
         "id": "3lion-anime",
-        "begin": "2017-02-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-28T15:00:00.000Z"
       }
     ]
   },
@@ -794,17 +443,11 @@
     "officialSite": "http://showbyrock-anime.com/",
     "begin": "2016-10-02T13:00:00.000Z",
     "end": "2016-12-18T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5520",
-        "begin": "2016-10-02T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T16:15:00.000Z"
       },
       {
         "site": "bangumi",
@@ -813,12 +456,7 @@
       {
         "site": "nicovideo",
         "id": "showbyrock_anime02",
-        "begin": "2016-10-06T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T13:30:00.000Z"
       }
     ]
   },
@@ -837,17 +475,11 @@
     "officialSite": "http://mahoiku.jp/",
     "begin": "2016-10-01T15:00:00.000Z",
     "end": "2016-12-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5506",
-        "begin": "2016-10-01T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -856,12 +488,7 @@
       {
         "site": "nicovideo",
         "id": "mahoiku",
-        "begin": "2016-10-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T03:00:00.000Z"
       }
     ]
   },
@@ -880,47 +507,16 @@
     "officialSite": "http://vivid-strike.com/",
     "begin": "2016-10-01T15:30:00.000Z",
     "end": "2016-12-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480025",
-        "begin": "2016-10-01T18:00:10.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5514",
-        "begin": "2016-10-01T18:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "wlaBP_HwsW4",
-        "begin": "2016-10-01T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-01T18:00:10.000Z"
       },
       {
         "site": "youku",
         "id": "de313ad87a1c11e6b16e",
-        "begin": "2016-10-01T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T18:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -941,97 +537,41 @@
     "officialSite": "http://www.natsume-anime.jp/",
     "begin": "2016-10-04T16:35:00.000Z",
     "end": "2016-12-20T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480033",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5550",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T19:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9toi9",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T19:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "YtWicPaULe7kcmgI",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T19:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "g/gyf3u5vx0m42531",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "MBDDjWSnoHE",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-04T19:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "156d1c7a7b1611e69e06",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T19:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10030038",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T19:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "301218",
-        "begin": "2016-10-04T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T19:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1040,12 +580,7 @@
       {
         "site": "nicovideo",
         "id": "natsume5",
-        "begin": "2016-10-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T03:00:00.000Z"
       }
     ]
   },
@@ -1061,17 +596,11 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2016-10-05T13:30:00.000Z",
     "end": "2016-12-21T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5561",
-        "begin": "2016-10-05T13:30:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T13:30:09.000Z"
       },
       {
         "site": "bangumi",
@@ -1080,12 +609,7 @@
       {
         "site": "nicovideo",
         "id": "te-kyu8",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1101,87 +625,36 @@
     "officialSite": "http://www.tbs.co.jp/anime/watamote/",
     "begin": "2016-10-06T16:58:00.000Z",
     "end": "2016-12-22T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5534",
-        "begin": "2016-10-07T06:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T06:00:10.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9ts7p",
-        "begin": "2016-10-07T06:00:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T06:00:13.000Z"
       },
       {
         "site": "pptv",
         "id": "XefRT7cdjcsurBQ",
-        "begin": "2016-10-07T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T04:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "x/xlvp58zd0o8441x",
-        "begin": "2016-10-07T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "A9SUm5SJjhA",
-        "begin": "2016-10-07T04:13:46.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-07T04:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "686a634078cb11e6b16e",
-        "begin": "2016-10-07T04:13:46.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T04:13:46.000Z"
       },
       {
         "site": "mgtv",
         "id": "301758",
-        "begin": "2016-10-07T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480035",
-        "begin": "2016-10-07T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T04:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1190,12 +663,7 @@
       {
         "site": "nicovideo",
         "id": "watamote_anime",
-        "begin": "2016-10-09T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T16:30:00.000Z"
       }
     ]
   },
@@ -1214,17 +682,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/gn/",
     "begin": "2016-10-06T17:28:00.000Z",
     "end": "2016-12-22T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5532",
-        "begin": "2016-10-07T04:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T04:00:10.000Z"
       },
       {
         "site": "bangumi",
@@ -1233,12 +695,7 @@
       {
         "site": "nicovideo",
         "id": "gn_anime",
-        "begin": "2016-10-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T03:00:00.000Z"
       }
     ]
   },
@@ -1258,27 +715,11 @@
     "officialSite": "http://bbkbrnk.com/",
     "begin": "2016-10-01T12:30:00.000Z",
     "end": "2016-12-17T13:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5508",
-        "begin": "2016-10-01T14:00:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "letv",
         "id": "10029953",
-        "begin": "2016-10-01T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1287,12 +728,7 @@
       {
         "site": "nicovideo",
         "id": "bbkbrnkebg",
-        "begin": "2016-10-12T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-12T15:30:00.000Z"
       }
     ]
   },
@@ -1308,27 +744,11 @@
     "officialSite": "http://utapri.tv/",
     "begin": "2016-10-01T16:00:00.000Z",
     "end": "2016-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "kGyvACa-e4U",
-        "begin": "2016-10-01T16:28:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "249bdf53795911e6b16e",
-        "begin": "2016-10-01T16:28:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T16:28:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1337,12 +757,7 @@
       {
         "site": "nicovideo",
         "id": "UTAPRI-LS",
-        "begin": "2016-10-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T03:00:00.000Z"
       }
     ]
   },
@@ -1361,47 +776,21 @@
     "officialSite": "http://www.classicaloid.net/",
     "begin": "2016-10-08T08:30:00.000Z",
     "end": "2017-03-25T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5521",
-        "begin": "2016-10-08T11:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T11:00:10.000Z"
       },
       {
         "site": "pptv",
         "id": "esexL5f9basOjPQ",
-        "begin": "2016-10-08T11:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "HPpoEDmHnbs",
-        "begin": "2016-10-10T08:51:58.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-08T11:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "67c8b987852711e6bdbb",
-        "begin": "2016-10-10T08:51:58.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-10T08:51:58.000Z"
       },
       {
         "site": "bangumi",
@@ -1421,47 +810,21 @@
     "officialSite": "http://www.matoi-anime.com/",
     "begin": "2016-10-04T14:00:00.000Z",
     "end": "2016-12-20T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5552",
-        "begin": "2016-10-04T15:30:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T15:30:10.000Z"
       },
       {
         "site": "pptv",
         "id": "yXhU0jqgEE6xL5c",
-        "begin": "2016-10-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "b0P0eRrr0NU",
-        "begin": "2016-10-08T09:15:09.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-04T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "658471587fa211e6bdbb",
-        "begin": "2016-10-08T09:15:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T09:15:09.000Z"
       },
       {
         "site": "bangumi",
@@ -1470,12 +833,7 @@
       {
         "site": "nicovideo",
         "id": "matoi-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1492,17 +850,11 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/tigermask_w/",
     "begin": "2016-10-01T17:45:00.000Z",
     "end": "2017-07-01T18:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9tmg1",
-        "begin": "2016-10-01T22:55:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T22:55:17.000Z"
       },
       {
         "site": "bangumi",
@@ -1511,12 +863,7 @@
       {
         "site": "nicovideo",
         "id": "tigermask_w",
-        "begin": "2016-10-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T15:00:00.000Z"
       }
     ]
   },
@@ -1532,27 +879,11 @@
     "officialSite": "http://g-tekketsu.com/",
     "begin": "2016-10-02T08:00:00.000Z",
     "end": "2017-04-02T08:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "0cpgYEhhh8Y",
-        "begin": "2016-10-02T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "2c1e303055f011e5a080",
-        "begin": "2016-10-02T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T08:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1560,13 +891,8 @@
       },
       {
         "site": "bilibili",
-        "id": "5535",
-        "begin": "2016-10-02T08:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "4310082",
+        "begin": "2016-10-02T08:00:00.000Z"
       }
     ]
   },
@@ -1585,17 +911,11 @@
     "officialSite": "http://www.dreamcreation.co.jp/bernard/",
     "begin": "2016-10-06T16:00:00.000Z",
     "end": "2016-12-22T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5537",
-        "begin": "2016-10-06T16:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T16:00:10.000Z"
       },
       {
         "site": "bangumi",
@@ -1604,12 +924,7 @@
       {
         "site": "nicovideo",
         "id": "bernard",
-        "begin": "2016-10-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T03:00:00.000Z"
       }
     ]
   },
@@ -1628,67 +943,26 @@
     "officialSite": "http://magicofstella.com/",
     "begin": "2016-10-03T13:30:00.000Z",
     "end": "2016-12-19T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5540",
-        "begin": "2016-10-03T14:30:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T14:30:09.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9tmut",
-        "begin": "2016-10-03T14:25:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T14:25:13.000Z"
       },
       {
         "site": "pptv",
         "id": "atfBP6cNfbsenAQ",
-        "begin": "2016-10-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "vlOZFOFN6bA",
-        "begin": "2016-10-03T14:28:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-03T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "be9804ad7fab11e6b16e",
-        "begin": "2016-10-03T14:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480028",
-        "begin": "2016-10-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T14:28:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1697,12 +971,7 @@
       {
         "site": "nicovideo",
         "id": "magicofstella",
-        "begin": "2016-10-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T15:30:00.000Z"
       }
     ]
   },
@@ -1718,27 +987,11 @@
     "officialSite": "http://www.j-haikyu.com/anime/",
     "begin": "2016-10-07T17:10:00.000Z",
     "end": "2016-12-09T17:40:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "fFOR7YTyu3s",
-        "begin": "2016-10-07T18:24:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "dfc93fc7852411e6bdbb",
-        "begin": "2016-10-07T18:24:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T18:24:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1747,12 +1000,7 @@
       {
         "site": "nicovideo",
         "id": "j-haikyu",
-        "begin": "2016-10-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T03:00:00.000Z"
       }
     ]
   },
@@ -1769,67 +1017,26 @@
     "officialSite": "http://syakunetsu.com/",
     "begin": "2016-10-03T16:35:00.000Z",
     "end": "2016-12-19T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480030",
-        "begin": "2016-10-03T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5539",
-        "begin": "2016-10-03T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9uell",
-        "begin": "2016-10-03T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "cKtRIe-oijg",
-        "begin": "2016-10-03T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-03T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "cfec86ce7f0011e6bdbb",
-        "begin": "2016-10-03T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10030001",
-        "begin": "2016-10-03T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-03T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1838,12 +1045,7 @@
       {
         "site": "nicovideo",
         "id": "syakunetsu",
-        "begin": "2016-10-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T03:00:00.000Z"
       }
     ]
   },
@@ -1859,47 +1061,16 @@
     "officialSite": "http://anime-longriders.com/",
     "begin": "2016-10-08T12:00:00.000Z",
     "end": "2017-02-05T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5518",
-        "begin": "2016-10-08T13:30:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ZGsjoPX7m08",
-        "begin": "2016-10-08T13:28:48.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-08T13:30:10.000Z"
       },
       {
         "site": "youku",
         "id": "b8b4ec3a852211e69e06",
-        "begin": "2016-10-08T13:28:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480037",
-        "begin": "2016-10-08T13:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T13:28:48.000Z"
       },
       {
         "site": "bangumi",
@@ -1908,12 +1079,7 @@
       {
         "site": "nicovideo",
         "id": "anime-longriders",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1929,67 +1095,26 @@
     "officialSite": "http://www.funewoamu.com/",
     "begin": "2016-10-13T16:35:00.000Z",
     "end": "2016-12-22T17:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480043",
-        "begin": "2016-10-13T16:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5516",
-        "begin": "2016-10-14T02:28:28.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-14T02:28:28.000Z"
       },
       {
         "site": "letv",
         "id": "10030442",
-        "begin": "2016-10-13T16:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-13T16:35:00.000Z"
       },
       {
         "site": "pptv",
         "id": "ADIenARq2hh7ibWE",
-        "begin": "2016-10-13T16:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "HzPUgml2E3c",
-        "begin": "2016-10-18T08:14:03.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-13T16:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "eabf144b795511e6b9bb",
-        "begin": "2016-10-18T08:14:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-18T08:14:03.000Z"
       },
       {
         "site": "bangumi",
@@ -2010,57 +1135,21 @@
     "officialSite": "http://www.udonnokuni-anime.jp/",
     "begin": "2016-10-08T17:15:00.000Z",
     "end": "2016-12-24T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5525",
-        "begin": "2016-10-08T19:30:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T19:30:10.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9urth",
-        "begin": "2016-10-08T19:00:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "6dbh9yNHRnk",
-        "begin": "2016-10-08T19:28:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-08T19:00:06.000Z"
       },
       {
         "site": "youku",
         "id": "11256a1f852b11e6bdbb",
-        "begin": "2016-10-08T19:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480040",
-        "begin": "2016-10-08T19:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T19:28:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2069,22 +1158,12 @@
       {
         "site": "nicovideo",
         "id": "udonnokuni-anime",
-        "begin": "2016-10-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T03:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "310552",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2101,67 +1180,31 @@
     "officialSite": "http://www.magic-kyun.jp/",
     "begin": "2016-10-02T13:30:00.000Z",
     "end": "2016-12-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5522",
-        "begin": "2016-10-02T14:30:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T14:30:09.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9utqt",
-        "begin": "2016-10-02T14:25:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T14:25:22.000Z"
       },
       {
         "site": "pptv",
         "id": "Mic7aWMAmltQ3tR0",
-        "begin": "2016-10-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T14:30:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "301761",
-        "begin": "2016-10-02T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "vvEQq3t1e1k",
-        "begin": "2016-10-08T08:49:30.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-02T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "c42519fa7eff11e6b32f",
-        "begin": "2016-10-08T08:49:30.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T08:49:30.000Z"
       },
       {
         "site": "bangumi",
@@ -2170,12 +1213,7 @@
       {
         "site": "nicovideo",
         "id": "magic-kyun",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2191,17 +1229,11 @@
     "officialSite": "http://nazotokine.com/",
     "begin": "2016-10-05T13:20:00.000Z",
     "end": "2016-12-21T13:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5557",
-        "begin": "2016-10-05T15:28:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T15:28:09.000Z"
       },
       {
         "site": "bangumi",
@@ -2210,12 +1242,7 @@
       {
         "site": "nicovideo",
         "id": "nazotokine-anime",
-        "begin": "2016-10-13T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-13T06:00:00.000Z"
       }
     ]
   },
@@ -2234,27 +1261,16 @@
     "officialSite": "http://idol-memories.com/",
     "begin": "2016-10-02T15:30:00.000Z",
     "end": "2016-12-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9z7p5",
-        "begin": "2017-01-05T07:05:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-05T07:05:37.000Z"
       },
       {
         "site": "bilibili",
         "id": "5486",
-        "begin": "2016-10-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2263,12 +1279,7 @@
       {
         "site": "nicovideo",
         "id": "idol-memories",
-        "begin": "2016-10-05T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T09:00:00.000Z"
       }
     ]
   },
@@ -2287,47 +1298,16 @@
     "officialSite": "http://www.ytv.co.jp/timebokan24/",
     "begin": "2016-10-01T08:30:00.000Z",
     "end": "2017-03-18T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5510",
-        "begin": "2016-10-01T11:00:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "X2zsEN8Vug4",
-        "begin": "2016-10-01T10:58:04.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-01T11:00:09.000Z"
       },
       {
         "site": "youku",
         "id": "6aa32c517a1b11e69e06",
-        "begin": "2016-10-01T10:58:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480022",
-        "begin": "2016-10-01T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-01T10:58:04.000Z"
       },
       {
         "site": "bangumi",
@@ -2347,57 +1327,26 @@
     "officialSite": "http://trickster-project.com/anime/",
     "begin": "2016-10-03T16:05:00.000Z",
     "end": "2017-03-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5542",
-        "begin": "2016-10-03T17:05:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T17:05:10.000Z"
       },
       {
         "site": "pptv",
         "id": "xHVf3UWrG1m8OqI",
-        "begin": "2016-10-03T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T17:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10030000",
-        "begin": "2016-10-03T17:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "REhmqwzQ93Q",
-        "begin": "2016-10-08T09:08:49.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-03T17:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "68d8d1147fb211e6b32f",
-        "begin": "2016-10-08T09:08:49.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T09:08:49.000Z"
       },
       {
         "site": "bangumi",
@@ -2406,12 +1355,7 @@
       {
         "site": "nicovideo",
         "id": "trickster-project",
-        "begin": "2016-10-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T03:00:00.000Z"
       }
     ]
   },
@@ -2431,17 +1375,11 @@
     "officialSite": "http://flipflappers.com/",
     "begin": "2016-10-06T12:00:00.000Z",
     "end": "2016-12-29T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9uqb5",
-        "begin": "2016-10-06T13:00:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T13:00:14.000Z"
       },
       {
         "site": "bangumi",
@@ -2450,12 +1388,7 @@
       {
         "site": "nicovideo",
         "id": "flipflappers",
-        "begin": "2016-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -2473,97 +1406,41 @@
     "officialSite": "http://chissweethome.com/",
     "begin": "2016-10-01T22:00:00.000Z",
     "end": "2017-09-24T22:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480023",
-        "begin": "2016-10-02T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5563",
-        "begin": "2016-10-02T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T04:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9uq9l",
-        "begin": "2016-10-02T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T04:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "Zc6qKJD2ZqQHhe0",
-        "begin": "2016-10-02T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T04:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "v/vmyhlcrhf8639bi",
-        "begin": "2016-10-02T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T04:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "301740",
-        "begin": "2016-10-02T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "KY5OaxL5PcU",
-        "begin": "2016-10-02T02:32:18.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-02T04:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "6b795ea97ee111e6bdbb",
-        "begin": "2016-10-02T02:32:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T02:32:18.000Z"
       },
       {
         "site": "letv",
         "id": "10029959",
-        "begin": "2016-10-02T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T04:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2572,12 +1449,7 @@
       {
         "site": "nicovideo",
         "id": "chissweethome",
-        "begin": "2018-09-24T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-09-24T15:00:00.000Z"
       }
     ]
   },
@@ -2596,57 +1468,16 @@
     "officialSite": "http://www.ajin.net/tv2nd/",
     "begin": "2016-10-07T17:40:00.000Z",
     "end": "2016-12-23T18:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5529",
-        "begin": "2016-10-07T17:40:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "bNfBP6cNfbsenAQ",
-        "begin": "2016-10-07T17:40:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "fxmPBk7stZ0",
-        "begin": "2016-10-10T03:02:54.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-07T17:40:00.000Z"
       },
       {
         "site": "youku",
         "id": "58827426852911e6b9bb",
-        "begin": "2016-10-10T03:02:54.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480046",
-        "begin": "2016-10-07T17:40:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-10T03:02:54.000Z"
       },
       {
         "site": "bangumi",
@@ -2655,12 +1486,7 @@
       {
         "site": "netflix",
         "id": "80043576",
-        "begin": "2016-04-12T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-12T07:00:00.000Z"
       }
     ]
   },
@@ -2679,17 +1505,11 @@
     "officialSite": "http://nanbaka.tv/",
     "begin": "2016-10-04T18:00:00.000Z",
     "end": "2016-12-27T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5548",
-        "begin": "2016-10-04T19:30:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T19:30:10.000Z"
       },
       {
         "site": "bangumi",
@@ -2698,12 +1518,7 @@
       {
         "site": "nicovideo",
         "id": "nanbaka",
-        "begin": "2016-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -2722,17 +1537,11 @@
     "officialSite": "http://keijollllllll.com/",
     "begin": "2016-10-06T14:30:00.000Z",
     "end": "2016-12-22T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ibUgkogpw4B6Bic2c",
-        "begin": "2016-10-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2752,17 +1561,11 @@
     "officialSite": "http://kiitarou.jp/",
     "begin": "2016-10-05T13:33:00.000Z",
     "end": "2016-12-21T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5556",
-        "begin": "2016-10-05T13:33:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T13:33:09.000Z"
       },
       {
         "site": "bangumi",
@@ -2771,12 +1574,7 @@
       {
         "site": "nicovideo",
         "id": "kiitarou",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2795,47 +1593,16 @@
     "officialSite": "http://www.mh-stories-rideon.jp/",
     "begin": "2016-10-01T23:30:00.000Z",
     "end": "2018-04-01T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10034731",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5519",
-        "begin": "2016-10-11T02:24:09.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "TFkJtLzDWcY",
-        "begin": "2016-10-08T08:47:24.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "800f827f7ef211e69c81",
-        "begin": "2016-10-08T08:47:24.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-08T08:47:24.000Z"
       },
       {
         "site": "bangumi",
@@ -2844,12 +1611,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh92rat",
-        "begin": "2018-10-18T16:00:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-18T16:00:12.000Z"
       }
     ]
   },
@@ -2861,7 +1623,6 @@
     "officialSite": "http://www.sanrio.co.jp/character/pepepepengiin/",
     "begin": "2016-10-02T14:18:00.000Z",
     "end": "2016-12-25T14:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2881,27 +1642,16 @@
     "officialSite": "http://www.garasunokamen3d.com/",
     "begin": "2016-10-03T12:55:00.000Z",
     "end": "2016-12-26T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5546",
-        "begin": "2016-11-14T03:00:08.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-14T03:00:08.000Z"
       },
       {
         "site": "pptv",
         "id": "hLCcGoLoWJb5d98",
-        "begin": "2016-10-03T12:55:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T12:55:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2910,12 +1660,7 @@
       {
         "site": "nicovideo",
         "id": "garasunokamen3d",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2935,17 +1680,11 @@
     "officialSite": "http://penet.co.jp/animehandsome/",
     "begin": "2016-10-03T16:00:00.000Z",
     "end": "2016-12-19T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5543",
-        "begin": "2016-10-03T13:30:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T13:30:09.000Z"
       },
       {
         "site": "bangumi",
@@ -2954,12 +1693,7 @@
       {
         "site": "nicovideo",
         "id": "gakuenhandsome",
-        "begin": "2016-10-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T03:00:00.000Z"
       }
     ]
   },
@@ -2975,67 +1709,26 @@
     "officialSite": "http://aooni-anime.com/tv/",
     "begin": "2016-10-02T18:05:00.000Z",
     "end": "2017-01-08T18:10:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480027",
-        "begin": "2016-10-02T19:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5538",
-        "begin": "2016-10-02T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T19:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9uh6p",
-        "begin": "2016-10-02T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "-seb9EUMdrs",
-        "begin": "2016-10-02T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-02T19:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "2ca6916c795511e6b32f",
-        "begin": "2016-10-02T19:05:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T19:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10029971",
-        "begin": "2016-10-02T19:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-02T19:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3055,57 +1748,26 @@
     "officialSite": "http://s.mxtv.jp/joker/",
     "begin": "2016-10-03T10:00:00.000Z",
     "end": "2016-12-26T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5545",
-        "begin": "2016-10-03T11:00:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T11:00:09.000Z"
       },
       {
         "site": "pptv",
         "id": "gLOdG4PpWZf6eOA",
-        "begin": "2016-10-03T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ho_Iluro9WQ",
-        "begin": "2016-10-03T10:58:32.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-03T11:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "2be7370c7fad11e69e06",
-        "begin": "2016-10-03T10:58:32.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T10:58:32.000Z"
       },
       {
         "site": "letv",
         "id": "10029986",
-        "begin": "2016-10-03T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T11:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3114,12 +1776,7 @@
       {
         "site": "qq",
         "id": "z/zggrxgnh8mh65q9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3135,18 +1792,7 @@
     "officialSite": "http://www.shogakukan.co.jp/pr/12sai/",
     "begin": "2016-10-03T10:30:00.000Z",
     "end": "2016-12-19T11:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5544",
-        "begin": "2016-10-03T10:30:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "184745"
@@ -3168,57 +1814,21 @@
     "officialSite": "http://soulbuster.jp/",
     "begin": "2016-10-04T09:30:00.000Z",
     "end": "2016-12-20T09:50:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "IBNFz-7b2l0",
-        "begin": "2016-10-04T09:28:47.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "457c1f335aab11e6b9bb",
-        "begin": "2016-10-04T09:28:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T09:28:47.000Z"
       },
       {
         "site": "qq",
         "id": "f/f4ut0w129tgamor",
-        "begin": "2016-10-04T09:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480031",
-        "begin": "2016-10-04T09:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T09:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10030282",
-        "begin": "2016-10-04T09:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T09:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3227,12 +1837,7 @@
       {
         "site": "nicovideo",
         "id": "soulbuster",
-        "begin": "2016-10-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T03:00:00.000Z"
       }
     ]
   },
@@ -3251,17 +1856,11 @@
     "officialSite": "http://cranegale.com/",
     "begin": "2016-10-05T13:00:00.000Z",
     "end": "2016-12-21T13:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5555",
-        "begin": "2016-10-05T15:15:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T15:15:09.000Z"
       },
       {
         "site": "bangumi",
@@ -3270,12 +1869,7 @@
       {
         "site": "nicovideo",
         "id": "cranegale-Galaxy",
-        "begin": "2016-10-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-07T15:00:00.000Z"
       }
     ]
   },
@@ -3291,17 +1885,11 @@
     "officialSite": "http://rainycocoa.jp/anime/",
     "begin": "2016-10-02T13:25:00.000Z",
     "end": "2016-12-18T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5564",
-        "begin": "2016-10-02T15:30:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-02T15:30:09.000Z"
       },
       {
         "site": "bangumi",
@@ -3310,12 +1898,7 @@
       {
         "site": "nicovideo",
         "id": "rainycocoa-Hawaii",
-        "begin": "2016-10-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T15:00:00.000Z"
       }
     ]
   },
@@ -3332,27 +1915,11 @@
     "officialSite": "http://yurionice.com/",
     "begin": "2016-10-05T17:21:00.000Z",
     "end": "2016-12-21T18:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "tudou",
-        "id": "6hZtWoVnYhw",
-        "begin": "2016-10-05T18:49:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "6b45aa39814e11e6b16e",
-        "begin": "2016-10-05T18:49:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T18:49:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3361,12 +1928,7 @@
       {
         "site": "nicovideo",
         "id": "yurionice",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3383,57 +1945,21 @@
     "officialSite": "http://anime-training.com/",
     "begin": "2016-10-05T13:43:00.000Z",
     "end": "2016-12-21T13:50:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480034",
-        "begin": "2016-10-05T13:55:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5558",
-        "begin": "2016-10-05T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "VRhFLSGyZfY",
-        "begin": "2016-10-05T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-05T13:55:00.000Z"
       },
       {
         "site": "youku",
         "id": "599329d9815011e6bdbb",
-        "begin": "2016-10-05T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T13:55:00.000Z"
       },
       {
         "site": "pptv",
         "id": "l6CMCnLYSIbpZ88",
-        "begin": "2016-10-05T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T13:55:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3442,12 +1968,7 @@
       {
         "site": "nicovideo",
         "id": "anitraixx",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3463,17 +1984,11 @@
     "officialSite": "http://allout-anime.com/index.html",
     "begin": "2016-10-06T15:00:00.000Z",
     "end": "2017-03-30T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IxXicfeVLuiclc2kI",
-        "begin": "2016-10-06T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3482,12 +1997,7 @@
       {
         "site": "nicovideo",
         "id": "allout-anime",
-        "begin": "2016-10-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T15:00:00.000Z"
       }
     ]
   },
@@ -3503,17 +2013,11 @@
     "officialSite": "http://www.kbc.co.jp/scg/",
     "begin": "2016-10-08T16:42:00.000Z",
     "end": "2016-12-31T16:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5527",
-        "begin": "2016-10-08T16:42:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-08T16:42:10.000Z"
       },
       {
         "site": "bangumi",
@@ -3522,12 +2026,7 @@
       {
         "site": "nicovideo",
         "id": "scg",
-        "begin": "2016-10-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T15:00:00.000Z"
       }
     ]
   },
@@ -3543,27 +2042,11 @@
     "officialSite": "https://www.animax.co.jp/luger-code",
     "begin": "2016-10-22T11:00:00.000Z",
     "end": "2016-10-22T11:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5704",
-        "begin": "2016-11-14T02:51:44.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "EiaIOjPRayghr6VE",
-        "begin": "2016-10-22T11:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-22T11:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3586,7 +2069,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cf-vanguard-g2/",
     "begin": "2016-10-02T01:00:00.000Z",
     "end": "2016-10-01T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3595,12 +2077,7 @@
       {
         "site": "nicovideo",
         "id": "cf-vanguard-NEXT",
-        "begin": "2016-10-04T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T12:00:00.000Z"
       }
     ]
   },
@@ -3619,17 +2096,11 @@
     "officialSite": "http://bungo-stray-dogs.jp/",
     "begin": "2016-10-05T16:05:00.000Z",
     "end": "2016-12-16T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ZMibpJ4ic1ZaMGhOw",
-        "begin": "2016-10-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3652,37 +2123,16 @@
     "officialSite": "http://www.hagane-orchestra.jp/index.html",
     "begin": "2016-10-09T16:00:00.000Z",
     "end": "2016-12-25T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5517",
-        "begin": "2016-10-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480041",
-        "begin": "2016-10-09T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "Lxj0ctpAsO5Rzzc",
-        "begin": "2016-10-09T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3691,12 +2141,7 @@
       {
         "site": "nicovideo",
         "id": "hagane-orchestra",
-        "begin": "2016-10-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T16:00:00.000Z"
       }
     ]
   },
@@ -3708,7 +2153,6 @@
     "officialSite": "http://anime-dayan.com/",
     "begin": "2016-10-06T16:49:00.000Z",
     "end": "2017-05-04T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3717,22 +2161,12 @@
       {
         "site": "nicovideo",
         "id": "anime-dayan",
-        "begin": "2017-01-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh5nc6d",
-        "begin": "2018-08-24T09:59:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-24T09:59:48.000Z"
       }
     ]
   },
@@ -3751,37 +2185,21 @@
     "officialSite": "http://cheating-craft.com/",
     "begin": "2016-10-05T09:30:00.000Z",
     "end": "2016-12-20T09:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5595",
-        "begin": "2016-10-06T03:46:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T03:46:28.000Z"
       },
       {
         "site": "pptv",
         "id": "tH9Z1ziblFVO2NJw",
-        "begin": "2016-10-04T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T02:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10030284",
-        "begin": "2016-10-04T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3790,12 +2208,7 @@
       {
         "site": "nicovideo",
         "id": "cheating-craft",
-        "begin": "2016-10-05T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T12:00:00.000Z"
       }
     ]
   },
@@ -3814,7 +2227,6 @@
     "officialSite": "http://cheating-craft.com/",
     "begin": "2016-10-05T09:30:00.000Z",
     "end": "2016-12-20T09:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3823,32 +2235,17 @@
       {
         "site": "bilibili",
         "id": "5570",
-        "begin": "2016-10-06T03:46:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T03:46:28.000Z"
       },
       {
         "site": "pptv",
         "id": "CTsVkicth0Q9y8Fg",
-        "begin": "2016-10-04T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T02:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10029690",
-        "begin": "2016-10-04T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T16:00:00.000Z"
       }
     ]
   },
@@ -3867,57 +2264,26 @@
     "officialSite": "http://tobe-hero.com/",
     "begin": "2016-10-05T09:45:00.000Z",
     "end": "2016-12-20T10:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5430",
-        "begin": "2016-10-06T02:37:49.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-06T02:37:49.000Z"
       },
       {
         "site": "pptv",
         "id": "QvXfXcUrm9k8uiaI",
-        "begin": "2016-10-04T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T02:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10029854",
-        "begin": "2016-10-04T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "DRxvEI3bvSI",
-        "begin": "2016-10-10T06:06:36.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-04T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "7918ab4b845411e69c81",
-        "begin": "2016-10-10T06:06:36.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-10T06:06:36.000Z"
       },
       {
         "site": "bangumi",
@@ -3926,12 +2292,7 @@
       {
         "site": "nicovideo",
         "id": "tobe-hero",
-        "begin": "2016-10-05T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-05T12:00:00.000Z"
       }
     ]
   },
@@ -3952,47 +2313,16 @@
     "officialSite": "http://www.youtube.com/watch?v=cfcqewZdBiU",
     "begin": "2016-10-09T23:00:00.000Z",
     "end": "2016-12-26T23:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rplz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5597",
-        "begin": "2016-10-17T02:23:24.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480042",
-        "begin": "2016-10-09T23:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10030257",
-        "begin": "2016-10-09T23:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T23:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -4001,12 +2331,7 @@
       {
         "site": "nicovideo",
         "id": "PBM",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4025,17 +2350,11 @@
     "officialSite": "http://vcard.ameba.jp/pub/campaign/campaign-2016-1/top",
     "begin": "2016-10-22T13:00:00.000Z",
     "end": "2016-11-05T13:11:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "FSELiafFXxwVo5k4",
-        "begin": "2016-10-22T13:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-22T13:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -4056,67 +2375,26 @@
     "officialSite": "http://nobunaga-no-shinobi.com/",
     "begin": "2016-10-04T12:55:00.000Z",
     "end": "2017-03-28T13:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480032",
-        "begin": "2016-10-04T13:55:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bilibili",
         "id": "5549",
-        "begin": "2016-10-04T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T13:55:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9ueih",
-        "begin": "2016-10-04T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "HdPGQHDBn2o",
-        "begin": "2016-10-04T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-04T13:55:00.000Z"
       },
       {
         "site": "youku",
         "id": "143b4e077fa111e69e06",
-        "begin": "2016-10-04T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-04T13:55:00.000Z"
       },
       {
         "site": "letv",
         "id": "10030036",
-        "begin": "2016-10-04T13:55:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-10-04T13:55:00.000Z"
       },
       {
         "site": "bangumi",
@@ -4125,12 +2403,7 @@
       {
         "site": "nicovideo",
         "id": "nobunaga-no-shinobi",
-        "begin": "2016-09-20T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-20T06:00:00.000Z"
       }
     ]
   },
@@ -4148,67 +2421,36 @@
     "officialSite": "http://bloodivores.com/",
     "begin": "2016-10-01T12:00:00.000Z",
     "end": "2016-12-16T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5599",
-        "begin": "2016-09-30T02:59:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-30T02:59:09.000Z"
       },
       {
         "site": "pptv",
         "id": "pY5q6FC2JmTHRa0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/ugr1y9sr4qi4uea",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9stix",
-        "begin": "2016-10-09T03:11:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T03:11:52.000Z"
       },
       {
         "site": "letv",
         "id": "10030106",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "302531",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4217,12 +2459,7 @@
       {
         "site": "nicovideo",
         "id": "bloodivores",
-        "begin": "2016-10-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T03:00:00.000Z"
       }
     ]
   },
@@ -4238,7 +2475,6 @@
     "officialSite": "http://bloodivores.com/",
     "begin": "2016-10-01T12:00:00.000Z",
     "end": "2016-12-16T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4247,62 +2483,32 @@
       {
         "site": "bilibili",
         "id": "5572",
-        "begin": "2016-09-30T02:59:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-09-30T02:59:09.000Z"
       },
       {
         "site": "pptv",
         "id": "db6aGIDmVpT3dd0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "g/g45oolfndk1iuh5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9utkd",
-        "begin": "2016-10-09T03:11:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-09T03:11:52.000Z"
       },
       {
         "site": "letv",
         "id": "10029682",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "301173",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4318,67 +2524,36 @@
     "officialSite": "http://ac.qq.com/event/5d5765b14b3ed2600efc5a6f59db7600.html",
     "begin": "2016-10-01T12:00:00.000Z",
     "end": "2017-03-08T12:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5602",
-        "begin": "2016-10-19T02:27:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-19T02:27:28.000Z"
       },
       {
         "site": "pptv",
         "id": "ha6KCHDWRoTnZc0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "p/p3jz7rr8fqpy1lk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9sj8d",
-        "begin": "2016-10-19T02:00:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-19T02:00:11.000Z"
       },
       {
         "site": "letv",
         "id": "10029891",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "mgtv",
         "id": "301580",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4394,17 +2569,11 @@
     "officialSite": "http://ac.qq.com/event/jlcx2016/index.html",
     "begin": "2016-10-11T12:00:00.000Z",
     "end": "2017-01-03T12:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "d/d4vm770mtld2jr5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4425,37 +2594,21 @@
     "officialSite": "http://movie.kurobas.com/",
     "begin": "2016-10-08T16:00:00.000Z",
     "end": "2016-10-08T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "vIhk4kqwIF7BP6c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9ar91",
-        "begin": "2017-02-28T16:00:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-28T16:00:59.000Z"
       },
       {
         "site": "letv",
         "id": "10035150",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4475,17 +2628,11 @@
     "officialSite": "http://www.precure-movie.com/",
     "begin": "2016-10-29T16:00:00.000Z",
     "end": "2016-10-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       },
       {
         "site": "bangumi",
@@ -4505,17 +2652,11 @@
     "officialSite": "http://higanjimax.com/",
     "begin": "2016-10-15T16:00:00.000Z",
     "end": "2017-03-25T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "j7WfHYXrW5n8euI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4524,22 +2665,12 @@
       {
         "site": "nicovideo",
         "id": "tetra",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5596",
-        "begin": "2016-10-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-14T16:00:01.000Z"
       }
     ]
   },
@@ -4555,17 +2686,11 @@
     "officialSite": "http://zaregoto-series.com/",
     "begin": "2016-10-26T16:00:00.000Z",
     "end": "2017-07-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Khr2dNxCsvBT0Tk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4574,12 +2699,7 @@
       {
         "site": "bilibili",
         "id": "5621",
-        "begin": "2016-10-25T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-25T16:00:01.000Z"
       }
     ]
   },
@@ -4595,17 +2715,11 @@
     "officialSite": "http://www.patlabor-reboot.jp/",
     "begin": "2016-10-15T16:00:00.000Z",
     "end": "2016-10-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "hbGbGYHnV5X4dt4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -4621,7 +2735,6 @@
     "officialSite": "http://gj8man.com/",
     "begin": "2016-10-08T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4630,12 +2743,7 @@
       {
         "site": "nicovideo",
         "id": "gj8man",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -4651,7 +2759,6 @@
     "officialSite": "http://gantzo.jp/",
     "begin": "2016-10-14T16:00:00.000Z",
     "end": "2016-10-14T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4660,22 +2767,12 @@
       {
         "site": "nicovideo",
         "id": "gantzo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80149259",
-        "begin": "2017-02-18T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-18T08:00:00.000Z"
       }
     ]
   },
@@ -4691,7 +2788,6 @@
     "officialSite": "http://www.zegapain.net/",
     "begin": "2016-10-15T16:00:00.000Z",
     "end": "2016-10-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -4700,22 +2796,12 @@
       {
         "site": "pptv",
         "id": "61E7uSGH9zWYFn4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5926",
-        "begin": "2016-10-14T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-14T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2016/11.json
+++ b/data/items/2016/11.json
@@ -11,17 +11,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/pokemon_sunmoon/",
     "begin": "2016-11-17T10:55:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10032274",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -30,42 +24,22 @@
       {
         "site": "mgtv",
         "id": "321993",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2018/jlbkmtyyl",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "8/8rbtcil5a2heb7d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgzmpot",
-        "begin": "2018-04-30T16:01:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-30T16:01:59.000Z"
       }
     ]
   },
@@ -82,17 +56,11 @@
     "officialSite": "http://kamigaminoki.com/",
     "begin": "2016-11-24T16:25:00.000Z",
     "end": "2017-04-27T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "dculI4vxYZ8CgOg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -101,22 +69,12 @@
       {
         "site": "nicovideo",
         "id": "kamigaminoki",
-        "begin": "2017-01-13T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-13T09:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5909",
-        "begin": "2016-11-23T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-11-23T16:00:01.000Z"
       }
     ]
   },
@@ -132,17 +90,11 @@
     "officialSite": "",
     "begin": "2016-11-11T16:00:00.000Z",
     "end": "2016-12-21T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "4FZCwCiaOicjyfHYU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -162,17 +114,11 @@
     "officialSite": "",
     "begin": "2016-11-25T16:00:00.000Z",
     "end": "2016-04-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "NgzoZs40pOJFwys",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -192,7 +138,6 @@
     "officialSite": "http://www.kinmosa.com/",
     "begin": "2016-11-12T16:00:00.000Z",
     "end": "2016-11-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -201,22 +146,12 @@
       {
         "site": "pptv",
         "id": "t4Fr6VG3J2XIRq4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "6205",
-        "begin": "2016-11-11T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8692",
+        "begin": "2016-11-11T16:00:01.000Z"
       }
     ]
   },
@@ -235,7 +170,6 @@
     "officialSite": "http://www.cyborg009.jp",
     "begin": "2016-11-23T16:00:00.000Z",
     "end": "2016-11-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -245,10 +179,6 @@
         "site": "netflix",
         "id": "80057749",
         "begin": "2017-02-10T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
         "comment": "原始版本为剧场版但是 Netflix 目前将其做成 14 集 TV 分割形式放送"
       }
     ]
@@ -268,7 +198,6 @@
     "officialSite": "http://www.konosekai.jp/",
     "begin": "2016-11-11T16:00:00.000Z",
     "end": "2016-11-12T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -277,12 +206,7 @@
       {
         "site": "netflix",
         "id": "80192244",
-        "begin": "2018-03-15T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-15T07:00:00.000Z"
       }
     ]
   }

--- a/data/items/2016/12.json
+++ b/data/items/2016/12.json
@@ -11,18 +11,7 @@
     "officialSite": "http://www.koroq-anime.com/",
     "begin": "2016-12-22T16:40:00.000Z",
     "end": "2017-03-09T16:50:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5830",
-        "begin": "2016-12-22T16:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "186072"
@@ -44,17 +33,11 @@
     "officialSite": "http://anime.fate-go.jp/",
     "begin": "2016-12-31T15:00:00.000Z",
     "end": "2016-12-31T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5747",
-        "begin": "2016-12-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-31T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -74,17 +57,11 @@
     "officialSite": "",
     "begin": "2016-12-25T16:00:00.000Z",
     "end": "2016-12-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10033860",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -93,12 +70,7 @@
       {
         "site": "bilibili",
         "id": "5833",
-        "begin": "2016-12-24T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-24T16:00:01.000Z"
       }
     ]
   },
@@ -115,37 +87,21 @@
     "officialSite": "http://movie.kurobas.com/",
     "begin": "2016-12-03T16:00:00.000Z",
     "end": "2016-12-03T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "rZN9ib2PJOXfaWMA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9ar69",
-        "begin": "2017-02-28T16:00:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-28T16:00:59.000Z"
       },
       {
         "site": "letv",
         "id": "10035150",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -165,27 +121,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/osomatsusan/oumatsusan/",
     "begin": "2016-12-12T16:00:00.000Z",
     "end": "2016-12-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rr9ym5rg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10033176",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -194,12 +139,7 @@
       {
         "site": "bilibili",
         "id": "5763",
-        "begin": "2016-12-13T06:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-13T06:30:00.000Z"
       }
     ]
   },
@@ -215,27 +155,16 @@
     "officialSite": "http://mikagesha.com/",
     "begin": "2016-12-20T16:00:00.000Z",
     "end": "2016-12-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "WibrGRKwSgsAjoQk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10033637",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -244,12 +173,7 @@
       {
         "site": "bilibili",
         "id": "5882",
-        "begin": "2016-12-19T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-19T16:00:01.000Z"
       }
     ]
   },
@@ -266,27 +190,16 @@
     "officialSite": "http://chronicle-anime.com/",
     "begin": "2016-12-03T16:00:00.000Z",
     "end": "2016-12-03T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IhQAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha8tqp",
-        "begin": "2016-12-16T08:55:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-16T08:55:22.000Z"
       },
       {
         "site": "bangumi",
@@ -295,12 +208,7 @@
       {
         "site": "bilibili",
         "id": "5769",
-        "begin": "2016-12-15T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-15T16:00:01.000Z"
       }
     ]
   },
@@ -316,17 +224,11 @@
     "officialSite": "http://www.popin-q.com/",
     "begin": "2016-12-23T16:00:00.000Z",
     "end": "2016-12-23T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9cn1h",
-        "begin": "2017-03-12T08:07:44.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-12T08:07:44.000Z"
       },
       {
         "site": "bangumi",
@@ -335,12 +237,7 @@
       {
         "site": "nicovideo",
         "id": "popin-q",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -356,7 +253,6 @@
     "officialSite": "http://www.ytv.co.jp/conan/episodeone/",
     "begin": "2016-12-09T16:00:00.000Z",
     "end": "2016-12-09T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -376,17 +272,11 @@
     "officialSite": "https://shingekinobahamut-virginsoul.jp",
     "begin": "2016-12-28T16:00:00.000Z",
     "end": "2017-02-20T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "Ixj0ctpAsO5Rzzc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -406,17 +296,11 @@
     "officialSite": "http://danmachi.com/danmachi/",
     "begin": "2016-12-07T16:00:00.000Z",
     "end": "2016-12-07T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "DTgUkvpg0A5x71c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -436,7 +320,6 @@
     "officialSite": "http://www.inazma-delivery.com",
     "begin": "2016-12-09T16:00:00.000Z",
     "end": "2017-02-10T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -445,22 +328,12 @@
       {
         "site": "nicovideo",
         "id": "inazma-delivery-new",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcbahx",
-        "begin": "2017-09-30T11:00:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-30T11:00:05.000Z"
       }
     ]
   },
@@ -476,7 +349,6 @@
     "officialSite": "http://www.honeyworks-movie.jp/",
     "begin": "2016-12-17T16:00:00.000Z",
     "end": "2016-12-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -485,22 +357,12 @@
       {
         "site": "nicovideo",
         "id": "sukininarusonoshunkanwo",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5576",
-        "begin": "2016-12-16T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-16T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2017/01.json
+++ b/data/items/2017/01.json
@@ -11,17 +11,11 @@
     "officialSite": "http://masamune-tv.com/",
     "begin": "2017-01-05T13:30:00.000Z",
     "end": "2017-03-23T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9244p",
-        "begin": "2017-01-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-05T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "nicovideo",
         "id": "masamune-tv",
-        "begin": "2017-01-12T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T13:30:00.000Z"
       }
     ]
   },
@@ -54,57 +43,31 @@
     "officialSite": "http://gabdro.com/",
     "begin": "2017-01-09T13:30:00.000Z",
     "end": "2017-03-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5793",
-        "begin": "2017-01-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh91prt",
-        "begin": "2017-01-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T15:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "ZcibpJ4ic1ZaMGhOw",
-        "begin": "2017-01-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T15:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "310215",
-        "begin": "2017-01-09T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T15:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2018/dhpjblddl",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -113,32 +76,17 @@
       {
         "site": "nicovideo",
         "id": "gabdro",
-        "begin": "2017-01-15T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-15T15:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "r/rb48zfttktfr7sq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "ec93eb2ec1b511e6acec",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -154,18 +102,7 @@
     "officialSite": "http://akibastrip-anime.com/",
     "begin": "2017-01-04T13:30:00.000Z",
     "end": "2017-03-29T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5773",
-        "begin": "2017-01-04T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "192794"
@@ -173,12 +110,7 @@
       {
         "site": "nicovideo",
         "id": "akibastrip",
-        "begin": "2017-01-06T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T15:30:00.000Z"
       }
     ]
   },
@@ -194,17 +126,11 @@
     "officialSite": "http://demichan.com/",
     "begin": "2017-01-07T15:00:00.000Z",
     "end": "2017-03-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "MAXvbdU7qiblMyjI",
-        "begin": "2017-01-07T16:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-07T16:25:00.000Z"
       },
       {
         "site": "bangumi",
@@ -213,12 +139,7 @@
       {
         "site": "nicovideo",
         "id": "demichan",
-        "begin": "2017-04-28T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-28T03:00:00.000Z"
       }
     ]
   },
@@ -235,17 +156,11 @@
     "officialSite": "http://sgs-anime.com/",
     "begin": "2017-01-06T15:30:00.000Z",
     "end": "2017-03-31T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5777",
-        "begin": "2017-01-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -266,57 +181,26 @@
     "officialSite": "http://yowapeda.com/",
     "begin": "2017-01-09T16:35:00.000Z",
     "end": "2017-06-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5794",
-        "begin": "2017-01-09T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh91phx",
-        "begin": "2017-01-09T17:35:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T17:35:06.000Z"
       },
       {
         "site": "youku",
         "id": "3c079984ce3211e6acec",
-        "begin": "2017-01-09T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "1HuCDX4gPVo",
-        "begin": "2017-01-09T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-09T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10034072",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -325,12 +209,7 @@
       {
         "site": "nicovideo",
         "id": "yowapeda_ng",
-        "begin": "2017-01-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T03:00:00.000Z"
       }
     ]
   },
@@ -346,27 +225,11 @@
     "officialSite": "http://konosuba.com/",
     "begin": "2017-01-11T16:05:00.000Z",
     "end": "2017-03-15T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "f54815ffbf5811e6b16e",
-        "begin": "2017-01-11T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "wnO-obHBRcc",
-        "begin": "2017-01-11T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-11T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -375,12 +238,7 @@
       {
         "site": "nicovideo",
         "id": "konosuba2",
-        "begin": "2017-01-18T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-18T16:00:00.000Z"
       }
     ]
   },
@@ -400,17 +258,11 @@
     "officialSite": "http://onihei-anime.com/",
     "begin": "2017-01-09T17:05:00.000Z",
     "end": "2017-04-03T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5792",
-        "begin": "2017-01-09T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -430,57 +282,26 @@
     "officialSite": "http://bang-dream.com/",
     "begin": "2017-01-21T13:00:00.000Z",
     "end": "2017-04-22T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "pJVicicWXLO3ncWsI",
-        "begin": "2017-01-21T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-21T14:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5807",
-        "begin": "2017-01-21T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-21T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh91lud",
-        "begin": "2017-01-21T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-21T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "8f5275e0bebe11e68ce4",
-        "begin": "2017-01-21T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "iF5hJPJ2Wq8",
-        "begin": "2017-01-21T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-21T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -501,57 +322,21 @@
     "officialSite": "http://www.dreamcreation.co.jp/aimaimi3/",
     "begin": "2017-01-03T14:30:00.000Z",
     "end": "2017-03-21T14:35:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480081",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "f11596abc8be11e6967c",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "fhd9YWegYmU",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "hbCcGoLoWJb5d98",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10033962",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -560,22 +345,12 @@
       {
         "site": "nicovideo",
         "id": "aimaimi3",
-        "begin": "2017-01-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-03T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5868",
-        "begin": "2017-01-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-02T16:00:01.000Z"
       }
     ]
   },
@@ -592,17 +367,11 @@
     "officialSite": "http://maidragon.jp/",
     "begin": "2017-01-11T15:00:00.000Z",
     "end": "2017-04-05T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5800",
-        "begin": "2017-01-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-11T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -611,12 +380,7 @@
       {
         "site": "nicovideo",
         "id": "maidragon",
-        "begin": "2017-01-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-14T03:00:00.000Z"
       }
     ]
   },
@@ -632,17 +396,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/urara/",
     "begin": "2017-01-05T17:13:00.000Z",
     "end": "2017-03-23T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5776",
-        "begin": "2017-01-06T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T04:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -651,12 +409,7 @@
       {
         "site": "nicovideo",
         "id": "urara-anime",
-        "begin": "2017-01-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T03:00:00.000Z"
       }
     ]
   },
@@ -672,57 +425,21 @@
     "officialSite": "http://shonentanteidan-neo.com/",
     "begin": "2017-01-02T12:55:00.000Z",
     "end": "2017-03-27T13:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480079",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "d1aa3e01c28111e68ce4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "gHiLXU1gZJ4",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "ecyoJo70ZKIFgibs",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10033856",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -731,12 +448,7 @@
       {
         "site": "nicovideo",
         "id": "tanteidanneo",
-        "begin": "2017-01-02T12:55:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-02T12:55:00.000Z"
       }
     ]
   },
@@ -755,47 +467,21 @@
     "officialSite": "http://tv.littlewitchacademia.jp/",
     "begin": "2017-01-08T15:00:00.000Z",
     "end": "2017-06-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5788",
-        "begin": "2017-01-09T09:57:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480082",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T09:57:25.000Z"
       },
       {
         "site": "pptv",
         "id": "XufRT7cdjcsurBQ",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10034045",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -804,12 +490,7 @@
       {
         "site": "netflix",
         "id": "80156387",
-        "begin": "2017-06-30T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T07:00:00.000Z"
       }
     ]
   },
@@ -825,57 +506,21 @@
     "officialSite": "http://www.tbs.co.jp/anime/seiren/",
     "begin": "2017-01-05T17:43:00.000Z",
     "end": "2017-03-23T18:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5774",
-        "begin": "2017-01-06T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrh9241x",
-        "begin": "2017-01-06T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T04:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "fbb56e7dc26f11e6acec",
-        "begin": "2017-01-06T04:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "VBWSjFhpPZw",
-        "begin": "2017-01-06T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-06T04:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "fciakIorwYJ4Bfibc",
-        "begin": "2017-01-06T04:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T04:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -884,12 +529,7 @@
       {
         "site": "nicovideo",
         "id": "seiren_anime",
-        "begin": "2017-01-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T03:00:00.000Z"
       }
     ]
   },
@@ -905,27 +545,11 @@
     "officialSite": "http://youjo-senki.jp/",
     "begin": "2017-01-06T13:00:00.000Z",
     "end": "2017-03-31T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "f13b345dc27e11e68fae",
-        "begin": "2017-01-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "vcjkymWV2CQ",
-        "begin": "2017-01-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-06T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -934,12 +558,7 @@
       {
         "site": "nicovideo",
         "id": "youjo-senki",
-        "begin": "2017-01-19T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-19T15:00:00.000Z"
       }
     ]
   },
@@ -955,37 +574,16 @@
     "officialSite": "http://fuuka.tv/",
     "begin": "2017-01-06T13:00:00.000Z",
     "end": "2017-03-24T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5778",
-        "begin": "2017-01-06T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrh91wud",
-        "begin": "2017-01-06T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T14:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10033991",
-        "begin": "2017-01-06T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-06T14:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1008,17 +606,11 @@
     "officialSite": "http://minakama-anime.jp/index.html",
     "begin": "2017-01-06T15:00:00.000Z",
     "end": "2017-03-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh91pnh",
-        "begin": "2017-01-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1027,12 +619,7 @@
       {
         "site": "nicovideo",
         "id": "minakama-anime",
-        "begin": "2017-01-20T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-20T03:00:00.000Z"
       }
     ]
   },
@@ -1048,17 +635,11 @@
     "officialSite": "http://www.ao-ex.com/",
     "begin": "2017-01-06T17:10:00.000Z",
     "end": "2017-03-24T17:42:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ppN9ib2PJOXfaWMA",
-        "begin": "2017-01-06T18:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T18:25:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1067,12 +648,7 @@
       {
         "site": "nicovideo",
         "id": "ao-ex02",
-        "begin": "2017-04-28T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-28T03:00:00.000Z"
       }
     ]
   },
@@ -1089,27 +665,11 @@
     "officialSite": "http://rakugo-shinju-anime.jp/",
     "begin": "2017-01-06T17:40:00.000Z",
     "end": "2017-03-24T18:12:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "5a12ceb2cf2c11e69e06",
-        "begin": "2017-01-06T19:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "8aRUlt0f-ko",
-        "begin": "2017-01-06T19:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-06T19:10:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1129,47 +689,26 @@
     "officialSite": "http://reikenzan.net/",
     "begin": "2017-01-07T15:00:00.000Z",
     "end": "2017-03-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5831",
-        "begin": "2017-01-06T02:51:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T02:51:00.000Z"
       },
       {
         "site": "pptv",
         "id": "D0AppmDib5yWIBm4",
-        "begin": "2017-01-06T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T02:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "304871",
-        "begin": "2017-01-06T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T02:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2017/dhpcqyzljsry2",
-        "begin": "2017-01-06T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-06T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1178,12 +717,7 @@
       {
         "site": "nicovideo",
         "id": "reikenzan2",
-        "begin": "2017-01-12T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T15:30:00.000Z"
       }
     ]
   },
@@ -1202,57 +736,26 @@
     "officialSite": "http://chronicle-anime.sega-net.com/index.html",
     "begin": "2017-01-07T17:19:00.000Z",
     "end": "2017-03-25T18:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh91x3l",
-        "begin": "2017-01-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "qU8gRvbpQ3c",
-        "begin": "2017-01-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-07T19:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "075d74c1d16411e6967c",
-        "begin": "2017-01-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-07T19:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "tUkvrAZkXZvibfOQ",
-        "begin": "2017-01-07T19:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-07T19:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5784",
-        "begin": "2017-01-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-07T19:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1261,12 +764,7 @@
       {
         "site": "nicovideo",
         "id": "chronicle-anime",
-        "begin": "2017-02-14T04:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-14T04:30:00.000Z"
       }
     ]
   },
@@ -1286,77 +784,36 @@
     "officialSite": "http://eldlive.tv/index.html",
     "begin": "2017-01-08T13:00:00.000Z",
     "end": "2017-03-26T13:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh92on1",
-        "begin": "2017-01-09T02:26:52.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5790",
-        "begin": "2017-01-08T14:30:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T02:26:52.000Z"
       },
       {
         "site": "qq",
         "id": "1/1fb4u6bunv0ui73",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "fcayMJjibbqwPjfU",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "310275",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2016/dhpyzjt",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10034011",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1365,12 +822,7 @@
       {
         "site": "nicovideo",
         "id": "eldlive",
-        "begin": "2017-01-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-11T03:00:00.000Z"
       }
     ]
   },
@@ -1388,17 +840,11 @@
     "officialSite": "http://nyanko-days.com/index.html",
     "begin": "2017-01-08T13:25:00.000Z",
     "end": "2017-03-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5786",
-        "begin": "2017-01-08T15:30:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T15:30:09.000Z"
       },
       {
         "site": "bangumi",
@@ -1407,12 +853,7 @@
       {
         "site": "nicovideo",
         "id": "nyanko-days",
-        "begin": "2017-01-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-11T03:00:00.000Z"
       }
     ]
   },
@@ -1432,77 +873,36 @@
     "officialSite": "http://toz-thex-anime.tales-ch.jp/",
     "begin": "2017-01-08T14:00:00.000Z",
     "end": "2017-04-29T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5789",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhanqu9",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "8d4e6f8a3e9f11e6b32f",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "HljTWXqPSSI",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "n6uFA2vRQXiciaYMg",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10024401",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2016/dhprccshx",
-        "begin": "2017-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1525,17 +925,11 @@
     "officialSite": "http://idoljihen.jp/",
     "begin": "2017-01-08T14:30:00.000Z",
     "end": "2017-03-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5787",
-        "begin": "2017-01-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-08T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1544,12 +938,7 @@
       {
         "site": "nicovideo",
         "id": "idoljihen-anime",
-        "begin": "2017-01-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-11T14:30:00.000Z"
       }
     ]
   },
@@ -1565,27 +954,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/gintama/",
     "begin": "2017-01-08T16:35:00.000Z",
     "end": "2017-03-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "cc0026e0962411de83b1",
-        "begin": "2017-01-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "XNzgwNDA",
-        "begin": "2017-01-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-08T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1594,12 +967,7 @@
       {
         "site": "nicovideo",
         "id": "gintama2017",
-        "begin": "2017-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T03:00:00.000Z"
       }
     ]
   },
@@ -1615,17 +983,11 @@
     "officialSite": "http://www.chiruran.jp/",
     "begin": "2017-01-09T16:00:00.000Z",
     "end": "2017-03-27T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5791",
-        "begin": "2017-01-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1634,12 +996,7 @@
       {
         "site": "nicovideo",
         "id": "chiruran-anime",
-        "begin": "2017-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T03:00:00.000Z"
       }
     ]
   },
@@ -1655,47 +1012,26 @@
     "officialSite": "http://acca-anime.com/",
     "begin": "2017-01-10T14:00:00.000Z",
     "end": "2017-03-28T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5795",
-        "begin": "2017-01-10T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh91wpp",
-        "begin": "2017-01-10T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T14:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "oJJibicGTKOnjbWcE",
-        "begin": "2017-01-10T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T14:30:00.000Z"
       },
       {
         "site": "letv",
         "id": "10034110",
-        "begin": "2017-01-10T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1704,12 +1040,7 @@
       {
         "site": "nicovideo",
         "id": "acca-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1728,47 +1059,26 @@
     "officialSite": "http://project-hs.net/",
     "begin": "2017-01-10T15:30:00.000Z",
     "end": "2017-03-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5797",
-        "begin": "2017-01-10T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T17:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh91oh1",
-        "begin": "2017-01-10T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T17:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "WOrGRKwSgsAjoQk",
-        "begin": "2017-01-10T17:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T17:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2017/handshakers",
-        "begin": "2017-01-10T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1777,12 +1087,7 @@
       {
         "site": "nicovideo",
         "id": "project-hs",
-        "begin": "2017-01-18T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-18T15:30:00.000Z"
       }
     ]
   },
@@ -1804,57 +1109,26 @@
     "officialSite": "http://kemono-friends.jp/",
     "begin": "2017-01-10T16:35:00.000Z",
     "end": "2017-03-28T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5796",
-        "begin": "2017-01-10T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh91pbh",
-        "begin": "2017-01-10T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "d1178292ce3811e68ce4",
-        "begin": "2017-01-10T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "tXv9ywWS6aA",
-        "begin": "2017-01-10T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-10T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10034111",
-        "begin": "2017-01-10T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-10T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1863,12 +1137,7 @@
       {
         "site": "nicovideo",
         "id": "kemono-friends",
-        "begin": "2017-01-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-13T03:00:00.000Z"
       }
     ]
   },
@@ -1885,17 +1154,11 @@
     "officialSite": "http://piace-anime.com/",
     "begin": "2017-01-11T13:30:00.000Z",
     "end": "2017-03-29T13:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh91nxl",
-        "begin": "2017-01-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-11T14:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1904,12 +1167,7 @@
       {
         "site": "nicovideo",
         "id": "piace-anime",
-        "begin": "2017-01-18T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-18T13:30:00.000Z"
       }
     ]
   },
@@ -1925,17 +1183,11 @@
     "officialSite": "http://oneroom-anime.com/",
     "begin": "2017-01-11T13:40:00.000Z",
     "end": "2017-03-29T13:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5798",
-        "begin": "2017-01-11T13:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-11T13:40:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1944,12 +1196,7 @@
       {
         "site": "nicovideo",
         "id": "one-room",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1965,17 +1212,11 @@
     "officialSite": "http://chaoschildanime.com/",
     "begin": "2017-01-11T16:35:00.000Z",
     "end": "2017-03-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5802",
-        "begin": "2017-01-11T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-11T19:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1984,12 +1225,7 @@
       {
         "site": "nicovideo",
         "id": "chaoschild",
-        "begin": "2017-01-20T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-20T16:00:00.000Z"
       }
     ]
   },
@@ -2006,37 +1242,16 @@
     "officialSite": "http://marginal4-anime.com/",
     "begin": "2017-01-12T14:30:00.000Z",
     "end": "2017-03-30T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh91m31",
-        "begin": "2017-01-12T16:01:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T16:01:16.000Z"
       },
       {
         "site": "youku",
         "id": "3646bb4cc8d411e6967c",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "IJw5rhO-s6A",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2056,57 +1271,21 @@
     "officialSite": "http://superlovers-anime.com/",
     "begin": "2017-01-12T14:30:00.000Z",
     "end": "2017-03-16T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5803",
-        "begin": "2017-01-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrh91o41",
-        "begin": "2017-01-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "71144b9cbf5411e69e06",
-        "begin": "2017-01-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "UoH0cSS2sNM",
-        "begin": "2017-01-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-12T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "VODMSobWzw1w7lY",
-        "begin": "2017-01-12T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": "2017-01-12T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2115,12 +1294,7 @@
       {
         "site": "nicovideo",
         "id": "superlovers2",
-        "begin": "2017-01-24T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-24T14:30:00.000Z"
       }
     ]
   },
@@ -2136,47 +1310,16 @@
     "officialSite": "http://www.kuzunohonkai.com/",
     "begin": "2017-01-12T16:10:00.000Z",
     "end": "2017-03-30T17:25:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5805",
-        "begin": "2017-01-11T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480083",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "EyMNiaicNZyQdq6FA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10034178",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2196,17 +1339,11 @@
     "officialSite": "http://www.rewrite-anime.tv/",
     "begin": "2017-01-14T14:30:00.000Z",
     "end": "2017-03-25T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5806",
-        "begin": "2017-01-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-14T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2227,57 +1364,26 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yamishibai/",
     "begin": "2017-01-14T17:05:00.000Z",
     "end": "2017-03-26T19:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10034226",
-        "begin": "2017-01-15T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-15T18:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5832",
-        "begin": "2017-01-15T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-15T18:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh91pm9",
-        "begin": "2017-01-15T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "00U33OVzKgw",
-        "begin": "2017-01-15T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-15T18:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "1b42802acd6a11e69c81",
-        "begin": "2017-01-15T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-15T18:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2286,12 +1392,7 @@
       {
         "site": "nicovideo",
         "id": "yamishibai4",
-        "begin": "2017-01-16T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-16T03:00:00.000Z"
       }
     ]
   },
@@ -2307,17 +1408,11 @@
     "officialSite": "http://www.kbc.co.jp/scg/",
     "begin": "2017-01-14T16:32:00.000Z",
     "end": "2017-04-08T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5808",
-        "begin": "2017-01-14T16:32:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-14T16:32:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2340,17 +1435,11 @@
     "officialSite": "http://nanbaka.tv/",
     "begin": "2017-01-07T13:30:00.000Z",
     "end": "2017-03-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5809",
-        "begin": "2017-01-03T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-03T19:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2371,77 +1460,36 @@
     "officialSite": "http://spiritpact.com/",
     "begin": "2017-01-07T12:00:00.000Z",
     "end": "2017-03-11T12:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5878",
-        "begin": "2017-01-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "iqiyi",
         "id": "a_19rrh92o0t",
-        "begin": "2017-01-10T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T02:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "uaiaQD8aXjswvrRU",
-        "begin": "2017-01-10T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "z/zvukuef65ldg9ym",
-        "begin": "2017-01-10T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T02:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "309595",
-        "begin": "2017-01-10T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T02:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2016/dhplqryb",
-        "begin": "2017-01-10T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-10T02:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10033664",
-        "begin": "2017-01-10T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-01-10T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2450,12 +1498,7 @@
       {
         "site": "nicovideo",
         "id": "spiritpact",
-        "begin": "2017-01-07T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-07T13:30:00.000Z"
       }
     ]
   },
@@ -2471,37 +1514,21 @@
     "officialSite": "",
     "begin": "2017-01-12T02:00:00.000Z",
     "end": "2017-06-08T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fsexL5f9basOjPQ",
-        "begin": "2017-01-12T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T02:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2017/dhpcysj1",
-        "begin": "2017-01-12T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T02:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "309854",
-        "begin": "2017-01-12T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2510,12 +1537,7 @@
       {
         "site": "bilibili",
         "id": "5854",
-        "begin": "2017-01-12T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-12T02:00:00.000Z"
       }
     ]
   },
@@ -2531,27 +1553,16 @@
     "officialSite": "http://chronicle-anime.com/",
     "begin": "2017-01-14T16:00:00.000Z",
     "end": "2017-01-14T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IhQAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha8tqp",
-        "begin": "2016-12-16T08:55:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-16T08:55:22.000Z"
       },
       {
         "site": "bangumi",
@@ -2571,17 +1582,11 @@
     "officialSite": "http://www.tamasichi.net/tama-pawns/",
     "begin": "2017-01-27T16:00:00.000Z",
     "end": "2017-02-01T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "0GZS0DiaeDkyvLZU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2590,12 +1595,7 @@
       {
         "site": "bilibili",
         "id": "5910",
-        "begin": "2017-01-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-26T16:00:01.000Z"
       }
     ]
   },
@@ -2611,17 +1611,11 @@
     "officialSite": "",
     "begin": "2017-01-12T16:00:00.000Z",
     "end": "2017-01-12T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "w3lT0TmfD02wLpY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2630,12 +1624,7 @@
       {
         "site": "bilibili",
         "id": "5906",
-        "begin": "2017-01-11T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-11T16:00:01.000Z"
       }
     ]
   },
@@ -2651,17 +1640,11 @@
     "officialSite": "",
     "begin": "2017-01-06T16:00:00.000Z",
     "end": "2017-04-03T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "ebibZF3iclVZP2dNw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2681,17 +1664,11 @@
     "officialSite": "http://chronicle-anime.com/",
     "begin": "2017-01-08T16:00:00.000Z",
     "end": "2017-03-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "eL6aGIDmVpT3dd0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2711,17 +1688,11 @@
     "officialSite": "http://superlovers-anime.com/",
     "begin": "2017-01-01T16:00:00.000Z",
     "end": "2017-09-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "32VPzTWbC0msKpI",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2737,7 +1708,6 @@
     "officialSite": "http://www6.nhk.or.jp/anime/program/detail.html?i=ganko",
     "begin": "2017-01-23T09:25:00.000Z",
     "end": "2017-03-27T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2753,7 +1723,6 @@
     "officialSite": "",
     "begin": "2017-01-09T15:00:00.000Z",
     "end": "2017-06-19T15:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2762,12 +1731,7 @@
       {
         "site": "nicovideo",
         "id": "sukiyaki_f",
-        "begin": "2017-01-22T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-01-22T15:00:00.000Z"
       }
     ]
   },
@@ -2783,7 +1747,6 @@
     "officialSite": "http://www.kuroshitsuji-movie.com/",
     "begin": "2017-01-21T16:00:00.000Z",
     "end": "2017-01-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2792,22 +1755,12 @@
       {
         "site": "nicovideo",
         "id": "kuroshitsuji-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "5b336ddcc8c111e69c81",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2823,7 +1776,6 @@
     "officialSite": "",
     "begin": "2017-01-23T16:00:00.000Z",
     "end": "2017-01-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2832,12 +1784,7 @@
       {
         "site": "pptv",
         "id": "PwTwbtY8rOpNyzM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2017/02.json
+++ b/data/items/2017/02.json
@@ -15,17 +15,11 @@
     "officialSite": "http://www.asahi.co.jp/precure/",
     "begin": "2017-02-04T23:30:00.000Z",
     "end": "2018-01-29T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh91xvd",
-        "begin": "2017-02-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-05T03:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -49,17 +43,11 @@
     "officialSite": "http://www.nhk.or.jp/anime/ryu/",
     "begin": "2017-02-18T11:00:00.000Z",
     "end": "2017-02-25T11:46:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5933",
-        "begin": "2017-02-18T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-18T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -68,12 +56,7 @@
       {
         "site": "nicovideo",
         "id": "anime-ryu",
-        "begin": "2017-02-10T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-10T09:00:00.000Z"
       }
     ]
   },
@@ -89,27 +72,16 @@
     "officialSite": "http://chronicle-anime.com/",
     "begin": "2017-02-11T16:00:00.000Z",
     "end": "2017-02-11T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "IhQAfuZMvPpd20M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrha8tqp",
-        "begin": "2016-12-16T08:55:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-12-16T08:55:22.000Z"
       },
       {
         "site": "bangumi",
@@ -129,17 +101,11 @@
     "officialSite": "http://digimon-adventure.net/",
     "begin": "2017-02-25T16:00:00.000Z",
     "end": "2017-02-25T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrhbcjih",
-        "begin": "2016-02-15T09:09:13.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-02-15T09:09:13.000Z"
       },
       {
         "site": "bangumi",
@@ -148,22 +114,12 @@
       {
         "site": "nicovideo",
         "id": "digimon-adventure-tri04",
-        "begin": "2016-04-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-04-01T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "9b274b3ad30811e6b9bb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -179,17 +135,11 @@
     "officialSite": "http://aooni-anime.com/",
     "begin": "2017-02-11T16:00:00.000Z",
     "end": "2017-02-11T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rradj4sw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -198,32 +148,17 @@
       {
         "site": "nicovideo",
         "id": "aooni-anime",
-        "begin": "2016-10-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-10-03T15:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5929",
-        "begin": "2017-02-10T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-02-10T16:00:01.000Z"
       },
       {
         "site": "youku",
         "id": "8635adbbee8a11e68ce4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -239,7 +174,6 @@
     "officialSite": "http://project-itoh.com/",
     "begin": "2017-02-03T16:00:00.000Z",
     "end": "2017-02-03T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -262,7 +196,6 @@
     "officialSite": "http://www.nhk.or.jp/seimei/pikaia2.html",
     "begin": "2017-02-26T07:45:00.000Z",
     "end": "2017-05-27T08:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -282,17 +215,11 @@
     "officialSite": "",
     "begin": "2017-02-22T16:00:00.000Z",
     "end": "2017-02-22T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "m6CMCnLYSIbpZ88",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -312,7 +239,6 @@
     "officialSite": "http://sao-movie.net/",
     "begin": "2017-02-18T16:00:00.000Z",
     "end": "2017-02-18T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -321,12 +247,7 @@
       {
         "site": "nicovideo",
         "id": "sao-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -342,7 +263,6 @@
     "officialSite": "http://movie.trinity-7.com/",
     "begin": "2017-02-25T16:00:00.000Z",
     "end": "2017-02-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -351,22 +271,12 @@
       {
         "site": "nicovideo",
         "id": "movie-trinity-7",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "naiaEAmrQQH7hX8c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -382,7 +292,6 @@
     "officialSite": "http://koisurushirokuma.jp/",
     "begin": "2017-02-28T16:00:00.000Z",
     "end": "2018-02-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -391,12 +300,7 @@
       {
         "site": "letv",
         "id": "10037653",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -412,7 +316,6 @@
     "officialSite": "http://yamato2202.net/",
     "begin": "2017-02-25T16:00:00.000Z",
     "end": "2017-02-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -421,12 +324,7 @@
       {
         "site": "youku",
         "id": "b6b6d5fcd30411e6b9bb",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2017/03.json
+++ b/data/items/2017/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://doraeiga.com/2017/",
     "begin": "2017-03-04T16:00:00.000Z",
     "end": "2017-03-04T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -34,17 +33,11 @@
     "officialSite": "http://tv-aichi.co.jp/fc-buddyfightX/",
     "begin": "2017-03-31T23:00:00.000Z",
     "end": "2018-03-31T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6073",
-        "begin": "2017-04-17T07:20:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-17T07:20:00.000Z"
       },
       {
         "site": "bangumi",
@@ -64,17 +57,11 @@
     "officialSite": "http://short.yume-100.com/",
     "begin": "2017-03-25T02:00:00.000Z",
     "end": "2017-12-25T02:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6008",
-        "begin": "2017-03-25T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-25T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -83,12 +70,7 @@
       {
         "site": "nicovideo",
         "id": "short-yume-100",
-        "begin": "2017-04-12T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T09:00:00.000Z"
       }
     ]
   },
@@ -104,17 +86,11 @@
     "officialSite": "http://gundam-tb.net/",
     "begin": "2017-03-24T03:00:00.000Z",
     "end": "2017-07-14T03:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6007",
-        "begin": "2017-03-24T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-24T03:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -134,37 +110,21 @@
     "officialSite": "http://henkeigirls.com/",
     "begin": "2017-03-27T16:00:00.000Z",
     "end": "2017-10-24T16:02:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "EycRjicddzQtu7FQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "sohu",
         "id": "s2017/dhpbxsn",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "l/ls84d0qcj6rcuq1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -173,32 +133,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhd0rb1",
-        "begin": "2017-08-29T08:37:22.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-29T08:37:22.000Z"
       },
       {
         "site": "bilibili",
         "id": "6070",
-        "begin": "2017-03-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-26T16:00:01.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd58efbfbd6f7311",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -214,7 +159,6 @@
     "officialSite": "http://pp-movie.com/",
     "begin": "2017-03-04T16:00:00.000Z",
     "end": "2017-03-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -223,12 +167,7 @@
       {
         "site": "nicovideo",
         "id": "pp-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -244,7 +183,6 @@
     "officialSite": "http://animetamago.jp/title.php?id=4",
     "begin": "2017-03-11T16:00:00.000Z",
     "end": "2017-03-11T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -253,12 +191,7 @@
       {
         "site": "nicovideo",
         "id": "zunko",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -274,7 +207,6 @@
     "officialSite": "http://yuyuyu.tv/washio/",
     "begin": "2017-03-18T16:00:00.000Z",
     "end": "2017-03-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -283,22 +215,12 @@
       {
         "site": "pptv",
         "id": "KAicpZ881peNGxCw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "6075",
-        "begin": "2017-03-17T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-17T16:00:01.000Z"
       }
     ]
   },
@@ -314,7 +236,6 @@
     "officialSite": "http://www.precure-dreamstars.com/",
     "begin": "2017-03-18T16:00:00.000Z",
     "end": "2017-03-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -323,12 +244,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   },
@@ -344,7 +260,6 @@
     "officialSite": "http://www.hai-furi.com/",
     "begin": "2017-03-31T16:00:00.000Z",
     "end": "2017-05-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -353,12 +268,7 @@
       {
         "site": "nicovideo",
         "id": "hai-furi-ova",
-        "begin": "2018-05-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-31T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2017/04.json
+++ b/data/items/2017/04.json
@@ -11,17 +11,11 @@
     "officialSite": "http://anime.granbluefantasy.jp/",
     "begin": "2017-04-01T15:00:00.000Z",
     "end": "2017-06-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "fTEamXXn3hxicicWU",
-        "begin": "2017-04-01T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-01T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -30,12 +24,7 @@
       {
         "site": "nicovideo",
         "id": "anime_granbluefantasy",
-        "begin": "2017-04-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T03:00:00.000Z"
       }
     ]
   },
@@ -55,27 +44,16 @@
     "officialSite": "http://www.saenai.tv/",
     "begin": "2017-04-13T15:55:00.000Z",
     "end": "2017-06-22T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "SP3XVb0jk9E0sho",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9f1yl",
-        "begin": "2017-04-13T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-13T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -99,17 +77,11 @@
     "officialSite": "http://danmachi.com/sword_oratoria/",
     "begin": "2017-04-14T15:30:00.000Z",
     "end": "2017-06-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f4qt",
-        "begin": "2017-04-14T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-14T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -118,12 +90,7 @@
       {
         "site": "nicovideo",
         "id": "danmachi_gaiden",
-        "begin": "2017-04-18T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-18T03:00:00.000Z"
       }
     ]
   },
@@ -143,37 +110,11 @@
     "officialSite": "http://sagrada-anime.com/",
     "begin": "2017-04-05T14:30:00.000Z",
     "end": "2017-09-13T15:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480091",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "ac0ab02ad88911e69e06",
-        "begin": "2017-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "RC4VeE5Wkhc",
-        "begin": "2017-04-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-05T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -182,12 +123,7 @@
       {
         "site": "nicovideo",
         "id": "sagrada-anime",
-        "begin": "2017-04-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T15:00:00.000Z"
       }
     ]
   },
@@ -206,27 +142,16 @@
     "officialSite": "http://shingeki.tv/season2/",
     "begin": "2017-04-01T13:00:00.000Z",
     "end": "2017-06-17T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9brh9",
-        "begin": "2017-04-01T20:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-01T20:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5970",
-        "begin": "2017-04-01T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-01T19:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -235,12 +160,7 @@
       {
         "site": "nicovideo",
         "id": "shingeki_season2",
-        "begin": "2017-03-24T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-24T06:00:00.000Z"
       }
     ]
   },
@@ -256,67 +176,31 @@
     "officialSite": "http://cingeki-anime.com/",
     "begin": "2017-04-04T12:55:00.000Z",
     "end": "2017-06-27T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "sohu",
         "id": "s2017/dhpoxdsjcb",
-        "begin": "2017-04-04T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T13:55:00.000Z"
       },
       {
         "site": "youku",
         "id": "70efbfbd5d23144811ef",
-        "begin": "2017-04-04T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "_UKJ9sX-aTc",
-        "begin": "2017-04-04T13:55:00.000Z",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-04T13:55:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "314020",
-        "begin": "2017-04-04T13:55:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T13:55:00.000Z"
       },
       {
         "site": "pptv",
         "id": "MgbycNgibruxPzTU",
-        "begin": "2017-04-04T13:55:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T13:55:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5966",
-        "begin": "2017-04-04T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T13:55:00.000Z"
       },
       {
         "site": "bangumi",
@@ -325,12 +209,7 @@
       {
         "site": "nicovideo",
         "id": "cingeki-anime",
-        "begin": "2017-05-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-05-17T03:00:00.000Z"
       }
     ]
   },
@@ -346,7 +225,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/drivehead/",
     "begin": "2017-04-14T22:00:00.000Z",
     "end": "2017-06-30T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -355,22 +233,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrheijc5",
-        "begin": "2017-10-25T21:41:27.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-25T21:41:27.000Z"
       },
       {
         "site": "bilibili",
-        "id": "6522",
-        "begin": "2017-04-15T01:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "6084",
+        "begin": "2017-04-15T01:30:00.000Z"
       }
     ]
   },
@@ -386,17 +254,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/cp/",
     "begin": "2017-04-06T16:59:00.000Z",
     "end": "2017-06-22T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6000",
-        "begin": "2017-04-07T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T04:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -405,12 +267,7 @@
       {
         "site": "nicovideo",
         "id": "cp",
-        "begin": "2017-04-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T03:00:00.000Z"
       }
     ]
   },
@@ -429,17 +286,11 @@
     "officialSite": "http://rokuaka.jp/",
     "begin": "2017-04-04T11:30:00.000Z",
     "end": "2017-06-20T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f27t",
-        "begin": "2017-04-04T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T13:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -448,12 +299,7 @@
       {
         "site": "nicovideo",
         "id": "rokuaka",
-        "begin": "2017-04-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-08T15:30:00.000Z"
       }
     ]
   },
@@ -470,27 +316,16 @@
     "officialSite": "http://www.fagirl.com/",
     "begin": "2017-04-03T16:05:00.000Z",
     "end": "2017-06-19T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f66t",
-        "begin": "2017-04-03T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-03T17:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5994",
-        "begin": "2017-04-03T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-03T17:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -499,12 +334,7 @@
       {
         "site": "nicovideo",
         "id": "fagirl",
-        "begin": "2017-04-07T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T13:00:00.000Z"
       }
     ]
   },
@@ -521,27 +351,16 @@
     "officialSite": "http://www.alicetozouroku.com/",
     "begin": "2017-04-02T13:30:00.000Z",
     "end": "2017-06-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5995",
-        "begin": "2017-04-02T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-02T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9f64p",
-        "begin": "2017-04-02T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-02T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -550,12 +369,7 @@
       {
         "site": "nicovideo",
         "id": "alicetozouroku",
-        "begin": "2017-05-31T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-05-31T03:00:00.000Z"
       }
     ]
   },
@@ -571,18 +385,7 @@
     "officialSite": "http://renaiboukun.com/",
     "begin": "2017-04-06T17:35:00.000Z",
     "end": "2017-06-22T18:05:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "bilibili",
-        "id": "5996",
-        "begin": "2017-04-06T18:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "bangumi",
         "id": "159795"
@@ -590,12 +393,7 @@
       {
         "site": "nicovideo",
         "id": "renaiboukun",
-        "begin": "2017-04-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T03:00:00.000Z"
       }
     ]
   },
@@ -613,17 +411,11 @@
     "officialSite": "http://eromanga-sensei.com/",
     "begin": "2017-04-08T15:30:00.000Z",
     "end": "2017-06-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5997",
-        "begin": "2017-04-08T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-08T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -632,12 +424,7 @@
       {
         "site": "nicovideo",
         "id": "eromanga-sensei",
-        "begin": "2017-04-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T15:00:00.000Z"
       }
     ]
   },
@@ -653,17 +440,11 @@
     "officialSite": "http://sukasuka-anime.com",
     "begin": "2017-04-11T14:30:00.000Z",
     "end": "2017-06-27T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f4gx",
-        "begin": "2017-04-11T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-11T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -672,12 +453,7 @@
       {
         "site": "nicovideo",
         "id": "sukasuka_anime",
-        "begin": "2017-04-19T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-19T15:30:00.000Z"
       }
     ]
   },
@@ -693,17 +469,11 @@
     "officialSite": "http://tsukigakirei.jp",
     "begin": "2017-04-06T15:00:00.000Z",
     "end": "2017-06-29T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5989",
-        "begin": "2017-04-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-06T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -723,17 +493,11 @@
     "officialSite": "http://tsugumomo.com",
     "begin": "2017-04-02T14:30:00.000Z",
     "end": "2017-06-18T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5988",
-        "begin": "2017-04-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-02T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -742,12 +506,7 @@
       {
         "site": "nicovideo",
         "id": "tsugumomo",
-        "begin": "2017-04-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-06T15:00:00.000Z"
       }
     ]
   },
@@ -764,27 +523,16 @@
     "officialSite": "http://zeronosyo.com",
     "begin": "2017-04-10T14:30:00.000Z",
     "end": "2017-06-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6001",
-        "begin": "2017-04-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-10T15:30:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "315437",
-        "begin": "2017-04-10T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-10T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -793,12 +541,7 @@
       {
         "site": "nicovideo",
         "id": "zeronosyo",
-        "begin": "2017-04-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-17T15:00:00.000Z"
       }
     ]
   },
@@ -814,17 +557,11 @@
     "officialSite": "http://sakura-quest.com",
     "begin": "2017-04-05T15:00:00.000Z",
     "end": "2017-09-20T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5992",
-        "begin": "2017-04-05T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-05T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -833,12 +570,7 @@
       {
         "site": "nicovideo",
         "id": "sakura-quest",
-        "begin": "2017-04-07T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T14:30:00.000Z"
       }
     ]
   },
@@ -857,57 +589,26 @@
     "officialSite": "http://nobunaga-no-shinobi.com/",
     "begin": "2017-04-07T16:35:00.000Z",
     "end": "2017-09-29T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f8t5",
-        "begin": "2017-04-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T17:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10035912",
-        "begin": "2017-04-07T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-07T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd7cefbfbd10112f",
-        "begin": "2017-04-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "nNF6raEiQAg",
-        "begin": "2017-04-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-07T17:35:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5965",
-        "begin": "2017-04-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T17:35:00.000Z"
       },
       {
         "site": "bangumi",
@@ -916,12 +617,7 @@
       {
         "site": "nicovideo",
         "id": "nobunaga-no-shinobi02",
-        "begin": "2017-04-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-09T03:00:00.000Z"
       }
     ]
   },
@@ -940,47 +636,16 @@
     "officialSite": "http://heroaca.com/",
     "begin": "2017-04-01T08:30:00.000Z",
     "end": "2017-09-30T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
-        "site": "acfun",
-        "id": "1480105",
-        "begin": "2017-04-01T09:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "bilibili",
-        "id": "5969",
-        "begin": "2017-04-01T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "91212",
+        "begin": "2017-04-01T09:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd1004efbfbd3478",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "pEFBZGfERLo",
-        "begin": "2017-04-01T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -989,32 +654,17 @@
       {
         "site": "qq",
         "id": "o/o1550gzahixfttn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh8h95x",
-        "begin": "2018-04-14T02:54:47.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-14T02:54:47.000Z"
       },
       {
         "site": "mgtv",
         "id": "315217",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1030,37 +680,11 @@
     "officialSite": "http://anime-rinne.com/",
     "begin": "2017-04-08T08:35:00.000Z",
     "end": "2017-09-23T09:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480099",
-        "begin": "2017-04-08T11:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "05202e5b111911efbfbd",
-        "begin": "2017-04-08T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "syDRJaJg4Tw",
-        "begin": "2017-04-08T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-08T11:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1069,12 +693,7 @@
       {
         "site": "nicovideo",
         "id": "rinne03",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1091,77 +710,31 @@
     "officialSite": "http://www.natsume-anime.jp/",
     "begin": "2017-04-11T16:35:00.000Z",
     "end": "2017-06-20T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "314036",
-        "begin": "2017-04-11T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-11T19:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2017/xmyrz6",
-        "begin": "2017-04-11T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-11T19:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9f5ut",
-        "begin": "2017-04-11T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480106",
-        "begin": "2017-04-11T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-11T19:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd7defbfbd3d06ef",
-        "begin": "2017-04-11T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "2ztR0qbh6i4",
-        "begin": "2017-04-11T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-11T19:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5977",
-        "begin": "2017-04-11T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-11T19:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1170,22 +743,12 @@
       {
         "site": "nicovideo",
         "id": "natsume6",
-        "begin": "2017-04-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T03:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "r/rzuinvatj34ekz7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1202,37 +765,21 @@
     "officialSite": "http://twinangel-break.com/",
     "begin": "2017-04-07T13:00:00.000Z",
     "end": "2017-06-23T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5955",
-        "begin": "2017-04-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-15T03:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10036007",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "LRXicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1241,12 +788,7 @@
       {
         "site": "nicovideo",
         "id": "twinangel-break",
-        "begin": "2017-04-17T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-17T15:30:00.000Z"
       }
     ]
   },
@@ -1265,37 +807,16 @@
     "officialSite": "http://seikaisuru-kado.com/",
     "begin": "2017-04-07T13:30:00.000Z",
     "end": "2017-06-29T03:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10036008",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480103",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "UibfRT7cdjcsurBQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -1304,22 +825,7 @@
       {
         "site": "nicovideo",
         "id": "seikaisuru-kado",
-        "begin": "2017-04-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5982",
-        "begin": "2017-04-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-13T03:00:00.000Z"
       }
     ]
   },
@@ -1339,17 +845,11 @@
     "officialSite": "http://machiavellism-anime.jp/",
     "begin": "2017-04-05T14:00:00.000Z",
     "end": "2017-06-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f4jd",
-        "begin": "2017-04-05T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-05T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1358,12 +858,7 @@
       {
         "site": "nicovideo",
         "id": "machiavellism",
-        "begin": "2017-04-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-16T16:00:00.000Z"
       }
     ]
   },
@@ -1382,37 +877,11 @@
     "officialSite": "http://uchoten2-anime.com/",
     "begin": "2017-04-09T13:00:00.000Z",
     "end": "2017-06-25T13:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480098",
-        "begin": "2017-04-09T13:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "efbfbdefbfbdefbfbd08",
-        "begin": "2017-04-09T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "SpDRKeq36sU",
-        "begin": "2017-04-09T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-09T13:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1421,12 +890,7 @@
       {
         "site": "nicovideo",
         "id": "uchoten2-anime",
-        "begin": "2017-04-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-14T15:00:00.000Z"
       }
     ]
   },
@@ -1445,27 +909,16 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/rilurilufairilu/",
     "begin": "2017-04-07T08:55:00.000Z",
     "end": "2018-03-30T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VurGRKwSgsAjoQk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5958",
-        "begin": "2017-04-09T03:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-09T03:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1485,27 +938,16 @@
     "officialSite": "http://recreators.tv/",
     "begin": "2017-04-08T14:30:00.000Z",
     "end": "2017-09-16T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5998",
-        "begin": "2017-04-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-08T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9f1v5",
-        "begin": "2017-04-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-08T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1514,12 +956,7 @@
       {
         "site": "youku",
         "id": "efbfbd42efbfbdefbfbd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1535,17 +972,11 @@
     "officialSite": "http://warau-new.jp/",
     "begin": "2017-04-03T14:00:00.000Z",
     "end": "2017-06-19T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5951",
-        "begin": "2017-04-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-03T15:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1554,12 +985,7 @@
       {
         "site": "nicovideo",
         "id": "warau-new",
-        "begin": "2017-04-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T15:00:00.000Z"
       }
     ]
   },
@@ -1575,47 +1001,16 @@
     "officialSite": "http://hstar-mu.com/",
     "begin": "2017-04-03T15:00:00.000Z",
     "end": "2017-06-19T15:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480094",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "3a3f0490e2b011e69e06",
-        "begin": "2017-04-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "sE4psYU06jI",
-        "begin": "2017-04-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-03T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5973",
-        "begin": "2017-04-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-03T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1624,22 +1019,12 @@
       {
         "site": "nicovideo",
         "id": "hstar-mu02",
-        "begin": "2017-04-03T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-03T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh83325",
-        "begin": "2017-06-30T16:02:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-30T16:02:45.000Z"
       }
     ]
   },
@@ -1658,47 +1043,16 @@
     "officialSite": "http://id-zero.com/",
     "begin": "2017-04-09T14:00:00.000Z",
     "end": "2017-06-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480100",
-        "begin": "2017-04-09T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "youku",
         "id": "24efbfbd204509efbfbd",
-        "begin": "2017-04-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "MF_XuRLHVXg",
-        "begin": "2017-04-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-09T16:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5999",
-        "begin": "2017-04-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-09T16:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1707,12 +1061,7 @@
       {
         "site": "netflix",
         "id": "80174918",
-        "begin": "2017-10-06T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T07:00:00.000Z"
       }
     ]
   },
@@ -1729,27 +1078,16 @@
     "officialSite": "http://fukumenkei-anime.jp/",
     "begin": "2017-04-11T14:00:00.000Z",
     "end": "2017-06-27T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f60d",
-        "begin": "2017-04-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-11T15:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5981",
-        "begin": "2017-04-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-11T15:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1769,17 +1107,11 @@
     "officialSite": "http://www.tbs.co.jp/anime/kabukibu/",
     "begin": "2017-04-06T17:29:00.000Z",
     "end": "2017-06-22T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5991",
-        "begin": "2017-04-06T18:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-06T18:28:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1788,12 +1120,7 @@
       {
         "site": "nicovideo",
         "id": "kabukibu",
-        "begin": "2017-04-21T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-21T14:00:00.000Z"
       }
     ]
   },
@@ -1812,7 +1139,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/duelmasters/",
     "begin": "2017-04-01T23:30:00.000Z",
     "end": "2018-03-25T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1821,12 +1147,7 @@
       {
         "site": "nicovideo",
         "id": "duelmasters_2017",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1846,47 +1167,16 @@
     "officialSite": "http://www.beyblade.tv/",
     "begin": "2017-04-03T08:55:00.000Z",
     "end": "2018-03-26T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "4fefbfbdefbfbd7816ef",
-        "begin": "2017-04-03T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "Wylt_kdgbVU",
-        "begin": "2017-04-03T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-03T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "LxP9eibNJufda2EA",
-        "begin": "2017-04-03T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480097",
-        "begin": "2017-04-03T16:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-03T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -1906,7 +1196,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/wasimo/",
     "begin": "2017-04-03T09:00:00.000Z",
     "end": "2017-11-14T09:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1931,67 +1220,26 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/ipp/",
     "begin": "2017-04-04T08:55:00.000Z",
     "end": "2018-03-27T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10035810",
-        "begin": "2017-04-04T09:55:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-04T09:55:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9f5s1",
-        "begin": "2017-04-04T09:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480095",
-        "begin": "2017-04-04T09:55:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T09:55:00.000Z"
       },
       {
         "site": "youku",
         "id": "105b2befbfbd09efbfbd",
-        "begin": "2017-04-04T09:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "hhG7Y5sJi78",
-        "begin": "2017-04-04T09:55:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-04T09:55:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5963",
-        "begin": "2017-04-04T09:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T09:55:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2000,12 +1248,7 @@
       {
         "site": "nicovideo",
         "id": "ipp",
-        "begin": "2017-04-14T12:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-14T12:30:00.000Z"
       }
     ]
   },
@@ -2022,67 +1265,26 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yamizukan/",
     "begin": "2017-04-02T18:35:00.000Z",
     "end": "2017-06-25T18:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f8xh",
-        "begin": "2017-04-02T19:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-02T19:35:00.000Z"
       },
       {
         "site": "letv",
         "id": "10035761",
-        "begin": "2017-04-02T19:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480096",
-        "begin": "2017-04-02T19:35:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-02T19:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "6e07112411efbfbd11ef",
-        "begin": "2017-04-02T19:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "FtO1_WOcyjU",
-        "begin": "2017-04-02T19:35:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-02T19:35:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "6011",
-        "begin": "2017-04-02T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-02T19:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2091,12 +1293,7 @@
       {
         "site": "nicovideo",
         "id": "yamizukan",
-        "begin": "2017-04-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-03T03:00:00.000Z"
       }
     ]
   },
@@ -2112,27 +1309,11 @@
     "officialSite": "http://soryo.w-anime.com/",
     "begin": "2017-04-02T16:00:00.000Z",
     "end": "2017-06-18T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "t4xo5k60JGLFQ6s",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5960",
-        "begin": "2017-04-03T02:40:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2141,12 +1322,7 @@
       {
         "site": "nicovideo",
         "id": "soryo-w-anime",
-        "begin": "2017-12-22T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-22T09:00:00.000Z"
       }
     ]
   },
@@ -2164,47 +1340,21 @@
     "officialSite": "http://gogo-gomachan.com/",
     "begin": "2017-04-04T09:45:00.000Z",
     "end": "2018-02-13T10:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f6b5",
-        "begin": "2017-04-04T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T12:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "410affe6e5d311e5b32f",
-        "begin": "2016-04-05T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "qiBO_bk7hZY",
-        "begin": "2016-04-05T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2016-04-05T11:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "6010",
-        "begin": "2017-04-04T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T12:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2224,67 +1374,26 @@
     "officialSite": "http://heine-royal.com/",
     "begin": "2017-04-04T17:05:00.000Z",
     "end": "2017-06-20T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f8up",
-        "begin": "2017-04-04T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T18:05:00.000Z"
       },
       {
         "site": "letv",
         "id": "10035811",
-        "begin": "2017-04-04T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480093",
-        "begin": "2017-04-04T18:05:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T18:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbdefbfbd3befbfbd",
-        "begin": "2017-04-04T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "jjWggTdz9pI",
-        "begin": "2017-04-04T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-04T18:05:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5990",
-        "begin": "2017-04-04T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-04T18:05:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2293,12 +1402,7 @@
       {
         "site": "nicovideo",
         "id": "heine-royal",
-        "begin": "2017-04-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-05T15:00:00.000Z"
       }
     ]
   },
@@ -2315,57 +1419,26 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/boruto/",
     "begin": "2017-04-05T08:55:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10035769",
-        "begin": "2017-04-09T09:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-09T09:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9f0tx",
-        "begin": "2017-04-09T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-09T09:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "311801efbfbd111211ef",
-        "begin": "2017-04-09T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "ffdR6DGHMFI",
-        "begin": "2017-04-09T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-09T09:30:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "5978",
-        "begin": "2017-04-09T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-09T09:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2374,12 +1447,7 @@
       {
         "site": "nicovideo",
         "id": "boruto",
-        "begin": "2017-04-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-09T15:00:00.000Z"
       }
     ]
   },
@@ -2395,17 +1463,11 @@
     "officialSite": "http://akunogundan.com/",
     "begin": "2017-04-05T13:30:00.000Z",
     "end": "2017-06-21T13:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5956",
-        "begin": "2017-04-05T13:45:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-05T13:45:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2414,12 +1476,7 @@
       {
         "site": "nicovideo",
         "id": "akunogundan",
-        "begin": "2017-04-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T15:00:00.000Z"
       }
     ]
   },
@@ -2435,47 +1492,16 @@
     "officialSite": "http://love-kome.com/",
     "begin": "2017-04-05T13:45:00.000Z",
     "end": "2017-06-21T13:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "313990",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480092",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "7e4458bae2ca11e6b9bb",
-        "begin": "2017-04-05T14:45:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "mAf8Sxudxb4",
-        "begin": "2017-04-05T14:45:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-05T14:45:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2484,12 +1510,7 @@
       {
         "site": "nicovideo",
         "id": "love-kome-anime",
-        "begin": "2017-04-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T15:00:00.000Z"
       }
     ]
   },
@@ -2505,37 +1526,11 @@
     "officialSite": "http://berserk-anime.com/",
     "begin": "2017-04-07T13:00:00.000Z",
     "end": "2017-06-23T14:00:00.000Z",
-    "comment": "",
     "sites": [
-      {
-        "site": "acfun",
-        "id": "1480101",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
       {
         "site": "pptv",
         "id": "VOzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5967",
-        "begin": "2017-04-08T02:15:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2544,12 +1539,7 @@
       {
         "site": "nicovideo",
         "id": "berserk-anime",
-        "begin": "2016-07-24T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2016-07-24T03:00:00.000Z"
       }
     ]
   },
@@ -2565,37 +1555,16 @@
     "officialSite": "https://shingekinobahamut-virginsoul.jp",
     "begin": "2017-04-07T17:10:00.000Z",
     "end": "2017-09-29T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "letv",
         "id": "10036009",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480102",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "5968",
-        "begin": "2017-04-08T02:15:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-08T02:15:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2604,22 +1573,12 @@
       {
         "site": "nicovideo",
         "id": "bahamut-vs",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "4dbc9c25e2bf11e6acec",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2637,17 +1596,11 @@
     "officialSite": "http://kbo-anime.com/",
     "begin": "2017-04-12T13:30:00.000Z",
     "end": "2017-06-28T13:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "mgtv",
         "id": "314097",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -2656,12 +1609,7 @@
       {
         "site": "nicovideo",
         "id": "kbo-anime",
-        "begin": "2017-04-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T15:00:00.000Z"
       }
     ]
   },
@@ -2677,17 +1625,11 @@
     "officialSite": "http://oneroom-anime.com/",
     "begin": "2017-04-12T13:40:00.000Z",
     "end": "2017-06-28T13:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5959",
-        "begin": "2017-04-12T13:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T13:40:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2696,12 +1638,7 @@
       {
         "site": "nicovideo",
         "id": "Room_Mate",
-        "begin": "2017-04-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-13T03:00:00.000Z"
       }
     ]
   },
@@ -2718,7 +1655,6 @@
     "officialSite": "http://www.7-sins.tv/",
     "begin": "2017-04-14T15:00:00.000Z",
     "end": "2017-07-29T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2727,12 +1663,7 @@
       {
         "site": "nicovideo",
         "id": "7-sins",
-        "begin": "2017-04-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-15T03:00:00.000Z"
       }
     ]
   },
@@ -2751,17 +1682,11 @@
     "officialSite": "http://atom-tb.com/",
     "begin": "2017-04-15T14:00:00.000Z",
     "end": "2017-07-08T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5979",
-        "begin": "2017-04-15T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-15T16:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2770,12 +1695,7 @@
       {
         "site": "nicovideo",
         "id": "atom-tb",
-        "begin": "2017-04-17T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-17T06:00:00.000Z"
       }
     ]
   },
@@ -2791,7 +1711,6 @@
     "officialSite": "http://neco-neco.jp/",
     "begin": "2017-04-05T09:45:00.000Z",
     "end": "2018-02-28T10:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2814,77 +1733,41 @@
     "officialSite": "http://ginno-guardian.jp/",
     "begin": "2017-04-01T12:00:00.000Z",
     "end": "2017-06-17T12:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6060",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10035880",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "313603",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9fkfl",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "y/yn3kar593j2b1lm",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2017/dhpyzsmr",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "TfXfXcUrm9k8uiaI",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -2893,12 +1776,7 @@
       {
         "site": "nicovideo",
         "id": "ginno-guardian",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2917,7 +1795,6 @@
     "officialSite": "http://ginno-guardian.jp/",
     "begin": "2017-04-01T12:00:00.000Z",
     "end": "2017-06-17T12:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2926,72 +1803,37 @@
       {
         "site": "bilibili",
         "id": "5856",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10035403",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "313299",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh9fs0d",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "c/co1rct64uxcugab",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2017/yzsmrzwb",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "q5B8ibmLIOHbZV78",
-        "begin": "2017-03-31T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-31T02:00:00.000Z"
       }
     ]
   },
@@ -3007,7 +1849,6 @@
     "officialSite": "http://ch.nicovideo.jp/peso-game-line-me-anime",
     "begin": "2017-04-03T12:55:00.000Z",
     "end": "2017-06-19T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3016,22 +1857,12 @@
       {
         "site": "nicovideo",
         "id": "peso-game-line-me-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
         "id": "6068",
-        "begin": "2017-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-02T16:00:01.000Z"
       }
     ]
   },
@@ -3047,17 +1878,11 @@
     "officialSite": "http://hinakonote.jp",
     "begin": "2017-04-07T12:00:00.000Z",
     "end": "2017-06-23T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "5993",
-        "begin": "2017-04-07T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-07T13:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3066,12 +1891,7 @@
       {
         "site": "nicovideo",
         "id": "hinakonote",
-        "begin": "2017-04-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-14T16:00:00.000Z"
       }
     ]
   },
@@ -3087,27 +1907,11 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/mukashibanashi/",
     "begin": "2017-04-02T00:00:00.000Z",
     "end": "2018-03-25T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "youku",
         "id": "7c49efbfbdefbfbd11ef",
-        "begin": "2017-04-02T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "tudou",
-        "id": "XO_kkMadc2Q",
-        "begin": "2017-04-02T01:00:00.000Z",
-        "official": false,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-04-02T01:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3116,12 +1920,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrheh3kd",
-        "begin": "2018-01-07T00:55:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T00:55:04.000Z"
       }
     ]
   },
@@ -3138,17 +1937,11 @@
     "officialSite": "http://www.aikatsu.net/",
     "begin": "2017-04-06T09:25:00.000Z",
     "end": "2018-03-29T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "iqiyi",
         "id": "a_19rrh9f4mh",
-        "begin": "2017-04-06T11:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-06T11:30:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3168,7 +1961,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cocotama/index2.html",
     "begin": "2017-04-06T09:00:00.000Z",
     "end": "2018-03-29T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3188,27 +1980,16 @@
     "officialSite": "http://s.mxtv.jp/anime/anitsuke/",
     "begin": "2017-04-07T12:55:00.000Z",
     "end": "2017-06-23T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "qq",
         "id": "m/maa2g8kqchabbgl",
-        "begin": "2017-03-28T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-28T02:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "6015",
-        "begin": "2017-03-28T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-03-28T02:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3217,12 +1998,7 @@
       {
         "site": "nicovideo",
         "id": "anitsuke",
-        "begin": "2017-04-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-09T15:00:00.000Z"
       }
     ]
   },
@@ -3238,7 +2014,6 @@
     "officialSite": "http://meisakukun.com/",
     "begin": "2017-04-07T09:20:00.000Z",
     "end": "2018-02-23T09:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3258,17 +2033,11 @@
     "officialSite": "http://www.nhk.or.jp/anime/nintama/yotei/",
     "begin": "2017-04-03T08:35:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "VibvFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3277,12 +2046,7 @@
       {
         "site": "youku",
         "id": "75ed8cfa4bfc463483b4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3298,7 +2062,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/snack-world/",
     "begin": "2017-04-13T10:25:00.000Z",
     "end": "2018-04-19T10:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3307,22 +2070,12 @@
       {
         "site": "nicovideo",
         "id": "snack-world",
-        "begin": "2017-04-20T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-20T03:00:00.000Z"
       },
       {
         "site": "bilibili",
         "id": "6004",
-        "begin": "2017-04-12T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-12T16:00:01.000Z"
       }
     ]
   },
@@ -3338,37 +2091,21 @@
     "officialSite": "http://anime.kakutora.com/",
     "begin": "2017-04-12T07:00:00.000Z",
     "end": "2017-11-29T07:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6069",
-        "begin": "2017-04-14T03:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-14T03:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10036060",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "hrqWFHziaUpDzcdk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3377,12 +2114,7 @@
       {
         "site": "nicovideo",
         "id": "trinary",
-        "begin": "2017-04-26T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-04-26T15:00:00.000Z"
       }
     ]
   },
@@ -3398,17 +2130,11 @@
     "officialSite": "http://pasu-chi.com/",
     "begin": "2017-04-14T21:30:00.000Z",
     "end": "2017-12-16T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "nqKODHTaSojradE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3428,27 +2154,11 @@
     "officialSite": "http://pasu-chi.com/",
     "begin": "2017-04-14T21:30:00.000Z",
     "end": "2017-12-16T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "pptv",
         "id": "lqqGBGzSQoDjYck",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "5954",
-        "begin": "2017-04-17T03:25:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -3469,7 +2179,6 @@
     "officialSite": "http://anime.monster-strike.com/",
     "begin": "2017-04-01T15:00:00.000Z",
     "end": "2017-09-02T15:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3478,52 +2187,27 @@
       {
         "site": "bilibili",
         "id": "6059",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhdz2gt",
-        "begin": "2017-08-14T10:31:53.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-14T10:31:53.000Z"
       },
       {
         "site": "pptv",
         "id": "xnVf3UWrG1m8OqI",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "w/wrqntnqyx2vhs7v",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "45efbfbd1fefbfbd5bef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3535,7 +2219,6 @@
     "officialSite": "http://www.panpaka.com",
     "begin": "2017-04-07T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3555,7 +2238,6 @@
     "officialSite": "http://yuyuyu.tv/washio/",
     "begin": "2017-04-15T16:00:00.000Z",
     "end": "2017-04-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3564,12 +2246,7 @@
       {
         "site": "pptv",
         "id": "KAicpZ881peNGxCw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3585,7 +2262,6 @@
     "officialSite": "",
     "begin": "2017-04-28T16:00:00.000Z",
     "end": "2017-09-01T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3594,22 +2270,12 @@
       {
         "site": "mgtv",
         "id": "314318",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "efbfbd17efbfbd6f3aef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3625,7 +2291,6 @@
     "officialSite": "http://www.conan-movie.jp/",
     "begin": "2017-04-15T16:00:00.000Z",
     "end": "2017-04-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3634,12 +2299,7 @@
       {
         "site": "qq",
         "id": "5/5wg77t6vu3utemv",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3655,7 +2315,6 @@
     "officialSite": "http://tm.iwatobi-sc.com/",
     "begin": "2017-04-22T16:00:00.000Z",
     "end": "2017-04-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3664,12 +2323,7 @@
       {
         "site": "nicovideo",
         "id": "free-tm-movie",
-        "begin": "2018-07-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-01T06:00:00.000Z"
       }
     ]
   }

--- a/data/items/2017/05.json
+++ b/data/items/2017/05.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yugioh-vrains/",
     "begin": "2017-05-10T09:25:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,32 +19,17 @@
       {
         "site": "nicovideo",
         "id": "yugioh-vrains",
-        "begin": "2017-06-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-05T15:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "IxYCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "cc91efbfbd44354211ef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "http://gaga.ne.jp/FT.DC/",
     "begin": "2017-05-06T16:00:00.000Z",
     "end": "2017-05-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,12 +53,7 @@
       {
         "site": "nicovideo",
         "id": "FT_DC",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -87,7 +65,6 @@
     "officialSite": "http://www.blame.jp/",
     "begin": "2017-05-20T16:00:00.000Z",
     "end": "2017-05-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -96,22 +73,12 @@
       {
         "site": "nicovideo",
         "id": "blame",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80115466",
-        "begin": "2017-05-19T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-05-19T15:00:00.000Z"
       }
     ]
   },
@@ -127,7 +94,6 @@
     "officialSite": "http://biohazard-vendetta.com/",
     "begin": "2017-05-27T16:00:00.000Z",
     "end": "2017-05-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -136,12 +102,7 @@
       {
         "site": "letv",
         "id": "10037456",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -153,7 +114,6 @@
     "officialSite": "http://www.tv-osaka.co.jp/ip4/jcd/short_anime.html",
     "begin": "2017-05-07T16:00:00.000Z",
     "end": "2018-03-25T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -162,12 +122,7 @@
       {
         "site": "nicovideo",
         "id": "caribadix",
-        "begin": "2018-04-27T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-27T15:00:00.000Z"
       }
     ]
   }

--- a/data/items/2017/06.json
+++ b/data/items/2017/06.json
@@ -14,7 +14,6 @@
     "officialSite": "http://hinalogic.com/",
     "begin": "2017-06-24T03:00:00.000Z",
     "end": "2017-09-16T03:24:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,22 +22,12 @@
       {
         "site": "youku",
         "id": "efbfbd5379efbfbd57ef",
-        "begin": "2017-06-24T04:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-06-24T04:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hinalogic",
-        "begin": "2017-07-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-05T03:00:00.000Z"
       }
     ]
   },
@@ -50,7 +39,6 @@
     "officialSite": "http://kinpri.com/",
     "begin": "2017-06-10T16:00:00.000Z",
     "end": "2017-06-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -59,12 +47,7 @@
       {
         "site": "nicovideo",
         "id": "PRIDE_the_HERO",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -80,7 +63,6 @@
     "officialSite": "http://mahouka.jp/",
     "begin": "2017-06-17T16:00:00.000Z",
     "end": "2017-06-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -89,32 +71,17 @@
       {
         "site": "pptv",
         "id": "Jh33dd1DsicFU0jo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "mahouka_movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "efbfbdefbfbdceb6efbf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -130,7 +97,6 @@
     "officialSite": "http://yamato2202.net/",
     "begin": "2017-06-24T16:00:00.000Z",
     "end": "2017-06-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -139,12 +105,7 @@
       {
         "site": "youku",
         "id": "efbfbdefbfbdefbfbdd8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2017/07.json
+++ b/data/items/2017/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://colopl.co.jp/battlegirl-hs/anime/",
     "begin": "2017-07-02T15:30:00.000Z",
     "end": "2017-09-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "bilibili",
         "id": "6306",
-        "begin": "2017-07-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-02T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "battlegirl-hs",
-        "begin": "2017-07-20T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-20T03:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://project-altair.com/",
     "begin": "2017-07-07T17:25:00.000Z",
     "end": "2017-12-22T18:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,52 +48,22 @@
       {
         "site": "bilibili",
         "id": "6320",
-        "begin": "2017-07-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T19:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "74efbfbd24784fefbfbd",
-        "begin": "2017-07-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "acfun",
-        "id": "1480118",
-        "begin": "2017-07-07T19:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T19:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh86w2l",
-        "begin": "2017-07-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T19:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "project-altair",
-        "begin": "2017-09-07T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-07T19:00:00.000Z"
       }
     ]
   },
@@ -121,7 +79,6 @@
     "officialSite": "http://knights-magic.com/",
     "begin": "2017-07-02T13:30:00.000Z",
     "end": "2017-09-24T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -130,22 +87,12 @@
       {
         "site": "bilibili",
         "id": "6304",
-        "begin": "2017-07-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-02T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "knights-magic",
-        "begin": "2017-07-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-03T03:00:00.000Z"
       }
     ]
   },
@@ -161,7 +108,6 @@
     "officialSite": "http://www.ballroom-official.jp/",
     "begin": "2017-07-08T17:08:00.000Z",
     "end": "2017-12-16T17:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,22 +116,12 @@
       {
         "site": "bilibili",
         "id": "6325",
-        "begin": "2017-07-08T18:08:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-08T18:08:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ballroom-anime",
-        "begin": "2019-01-24T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-24T09:00:00.000Z"
       }
     ]
   },
@@ -201,7 +137,6 @@
     "officialSite": "http://kda-anime.com/index.html",
     "begin": "2017-07-02T15:00:00.000Z",
     "end": "2017-09-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -210,22 +145,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh830zx",
-        "begin": "2017-07-02T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-02T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kda-anime",
-        "begin": "2017-07-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-05T03:00:00.000Z"
       }
     ]
   },
@@ -241,7 +166,6 @@
     "officialSite": "http://ahogirl.jp/",
     "begin": "2017-07-04T14:00:00.000Z",
     "end": "2017-09-19T14:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -250,22 +174,12 @@
       {
         "site": "bilibili",
         "id": "6311",
-        "begin": "2017-07-04T14:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-04T14:15:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ahogirl",
-        "begin": "2017-07-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-09T15:00:00.000Z"
       }
     ]
   },
@@ -281,7 +195,6 @@
     "officialSite": "http://tsuredure-project.jp/",
     "begin": "2017-07-04T14:15:00.000Z",
     "end": "2017-09-19T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -290,32 +203,17 @@
       {
         "site": "bilibili",
         "id": "6312",
-        "begin": "2017-07-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-04T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tsuredure-project",
-        "begin": "2017-07-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-09T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "63efbfbd457854efbfbd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -327,7 +225,6 @@
     "officialSite": "http://rwby.jp/",
     "begin": "2017-07-07T16:05:00.000Z",
     "end": "2017-09-29T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -350,7 +247,6 @@
     "officialSite": "http://isekai-shokudo.com/",
     "begin": "2017-07-03T16:35:00.000Z",
     "end": "2017-09-18T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -359,32 +255,17 @@
       {
         "site": "bilibili",
         "id": "6310",
-        "begin": "2017-07-03T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-03T17:35:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "319028",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "isekai-shokudo",
-        "begin": "2017-07-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-08T03:00:00.000Z"
       }
     ]
   },
@@ -401,41 +282,20 @@
     "officialSite": "http://hajimete-no-gal.jp/",
     "begin": "2017-07-12T14:00:00.000Z",
     "end": "2017-09-13T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "198675"
       },
       {
-        "site": "bilibili",
-        "id": "6338",
-        "begin": "2017-07-12T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "iqiyi",
         "id": "a_19rrh86wrx",
-        "begin": "2017-07-12T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-12T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hajimete-no-gal",
-        "begin": "2017-07-19T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-19T15:30:00.000Z"
       }
     ]
   },
@@ -451,7 +311,6 @@
     "officialSite": "http://you-zitsu.com/",
     "begin": "2017-07-12T14:30:00.000Z",
     "end": "2017-09-27T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -460,22 +319,12 @@
       {
         "site": "bilibili",
         "id": "6339",
-        "begin": "2017-07-12T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-12T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "you-zitsu",
-        "begin": "2017-07-18T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-18T16:00:00.000Z"
       }
     ]
   },
@@ -491,7 +340,6 @@
     "officialSite": "http://www.gamers-anime.com/",
     "begin": "2017-07-13T12:00:00.000Z",
     "end": "2017-09-28T12:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -500,42 +348,22 @@
       {
         "site": "bilibili",
         "id": "6340",
-        "begin": "2017-07-14T07:36:24.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-14T07:36:24.000Z"
       },
       {
         "site": "letv",
         "id": "10037717",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "VObSULgejswvrRU",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "gamers-anime",
-        "begin": "2017-07-28T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-28T03:00:00.000Z"
       }
     ]
   },
@@ -551,7 +379,6 @@
     "officialSite": "http://fate-apocrypha.com/",
     "begin": "2017-07-01T15:00:00.000Z",
     "end": "2017-12-30T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -560,22 +387,12 @@
       {
         "site": "bilibili",
         "id": "6301",
-        "begin": "2017-07-01T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T16:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80180849",
-        "begin": "2017-11-07T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-07T08:00:00.000Z"
       }
     ]
   },
@@ -591,7 +408,6 @@
     "officialSite": "http://www.pripri-anime.jp/",
     "begin": "2017-07-09T14:00:00.000Z",
     "end": "2017-09-24T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -600,22 +416,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh8319h",
-        "begin": "2017-07-09T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-09T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "pripri-anime",
-        "begin": "2017-07-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-12T03:00:00.000Z"
       }
     ]
   },
@@ -631,7 +437,6 @@
     "officialSite": "http://miabyss.com/",
     "begin": "2017-07-07T12:30:00.000Z",
     "end": "2017-09-29T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -640,22 +445,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh83bd1",
-        "begin": "2017-07-07T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "miabyss",
-        "begin": "2017-07-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-14T15:00:00.000Z"
       }
     ]
   },
@@ -675,7 +470,6 @@
     "officialSite": "http://katsugeki-touken.com/",
     "begin": "2017-07-01T15:30:00.000Z",
     "end": "2017-09-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -684,32 +478,17 @@
       {
         "site": "bilibili",
         "id": "6302",
-        "begin": "2017-07-01T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T17:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh83a4d",
-        "begin": "2017-07-01T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "katsugeki-touken",
-        "begin": "2017-07-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-06T03:00:00.000Z"
       }
     ]
   },
@@ -725,7 +504,6 @@
     "officialSite": "http://saiyuki-rb.jp/",
     "begin": "2017-07-05T13:00:00.000Z",
     "end": "2017-09-20T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -734,22 +512,12 @@
       {
         "site": "youku",
         "id": "1b36efbfbdefbfbd2a45",
-        "begin": "2017-07-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-05T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "saiyuki_rb",
-        "begin": "2017-07-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-10T15:00:00.000Z"
       }
     ]
   },
@@ -768,41 +536,20 @@
     "officialSite": "http://www.symphogear-axz.com/",
     "begin": "2017-07-01T16:00:00.000Z",
     "end": "2017-09-30T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "163711"
       },
       {
-        "site": "acfun",
-        "id": "1480116",
-        "begin": "2017-07-01T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "pptv",
         "id": "ickMtqxN56SeKCHA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "symphogear-axz",
-        "begin": "2017-07-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-08T03:00:00.000Z"
       }
     ]
   },
@@ -818,7 +565,6 @@
     "officialSite": "http://www.jigokushoujo.com/",
     "begin": "2017-07-14T15:00:00.000Z",
     "end": "2017-09-29T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -827,32 +573,17 @@
       {
         "site": "bilibili",
         "id": "6341",
-        "begin": "2017-07-14T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-14T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh86w5p",
-        "begin": "2017-07-14T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-14T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "jigokushoujo",
-        "begin": "2017-07-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-17T03:00:00.000Z"
       }
     ]
   },
@@ -868,7 +599,6 @@
     "officialSite": "http://www.tenshi-no-3p.com/",
     "begin": "2017-07-10T11:00:00.000Z",
     "end": "2017-09-25T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -877,22 +607,12 @@
       {
         "site": "bilibili",
         "id": "6328",
-        "begin": "2017-07-10T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-10T12:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tenshi-no-3p",
-        "begin": "2017-07-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-17T15:00:00.000Z"
       }
     ]
   },
@@ -911,7 +631,6 @@
     "officialSite": "http://kakegurui-anime.com/",
     "begin": "2017-07-01T13:00:00.000Z",
     "end": "2017-09-23T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -920,22 +639,12 @@
       {
         "site": "youku",
         "id": "5f6aefbfbd7a54efbfbd",
-        "begin": "2017-08-03T02:14:27.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2017-08-03T02:14:27.000Z"
       },
       {
         "site": "netflix",
         "id": "80175351",
-        "begin": "2018-02-01T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-01T08:00:00.000Z"
       }
     ]
   },
@@ -951,41 +660,20 @@
     "officialSite": "http://www.dreamcreation.co.jp/musekinin/",
     "begin": "2017-07-11T12:55:00.000Z",
     "end": "2017-09-26T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "216995"
       },
       {
-        "site": "bilibili",
-        "id": "6331",
-        "begin": "2017-07-13T11:46:38.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "pptv",
         "id": "UOrGRKwSgsAjoQk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "musekinin",
-        "begin": "2017-07-18T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-18T03:00:00.000Z"
       }
     ]
   },
@@ -1001,7 +689,6 @@
     "officialSite": "http://youapa-anime.jp/",
     "begin": "2017-07-03T14:00:00.000Z",
     "end": "2017-12-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1010,42 +697,22 @@
       {
         "site": "bilibili",
         "id": "6308",
-        "begin": "2017-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-03T14:30:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "316347",
-        "begin": "2017-07-03T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-03T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "youapa-anime",
-        "begin": "2017-07-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-05T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "11efbfbd264fefbfbd11",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1061,7 +728,6 @@
     "officialSite": "http://koiuso-anime.com/",
     "begin": "2017-07-03T15:00:00.000Z",
     "end": "2017-09-18T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1070,22 +736,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh83c1p",
-        "begin": "2017-07-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-03T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "koiuso-anime",
-        "begin": "2017-07-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-04T15:30:00.000Z"
       }
     ]
   },
@@ -1101,7 +757,6 @@
     "officialSite": "http://clionenoakari.com/",
     "begin": "2017-07-12T13:30:00.000Z",
     "end": "2017-09-27T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1110,42 +765,22 @@
       {
         "site": "bilibili",
         "id": "6335",
-        "begin": "2017-07-13T07:14:16.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-13T07:14:16.000Z"
       },
       {
         "site": "letv",
         "id": "10037718",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "SicXfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "efbfbd43efbfbd484fef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1161,7 +796,6 @@
     "officialSite": "http://guruguru-anime.jp/",
     "begin": "2017-07-11T16:35:00.000Z",
     "end": "2017-12-19T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1170,32 +804,17 @@
       {
         "site": "bilibili",
         "id": "6332",
-        "begin": "2017-07-11T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-11T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbdefbfbdefbfbd2a",
-        "begin": "2017-07-11T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-11T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh86xb9",
-        "begin": "2017-07-11T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-11T17:35:00.000Z"
       }
     ]
   },
@@ -1211,7 +830,6 @@
     "officialSite": "http://kisekichosakan.jp/",
     "begin": "2017-07-07T13:30:00.000Z",
     "end": "2017-09-22T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1220,22 +838,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh830il",
-        "begin": "2017-07-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kisekichosakan",
-        "begin": "2017-07-19T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-19T14:30:00.000Z"
       }
     ]
   },
@@ -1251,31 +859,15 @@
     "officialSite": "http://anime-ikemen-sengoku.jp/",
     "begin": "2017-07-12T13:10:00.000Z",
     "end": "2017-09-27T13:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "197200"
       },
       {
-        "site": "acfun",
-        "id": "1480115",
-        "begin": "2017-07-12T13:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "ikemen-sengoku",
-        "begin": "2017-07-12T13:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-12T13:10:00.000Z"
       }
     ]
   },
@@ -1294,7 +886,6 @@
     "officialSite": "http://chronosruler.jp/",
     "begin": "2017-07-07T15:30:00.000Z",
     "end": "2017-09-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1303,32 +894,17 @@
       {
         "site": "mgtv",
         "id": "312408",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "dbbd5607c5ca11e68ce4",
-        "begin": "2017-07-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "chronosruler",
-        "begin": "2017-07-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-12T03:00:00.000Z"
       }
     ]
   },
@@ -1344,7 +920,6 @@
     "officialSite": "http://skirt.w-anime.com/",
     "begin": "2017-07-02T16:00:00.000Z",
     "end": "2017-09-17T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1353,22 +928,12 @@
       {
         "site": "pptv",
         "id": "Az0Xlf1j0xF08lo",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "skirt-w-anime",
-        "begin": "2017-12-22T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-22T09:00:00.000Z"
       }
     ]
   },
@@ -1385,7 +950,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yamishibai/",
     "begin": "2017-07-02T18:30:00.000Z",
     "end": "2017-10-01T19:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1394,42 +958,22 @@
       {
         "site": "bilibili",
         "id": "6346",
-        "begin": "2017-07-02T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-02T19:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh83cnx",
-        "begin": "2017-07-02T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-02T19:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbdefbfbd285c5b08",
-        "begin": "2017-07-02T19:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-02T19:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yamishibai5",
-        "begin": "2017-07-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-03T03:00:00.000Z"
       }
     ]
   },
@@ -1445,41 +989,20 @@
     "officialSite": "http://7o3x.com/",
     "begin": "2017-07-04T16:59:00.000Z",
     "end": "2017-09-19T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "203010"
       },
       {
-        "site": "acfun",
-        "id": "1480113",
-        "begin": "2017-07-04T18:11:26.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "pptv",
         "id": "LxH7eeFHticVY1j4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "7o3x_anime",
-        "begin": "2017-07-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-05T03:00:00.000Z"
       }
     ]
   },
@@ -1495,41 +1018,20 @@
     "officialSite": "http://netsuzoutrap.com/",
     "begin": "2017-07-05T11:00:00.000Z",
     "end": "2017-09-20T11:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "198099"
       },
       {
-        "site": "bilibili",
-        "id": "6314",
-        "begin": "2017-07-05T12:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
         "site": "youku",
         "id": "3cefbfbd37efbfbd5bef",
-        "begin": "2017-07-05T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-05T12:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "netsuzoutrap",
-        "begin": "2017-07-05T18:40:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-05T18:40:00.000Z"
       }
     ]
   },
@@ -1545,7 +1047,6 @@
     "officialSite": "http://www.dive-anime.com/",
     "begin": "2017-07-06T15:55:00.000Z",
     "end": "2017-09-21T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1554,12 +1055,7 @@
       {
         "site": "youku",
         "id": "0befbfbd27efbfbd4fef",
-        "begin": "2017-07-06T18:55:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-06T18:55:00.000Z"
       }
     ]
   },
@@ -1575,7 +1071,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/konbini/",
     "begin": "2017-07-06T17:00:00.000Z",
     "end": "2017-09-28T17:28:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1584,42 +1079,17 @@
       {
         "site": "letv",
         "id": "10037659",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "LQicpZ881peNGxCw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "6317",
-        "begin": "2017-07-09T03:18:21.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "konbini",
-        "begin": "2017-07-06T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-06T21:00:00.000Z"
       }
     ]
   },
@@ -1635,31 +1105,15 @@
     "officialSite": "http://www.tbs.co.jp/anime/cfru/",
     "begin": "2017-07-06T17:30:00.000Z",
     "end": "2017-09-28T17:58:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "204483"
       },
       {
-        "site": "acfun",
-        "id": "1480114",
-        "begin": "2017-07-06T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "cfru",
-        "begin": "2017-07-06T22:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-06T22:00:00.000Z"
       }
     ]
   },
@@ -1676,7 +1130,6 @@
     "officialSite": "http://18if.jp/",
     "begin": "2017-07-07T13:00:00.000Z",
     "end": "2017-09-29T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1685,52 +1138,27 @@
       {
         "site": "bilibili",
         "id": "6319",
-        "begin": "2017-07-07T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "18if",
-        "begin": "2017-07-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-08T15:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2018/18ifmjywl",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhdi46l",
-        "begin": "2018-04-30T16:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-30T16:00:10.000Z"
       },
       {
         "site": "youku",
         "id": "71efbfbd32665eefbfbd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1746,51 +1174,25 @@
     "officialSite": "http://www.hitorijime-myhero.com/",
     "begin": "2017-07-08T16:30:00.000Z",
     "end": "2017-09-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "186908"
       },
       {
-        "site": "bilibili",
-        "id": "6324",
-        "begin": "2017-07-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "youku",
         "id": "efbfbdefbfbd293d4fef",
-        "begin": "2017-07-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-08T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh86wot",
-        "begin": "2017-07-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-08T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hitorijime-myhero",
-        "begin": "2017-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-14T16:00:00.000Z"
       }
     ]
   },
@@ -1807,7 +1209,6 @@
     "officialSite": "http://centaur-anime.com/",
     "begin": "2017-07-09T13:00:00.000Z",
     "end": "2017-09-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1816,32 +1217,17 @@
       {
         "site": "bilibili",
         "id": "6326",
-        "begin": "2017-07-09T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-09T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "centaur",
-        "begin": "2017-07-18T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-18T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd3b21c385efbfbd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1861,7 +1247,6 @@
     "officialSite": "http://isesuma-anime.jp/",
     "begin": "2017-07-11T11:30:00.000Z",
     "end": "2017-09-26T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1870,22 +1255,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh832wl",
-        "begin": "2017-07-11T12:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-11T12:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "isesuma-anime",
-        "begin": "2017-07-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-13T15:00:00.000Z"
       }
     ]
   },
@@ -1901,7 +1276,6 @@
     "officialSite": "http://kaitoansa.com/",
     "begin": "2017-07-12T11:10:00.000Z",
     "end": "2017-09-27T11:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1910,42 +1284,22 @@
       {
         "site": "bilibili",
         "id": "6376",
-        "begin": "2017-07-14T10:33:12.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-14T10:33:12.000Z"
       },
       {
         "site": "pptv",
         "id": "UevFQ6sRgb8iaoAg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "kaitoansa",
-        "begin": "2017-07-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-13T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "10efbfbd3cefbfbd61ef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1961,7 +1315,6 @@
     "officialSite": "http://enmusuyouko.com/",
     "begin": "2017-07-01T12:00:00.000Z",
     "end": "2017-12-16T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1970,82 +1323,42 @@
       {
         "site": "bilibili",
         "id": "6353",
-        "begin": "2017-07-01T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh83gpp",
-        "begin": "2017-07-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T03:00:00.000Z"
       },
       {
         "site": "letv",
         "id": "10037541",
-        "begin": "2017-07-01T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T02:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "316372",
-        "begin": "2017-07-01T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T02:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "ibEErqRF35yWIBm4",
-        "begin": "2017-07-01T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "q/qzmn289abuigokp",
-        "begin": "2017-07-01T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T02:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2017/dhphyxhnryb",
-        "begin": "2017-07-01T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-01T02:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "enmusuyouko",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2061,7 +1374,6 @@
     "officialSite": "http://nora-anime.net/",
     "begin": "2017-07-12T13:45:00.000Z",
     "end": "2017-09-27T13:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2070,62 +1382,32 @@
       {
         "site": "bilibili",
         "id": "6349",
-        "begin": "2017-07-13T07:10:44.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-13T07:10:44.000Z"
       },
       {
         "site": "pptv",
         "id": "RffhX8ctndsibvCQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "nora-anime",
-        "begin": "2017-07-12T13:45:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-12T13:45:00.000Z"
       },
       {
         "site": "letv",
         "id": "10037767",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhv11q5",
-        "begin": "2019-01-15T01:26:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-15T01:26:25.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd3aefbfbd6c5eef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2145,7 +1427,6 @@
     "officialSite": "http://newgame-anime.com/",
     "begin": "2017-07-11T12:30:00.000Z",
     "end": "2017-09-26T12:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2154,62 +1435,32 @@
       {
         "site": "bilibili",
         "id": "6330",
-        "begin": "2017-07-11T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-11T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh876x1",
-        "begin": "2017-07-11T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-11T14:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2018/dhpnewgame2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "newgame2",
-        "begin": "2017-07-18T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-18T15:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "t/t2n662xtx8gef1h",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "efbfbd3e6aefbfbd4fef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2225,51 +1476,25 @@
     "officialSite": "http://thereflection-anime.net/",
     "begin": "2017-07-22T14:00:00.000Z",
     "end": "2017-10-07T14:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "151974"
       },
       {
-        "site": "bilibili",
-        "id": "6343",
-        "begin": "2017-07-25T13:19:31.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
-      },
-      {
         "site": "iqiyi",
         "id": "a_19rrhdttcl",
-        "begin": "2017-08-07T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-07T12:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "317263",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "thereflection-anime",
-        "begin": "2017-07-22T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-22T16:30:00.000Z"
       }
     ]
   },
@@ -2281,7 +1506,6 @@
     "officialSite": "http://shadowoflaffandor.com/",
     "begin": "2017-07-12T13:50:00.000Z",
     "end": "2017-09-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2290,12 +1514,7 @@
       {
         "site": "pptv",
         "id": "UuzIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2311,7 +1530,6 @@
     "officialSite": "http://te-kyu.com/",
     "begin": "2017-07-12T13:40:00.000Z",
     "end": "2017-09-27T13:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2320,22 +1538,12 @@
       {
         "site": "bilibili",
         "id": "6337",
-        "begin": "2017-07-12T13:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-12T13:40:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "te-kyu09",
-        "begin": "2017-07-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-13T03:00:00.000Z"
       }
     ]
   },
@@ -2351,7 +1559,6 @@
     "officialSite": "https://ganma.jp/musamura",
     "begin": "2017-07-10T16:00:00.000Z",
     "end": "2017-07-10T16:01:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2360,12 +1567,7 @@
       {
         "site": "pptv",
         "id": "Qic3XVb0jk9E0sho",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2381,7 +1583,6 @@
     "officialSite": "http://avex.jp/piko-lullaby/",
     "begin": "2017-07-17T01:48:00.000Z",
     "end": "2017-09-27T01:51:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2390,32 +1591,17 @@
       {
         "site": "bilibili",
         "id": "6378",
-        "begin": "2017-07-19T02:38:52.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-19T02:38:52.000Z"
       },
       {
         "site": "pptv",
         "id": "WibXPTbUbia8ksqhI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "piko-lullaby",
-        "begin": "2017-07-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-16T15:00:00.000Z"
       }
     ]
   },
@@ -2434,31 +1620,15 @@
     "officialSite": "http://dlife.disney.co.jp/program/marvel_starwars/future_avengers.html",
     "begin": "2017-07-21T23:00:00.000Z",
     "end": "2018-01-19T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "210324"
       },
       {
-        "site": "bilibili",
-        "id": "6342",
-        "begin": "2017-07-27T08:17:45.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "pptv",
         "id": "sIpm5EyyImDDQak",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2470,7 +1640,6 @@
     "officialSite": "http://www.ktv.jp/yurayura/",
     "begin": "2017-07-23T20:04:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2486,7 +1655,6 @@
     "officialSite": "http://www.seizeiganbare.jp/",
     "begin": "2017-07-29T15:00:00.000Z",
     "end": "2018-07-15T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2495,12 +1663,7 @@
       {
         "site": "nicovideo",
         "id": "seizeiganbare",
-        "begin": "2017-08-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-12T03:00:00.000Z"
       }
     ]
   },
@@ -2516,7 +1679,6 @@
     "officialSite": "http://king-cr.jp/special/seitokai_G/",
     "begin": "2017-07-21T16:00:00.000Z",
     "end": "2017-07-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2525,12 +1687,7 @@
       {
         "site": "nicovideo",
         "id": "seitokai_G",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2546,7 +1703,6 @@
     "officialSite": "http://maryflower.jp",
     "begin": "2017-07-08T16:00:00.000Z",
     "end": "2017-07-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2555,12 +1711,7 @@
       {
         "site": "nicovideo",
         "id": "maryflower",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2576,7 +1727,6 @@
     "officialSite": "http://yuyuyu.tv/washio/",
     "begin": "2017-07-08T16:00:00.000Z",
     "end": "2017-07-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2585,12 +1735,7 @@
       {
         "site": "pptv",
         "id": "KAicpZ881peNGxCw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2606,7 +1751,6 @@
     "officialSite": "https://www.netflix.com/title/80095241",
     "begin": "2017-07-07T07:00:00.000Z",
     "end": "2017-07-07T07:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2615,12 +1759,7 @@
       {
         "site": "netflix",
         "id": "80095241",
-        "begin": "2017-07-07T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-07T07:00:00.000Z"
       }
     ]
   },
@@ -2636,7 +1775,6 @@
     "officialSite": "http://tm.iwatobi-sc.com/",
     "begin": "2017-07-01T16:00:00.000Z",
     "end": "2017-07-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2645,12 +1783,7 @@
       {
         "site": "nicovideo",
         "id": "free-tm-movie",
-        "begin": "2018-07-01T06:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-01T06:00:00.000Z"
       }
     ]
   },
@@ -2666,7 +1799,6 @@
     "officialSite": "http://ngnl.jp/",
     "begin": "2017-07-15T16:00:00.000Z",
     "end": "2017-07-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2675,12 +1807,7 @@
       {
         "site": "nicovideo",
         "id": "ngnl-zero",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2017/08.json
+++ b/data/items/2017/08.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.monogatari-series.com/owarimonogatari/",
     "begin": "2017-08-12T11:00:00.000Z",
     "end": "2017-08-13T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "bilibili",
         "id": "6345",
-        "begin": "2017-08-12T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-12T12:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "owarimonogatari2",
-        "begin": "2018-10-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-31T15:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://project-algorhythm.com/",
     "begin": "2017-08-17T16:00:00.000Z",
     "end": "2017-10-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,22 +48,12 @@
       {
         "site": "nicovideo",
         "id": "project-algorhythm",
-        "begin": "2017-08-24T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-24T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhd9rlx",
-        "begin": "2017-09-08T06:55:18.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-09-08T06:55:18.000Z"
       }
     ]
   },
@@ -87,7 +65,6 @@
     "officialSite": "http://kofd.snkchina.com.cn/",
     "begin": "2017-08-03T16:00:00.000Z",
     "end": "2018-01-11T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -96,12 +73,7 @@
       {
         "site": "mgtv",
         "id": "317083",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -117,7 +89,6 @@
     "officialSite": "http://boueibu.com/",
     "begin": "2017-08-26T16:00:00.000Z",
     "end": "2017-08-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -126,32 +97,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1ugkd",
-        "begin": "2017-11-14T15:55:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-14T15:55:14.000Z"
       },
       {
         "site": "nicovideo",
         "id": "boueibu_LLL",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "20320",
-        "begin": "2017-11-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8232",
+        "begin": "2017-11-14T16:00:00.000Z"
       }
     ]
   },
@@ -167,7 +123,6 @@
     "officialSite": "",
     "begin": "2017-08-26T16:00:00.000Z",
     "end": "2017-08-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -176,12 +131,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhcx3xx",
-        "begin": "2017-08-27T08:38:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-08-27T08:38:21.000Z"
       }
     ]
   }

--- a/data/items/2017/09.json
+++ b/data/items/2017/09.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "2017-09-13T16:00:00.000Z",
     "end": "2017-09-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,42 +19,22 @@
       {
         "site": "mgtv",
         "id": "322697",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "j/jodsh3q8h6lulgl",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "letv",
         "id": "10038142",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "efbfbdd398efbfbdefbf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -71,7 +50,6 @@
     "officialSite": "http://digimon-adventure.net/",
     "begin": "2017-09-30T16:00:00.000Z",
     "end": "2017-09-30T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,22 +58,12 @@
       {
         "site": "nicovideo",
         "id": "digimon-adventure-tri05",
-        "begin": "2018-06-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-06-01T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd42efbfbd6defbf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -111,7 +79,6 @@
     "officialSite": "http://eurekaseven.jp/",
     "begin": "2017-09-16T16:00:00.000Z",
     "end": "2017-09-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -120,12 +87,7 @@
       {
         "site": "nicovideo",
         "id": "eurekaseven-hievolution1",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2017/10.json
+++ b/data/items/2017/10.json
@@ -11,7 +11,6 @@
     "officialSite": "http://imas-sidem.com/",
     "begin": "2017-10-07T14:30:00.000Z",
     "end": "2017-12-30T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,42 +19,22 @@
       {
         "site": "bilibili",
         "id": "6431",
-        "begin": "2017-10-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T15:30:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "318665",
-        "begin": "2017-10-07T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "imas-sidem",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "k/kgtpesoq4702ck5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -71,7 +50,6 @@
     "officialSite": "http://imotosae.com/",
     "begin": "2017-10-08T13:30:00.000Z",
     "end": "2017-12-24T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,22 +58,12 @@
       {
         "site": "bilibili",
         "id": "6440",
-        "begin": "2017-10-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "imotosae",
-        "begin": "2017-10-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-11T03:00:00.000Z"
       }
     ]
   },
@@ -107,7 +75,6 @@
     "officialSite": "http://justbecause.jp/",
     "begin": "2017-10-05T12:00:00.000Z",
     "end": "2017-12-28T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -116,32 +83,17 @@
       {
         "site": "bilibili",
         "id": "6427",
-        "begin": "2017-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-05T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "q5SAicmbMPHrdW8M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "justbecause",
-        "begin": "2017-10-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-14T03:00:00.000Z"
       }
     ]
   },
@@ -158,7 +110,6 @@
     "officialSite": "http://konohanatei.jp/",
     "begin": "2017-10-04T11:00:00.000Z",
     "end": "2017-12-20T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -167,52 +118,27 @@
       {
         "site": "bilibili",
         "id": "6425",
-        "begin": "2017-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcafct",
-        "begin": "2017-10-04T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "ibEIurBR66iaiaLCXE",
-        "begin": "2017-10-04T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "konohanatei",
-        "begin": "2017-10-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "1d78d0b3efbfbd2f11ef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -231,7 +157,6 @@
     "officialSite": "http://netoju.com/",
     "begin": "2017-10-09T16:40:00.000Z",
     "end": "2017-12-11T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -240,22 +165,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhcb5fp",
-        "begin": "2017-10-06T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "netoju",
-        "begin": "2017-10-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T15:30:00.000Z"
       }
     ]
   },
@@ -272,31 +187,15 @@
     "officialSite": "http://majimesugiru-anime.jp/",
     "begin": "2017-10-11T15:30:00.000Z",
     "end": "2017-12-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "216570"
       },
       {
-        "site": "bilibili",
-        "id": "6465",
-        "begin": "2017-10-11T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "majimesugiru",
-        "begin": "2017-10-20T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-20T16:00:00.000Z"
       }
     ]
   },
@@ -312,7 +211,6 @@
     "officialSite": "http://uqholder.jp/",
     "begin": "2017-10-02T15:00:00.000Z",
     "end": "2017-12-18T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -321,22 +219,12 @@
       {
         "site": "bilibili",
         "id": "6418",
-        "begin": "2017-10-02T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-02T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "uqholder",
-        "begin": "2017-10-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T03:00:00.000Z"
       }
     ]
   },
@@ -355,71 +243,35 @@
     "officialSite": "http://anime.senbura.jp/",
     "begin": "2017-10-03T14:00:00.000Z",
     "end": "2017-12-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "211994"
       },
       {
-        "site": "acfun",
-        "id": "1480145",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "bilibili",
         "id": "6449",
-        "begin": "2017-10-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "383fefbfbd14efbfbd17",
-        "begin": "2017-10-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh85bp9",
-        "begin": "2017-10-03T14:55:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T14:55:07.000Z"
       },
       {
         "site": "pptv",
         "id": "a9TAPqYMfLodmwM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "anime_senbura",
-        "begin": "2017-10-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T15:00:00.000Z"
       }
     ]
   },
@@ -435,7 +287,6 @@
     "officialSite": "http://www.osakefufu-anime.jp/",
     "begin": "2017-10-03T16:00:00.000Z",
     "end": "2017-12-26T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -444,12 +295,7 @@
       {
         "site": "bilibili",
         "id": "6423",
-        "begin": "2017-10-03T16:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T16:05:00.000Z"
       }
     ]
   },
@@ -465,7 +311,6 @@
     "officialSite": "http://cingeki-anime.com/",
     "begin": "2017-10-03T12:54:00.000Z",
     "end": "2017-12-26T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -474,22 +319,12 @@
       {
         "site": "bilibili",
         "id": "6424",
-        "begin": "2017-10-03T12:54:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T12:54:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "cingeki-anime02",
-        "begin": "2017-10-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T03:00:00.000Z"
       }
     ]
   },
@@ -505,7 +340,6 @@
     "officialSite": "http://12taisen.com/",
     "begin": "2017-10-03T17:30:00.000Z",
     "end": "2017-12-19T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -514,22 +348,12 @@
       {
         "site": "bilibili",
         "id": "6420",
-        "begin": "2017-10-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "12taisen",
-        "begin": "2017-10-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-09T03:00:00.000Z"
       }
     ]
   },
@@ -541,7 +365,6 @@
     "officialSite": "http://tsukipro-anime.com/",
     "begin": "2017-10-04T13:30:00.000Z",
     "end": "2017-12-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -550,22 +373,12 @@
       {
         "site": "bilibili",
         "id": "6453",
-        "begin": "2017-10-04T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tsukipro-anime",
-        "begin": "2017-10-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T16:00:00.000Z"
       }
     ]
   },
@@ -581,7 +394,6 @@
     "officialSite": "http://girls-last-tour.com/",
     "begin": "2017-10-06T13:30:00.000Z",
     "end": "2017-12-22T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -590,22 +402,12 @@
       {
         "site": "bilibili",
         "id": "6463",
-        "begin": "2017-10-06T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "girls-last-tour",
-        "begin": "2017-10-13T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-13T13:30:00.000Z"
       }
     ]
   },
@@ -621,7 +423,6 @@
     "officialSite": "http://omitsuyo.w-anime.com/",
     "begin": "2017-10-01T16:00:00.000Z",
     "end": "2017-12-17T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -630,12 +431,7 @@
       {
         "site": "nicovideo",
         "id": "omitsuyo-w-anime",
-        "begin": "2017-10-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-13T03:00:00.000Z"
       }
     ]
   },
@@ -652,7 +448,6 @@
     "officialSite": "http://rainycocoa.jp/anime/",
     "begin": "2017-10-04T13:25:00.000Z",
     "end": "2017-12-20T13:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -661,22 +456,12 @@
       {
         "site": "bilibili",
         "id": "6476",
-        "begin": "2017-10-04T15:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T15:25:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "rainycocoa4",
-        "begin": "2017-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -695,51 +480,25 @@
     "officialSite": "http://www.lovelive-anime.jp/uranohoshi/",
     "begin": "2017-10-07T13:30:00.000Z",
     "end": "2017-12-30T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "210272"
       },
       {
-        "site": "acfun",
-        "id": "1480158",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "bilibili",
         "id": "6433",
-        "begin": "2017-10-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "uranohoshi02",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "eca3b966efbfbdefbfbd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -756,7 +515,6 @@
     "officialSite": "http://www.kinonotabi-anime.com/",
     "begin": "2017-10-06T15:30:00.000Z",
     "end": "2017-12-22T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -765,22 +523,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhca411",
-        "begin": "2017-10-06T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kinonotabi-AS",
-        "begin": "2017-10-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-13T15:30:00.000Z"
       }
     ]
   },
@@ -796,7 +544,6 @@
     "officialSite": "http://vanishing-line.jp/",
     "begin": "2017-10-06T16:23:00.000Z",
     "end": "2018-03-30T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -805,52 +552,27 @@
       {
         "site": "bilibili",
         "id": "6468",
-        "begin": "2017-10-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T16:00:01.000Z"
       },
       {
         "site": "letv",
         "id": "10038684",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "NgnjYckvn91AviaY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "vanishing-line",
-        "begin": "2017-10-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "4aefbfbdefbfbd54efbf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -866,7 +588,6 @@
     "officialSite": "http://land-of-the-lustrous.com/",
     "begin": "2017-10-07T13:00:00.000Z",
     "end": "2017-12-23T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -875,22 +596,12 @@
       {
         "site": "bilibili",
         "id": "6434",
-        "begin": "2017-10-07T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "land-of-the-lustrous",
-        "begin": "2017-10-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T15:00:00.000Z"
       }
     ]
   },
@@ -906,7 +617,6 @@
     "officialSite": "http://mahoyome.jp/",
     "begin": "2017-10-07T16:30:00.000Z",
     "end": "2018-03-23T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -915,42 +625,22 @@
       {
         "site": "bilibili",
         "id": "6438",
-        "begin": "2017-10-07T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T17:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbdd6a653efbfbd19",
-        "begin": "2017-10-07T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T17:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcbanh",
-        "begin": "2017-10-07T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T17:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "mahoyome",
-        "begin": "2017-10-12T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-12T15:30:00.000Z"
       }
     ]
   },
@@ -966,7 +656,6 @@
     "officialSite": "http://www.hozukino-reitetsu.com/",
     "begin": "2017-10-07T16:00:00.000Z",
     "end": "2017-12-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -975,22 +664,12 @@
       {
         "site": "bilibili",
         "id": "6447",
-        "begin": "2017-10-07T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T17:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hozukino-reitetsu2",
-        "begin": "2017-10-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T03:00:00.000Z"
       }
     ]
   },
@@ -1010,7 +689,6 @@
     "officialSite": "http://kujisuna-anime.com/",
     "begin": "2017-10-08T14:00:00.000Z",
     "end": "2017-12-24T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1019,32 +697,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhcbehh",
-        "begin": "2017-10-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T15:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80174917",
-        "begin": "2018-03-13T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-13T07:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kujisuna-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1060,7 +723,6 @@
     "officialSite": "http://blend-s.jp/",
     "begin": "2017-10-07T15:30:00.000Z",
     "end": "2017-12-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1069,42 +731,22 @@
       {
         "site": "bilibili",
         "id": "6432",
-        "begin": "2017-10-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T17:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcb365",
-        "begin": "2017-10-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T17:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "8EkjoQlv3x2AicmY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "blend-s",
-        "begin": "2017-10-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T03:00:00.000Z"
       }
     ]
   },
@@ -1120,41 +762,20 @@
     "officialSite": "http://twocartv.jp/",
     "begin": "2017-10-09T15:30:00.000Z",
     "end": "2017-12-23T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "220848"
       },
       {
-        "site": "acfun",
-        "id": "1480151",
-        "begin": "2017-10-09T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "pptv",
         "id": "FCcRjicddzQtu7FQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "twocar",
-        "begin": "2017-10-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-12T16:00:00.000Z"
       }
     ]
   },
@@ -1170,7 +791,6 @@
     "officialSite": "http://coderealize-anime.com/",
     "begin": "2017-10-08T16:35:00.000Z",
     "end": "2017-12-23T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1179,22 +799,12 @@
       {
         "site": "bilibili",
         "id": "6435",
-        "begin": "2017-10-07T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T12:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "coderealize-anime",
-        "begin": "2017-10-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-09T15:00:00.000Z"
       }
     ]
   },
@@ -1210,7 +820,6 @@
     "officialSite": "http://umaru-ani.me/",
     "begin": "2017-10-08T15:00:00.000Z",
     "end": "2017-12-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1219,22 +828,12 @@
       {
         "site": "bilibili",
         "id": "6446",
-        "begin": "2017-10-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "umarur-anime",
-        "begin": "2017-10-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-11T15:00:00.000Z"
       }
     ]
   },
@@ -1246,7 +845,6 @@
     "officialSite": "http://www.infini-tforce.com/",
     "begin": "2017-10-02T17:44:00.000Z",
     "end": "2017-12-25T18:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1255,42 +853,22 @@
       {
         "site": "bilibili",
         "id": "6452",
-        "begin": "2017-10-03T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T17:35:00.000Z"
       },
       {
         "site": "pptv",
         "id": "KBP9eibNJufda2EA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "infini-tforce",
-        "begin": "2017-10-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "51efbfbd2cd58b1411ef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1306,7 +884,6 @@
     "officialSite": "http://mogol-girl.com/",
     "begin": "2017-10-02T16:05:00.000Z",
     "end": "2017-12-18T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1315,42 +892,22 @@
       {
         "site": "bilibili",
         "id": "6479",
-        "begin": "2017-10-02T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-02T17:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd594c76efbfbdef",
-        "begin": "2017-10-02T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-02T17:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcbbj9",
-        "begin": "2017-10-02T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-02T17:05:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "mogol-girl",
-        "begin": "2017-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -1370,7 +927,6 @@
     "officialSite": "http://kekkaisensen.com/",
     "begin": "2017-10-07T18:08:00.000Z",
     "end": "2017-12-23T18:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1379,52 +935,27 @@
       {
         "site": "bilibili",
         "id": "6439",
-        "begin": "2017-10-07T19:08:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T19:08:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcbd71",
-        "begin": "2017-10-07T19:08:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T19:08:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "318666",
-        "begin": "2017-10-07T19:08:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T19:08:00.000Z"
       },
       {
         "site": "qq",
         "id": "n/nubvtawpmjjgvu7",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "kekkaisensen-beyond",
-        "begin": "2017-10-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-11T03:00:00.000Z"
       }
     ]
   },
@@ -1441,7 +972,6 @@
     "officialSite": "http://yuyuyu.tv/",
     "begin": "2017-10-06T16:55:00.000Z",
     "end": "2018-01-05T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1450,22 +980,12 @@
       {
         "site": "bilibili",
         "id": "6448",
-        "begin": "2017-10-06T19:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T19:25:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yuyuyu_tv02",
-        "begin": "2017-11-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-20T15:00:00.000Z"
       }
     ]
   },
@@ -1485,7 +1005,6 @@
     "officialSite": "http://3lion-anime.com/",
     "begin": "2017-10-14T14:00:00.000Z",
     "end": "2018-03-31T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1494,42 +1013,22 @@
       {
         "site": "bilibili",
         "id": "6445",
-        "begin": "2017-10-14T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-14T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcbdg5",
-        "begin": "2017-10-14T16:25:17.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-14T16:25:17.000Z"
       },
       {
         "site": "nicovideo",
         "id": "3lion-anime2",
-        "begin": "2018-04-24T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-24T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "76efbfbdefbfbdd18618",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1548,81 +1047,40 @@
     "officialSite": "http://animegataris.com/",
     "begin": "2017-10-08T13:00:00.000Z",
     "end": "2017-12-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "213329"
       },
       {
-        "site": "acfun",
-        "id": "1480153",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "bilibili",
         "id": "6441",
-        "begin": "2017-10-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T14:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd08efbfbd5e4611",
-        "begin": "2017-10-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcbck5",
-        "begin": "2017-10-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T14:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "x/xva6h38vn2qiy2w",
-        "begin": "2017-10-08T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "animegataris",
-        "begin": "2017-10-08T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T13:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "326098",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1639,71 +1097,35 @@
     "officialSite": "http://osomatsusan.com/",
     "begin": "2017-10-02T16:35:00.000Z",
     "end": "2018-03-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "212609"
       },
       {
-        "site": "acfun",
-        "id": "1480143",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "bilibili",
         "id": "6421",
-        "begin": "2017-10-02T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-02T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "e49c9defbfbd5911efbf",
-        "begin": "2017-10-02T17:35:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-02T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhcangd",
-        "begin": "2017-10-02T17:30:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-02T17:30:07.000Z"
       },
       {
         "site": "pptv",
         "id": "rY5q6FC2JmTHRa0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "osomatsusan2",
-        "begin": "2017-10-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T15:00:00.000Z"
       }
     ]
   },
@@ -1722,7 +1144,6 @@
     "officialSite": "http://www.classicaloid.net/",
     "begin": "2017-10-07T08:35:00.000Z",
     "end": "2018-03-24T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1731,12 +1152,7 @@
       {
         "site": "bilibili",
         "id": "6454",
-        "begin": "2017-10-07T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T11:00:00.000Z"
       }
     ]
   },
@@ -1756,71 +1172,35 @@
     "officialSite": "http://bclover.jp/",
     "begin": "2017-10-03T09:25:00.000Z",
     "end": "2018-09-25T09:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "202880"
       },
       {
-        "site": "acfun",
-        "id": "1480144",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "bilibili",
         "id": "6422",
-        "begin": "2017-10-03T10:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T10:25:00.000Z"
       },
       {
         "site": "youku",
         "id": "cf863914efbfbdefbfbd",
-        "begin": "2017-10-03T10:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T10:25:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhek9x9",
-        "begin": "2017-10-03T10:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T10:25:00.000Z"
       },
       {
         "site": "pptv",
         "id": "maKODHTaSojradE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "bclover",
-        "begin": "2017-10-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T15:00:00.000Z"
       }
     ]
   },
@@ -1837,7 +1217,6 @@
     "officialSite": "http://www.shokugekinosoma.com/",
     "begin": "2017-10-03T15:30:00.000Z",
     "end": "2017-12-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1846,22 +1225,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhcadk5",
-        "begin": "2017-10-03T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "mqWPDXXbS4nsatI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1873,7 +1242,6 @@
     "officialSite": "http://urahara.party/",
     "begin": "2017-10-05T13:00:00.000Z",
     "end": "2017-12-21T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1882,32 +1250,17 @@
       {
         "site": "bilibili",
         "id": "6474",
-        "begin": "2017-10-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-04T11:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "o5x49l7ENHLVU7s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "urahara",
-        "begin": "2017-10-11T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-11T13:30:00.000Z"
       }
     ]
   },
@@ -1923,7 +1276,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/pingu/",
     "begin": "2017-10-07T00:20:00.000Z",
     "end": "2018-03-31T00:27:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1943,7 +1295,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/gintama/",
     "begin": "2017-10-01T17:05:00.000Z",
     "end": "2017-12-24T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1952,22 +1303,12 @@
       {
         "site": "youku",
         "id": "1c7c632aefbfbdefbfbd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "6FM9uyOJibTeaGIA",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1983,7 +1324,6 @@
     "officialSite": "http://kingsgame-anime.com/",
     "begin": "2017-10-05T14:30:00.000Z",
     "end": "2017-12-21T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1991,23 +1331,13 @@
       },
       {
         "site": "bilibili",
-        "id": "6426",
-        "begin": "2017-10-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "10592",
+        "begin": "2017-10-05T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kingsgame",
-        "begin": "2017-10-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T15:00:00.000Z"
       }
     ]
   },
@@ -2023,7 +1353,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/DC/",
     "begin": "2017-10-05T16:58:00.000Z",
     "end": "2017-12-21T17:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2032,32 +1361,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhca1a5",
-        "begin": "2017-10-05T23:58:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-05T23:58:00.000Z"
       },
       {
         "site": "pptv",
         "id": "JRYCgOhOvvxf3UU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "dynamic-chord",
-        "begin": "2017-10-05T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-05T21:00:00.000Z"
       }
     ]
   },
@@ -2073,7 +1387,6 @@
     "officialSite": "http://anime.dream-fes.com/",
     "begin": "2017-10-06T13:00:00.000Z",
     "end": "2017-12-22T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2093,7 +1406,6 @@
     "officialSite": "http://wakeupgirls3.jp/",
     "begin": "2017-10-09T17:05:00.000Z",
     "end": "2018-01-07T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2102,52 +1414,27 @@
       {
         "site": "bilibili",
         "id": "6442",
-        "begin": "2017-10-09T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-09T18:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhca8w5",
-        "begin": "2017-10-09T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-09T18:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd03efbfbd2b2a4a",
-        "begin": "2017-10-09T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-09T18:05:00.000Z"
       },
       {
         "site": "pptv",
         "id": "rI9p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "wakeupgirls3",
-        "begin": "2017-10-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-12T15:00:00.000Z"
       }
     ]
   },
@@ -2163,61 +1450,30 @@
     "officialSite": "http://love-kome.com/",
     "begin": "2017-10-07T14:30:00.000Z",
     "end": "2017-12-23T14:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "218383"
       },
       {
-        "site": "acfun",
-        "id": "1480156",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "bilibili",
         "id": "6478",
-        "begin": "2017-10-08T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T17:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd75efbfbd47efbf",
-        "begin": "2017-10-08T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T17:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "318660",
-        "begin": "2017-10-08T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "love-kome02",
-        "begin": "2017-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -2233,7 +1489,6 @@
     "officialSite": "http://diesirae-anime.com/",
     "begin": "2017-10-06T16:05:00.000Z",
     "end": "2017-12-22T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2242,42 +1497,22 @@
       {
         "site": "bilibili",
         "id": "6430",
-        "begin": "2017-10-06T17:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T17:05:00.000Z"
       },
       {
         "site": "pptv",
         "id": "CDQgngZs3Bp9ib2M",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "q/qh4142yzut75cd0",
-        "begin": "2017-10-06T17:00:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-06T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "diesirae-anime",
-        "begin": "2017-10-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-11T15:00:00.000Z"
       }
     ]
   },
@@ -2293,41 +1528,20 @@
     "officialSite": "http://mebius-anime.com/",
     "begin": "2017-10-06T12:54:00.000Z",
     "end": "2017-12-22T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "198707"
       },
       {
-        "site": "bilibili",
-        "id": "6498",
-        "begin": "2017-10-07T08:16:46.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "pptv",
         "id": "qZJibicGTKOnjbWcE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "54efbfbdefbfbddc9135",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2343,31 +1557,15 @@
     "officialSite": "http://s.mxtv.jp/anime/glamorous_heroes/",
     "begin": "2017-10-06T17:10:00.000Z",
     "end": "2017-12-08T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "227462"
       },
       {
-        "site": "acfun",
-        "id": "1480147",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "youku",
         "id": "efbfbd44efbfbd00efbf",
-        "begin": "2017-10-07T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T01:00:00.000Z"
       }
     ]
   },
@@ -2383,7 +1581,6 @@
     "officialSite": "http://www.ytv.co.jp/timebokan/",
     "begin": "2017-10-07T08:30:00.000Z",
     "end": "2018-03-24T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2392,12 +1589,7 @@
       {
         "site": "bilibili",
         "id": "6477",
-        "begin": "2017-10-07T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-07T11:00:00.000Z"
       }
     ]
   },
@@ -2414,7 +1606,6 @@
     "officialSite": "http://www.inuyashiki-project.com/",
     "begin": "2017-10-12T15:55:00.000Z",
     "end": "2017-12-21T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2423,12 +1614,7 @@
       {
         "site": "youku",
         "id": "efbfbd3652c6984b11ef",
-        "begin": "2017-10-26T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-26T19:00:00.000Z"
       }
     ]
   },
@@ -2444,7 +1630,6 @@
     "officialSite": "http://dlife.disney.co.jp/program/disney/fireball_humorous.html",
     "begin": "2017-10-06T12:55:00.000Z",
     "end": "2017-12-08T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2452,13 +1637,8 @@
       },
       {
         "site": "bilibili",
-        "id": "20603",
-        "begin": "2017-10-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8332",
+        "begin": "2017-10-05T16:00:01.000Z"
       }
     ]
   },
@@ -2474,7 +1654,6 @@
     "officialSite": "http://s.mxtv.jp/anime/dia_horizon/",
     "begin": "2017-10-02T16:00:00.000Z",
     "end": "2017-12-18T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2494,61 +1673,30 @@
     "officialSite": "http://evilorlive.jp/",
     "begin": "2017-10-10T16:41:00.000Z",
     "end": "2018-01-02T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "195713"
       },
       {
-        "site": "bilibili",
-        "id": "6471",
-        "begin": "2017-10-10T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "pptv",
         "id": "uINt61O5KWfKSLA",
-        "begin": "2017-10-10T02:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "k/kr796tro7q6n72s",
-        "begin": "2017-10-10T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T02:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2017/lixiangjinqu",
-        "begin": "2017-10-10T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T02:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "EVIL_OR_LIVE",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2567,7 +1715,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/cf-vanguard-gz/",
     "begin": "2017-10-08T01:00:00.000Z",
     "end": "2018-04-01T00:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2576,22 +1723,12 @@
       {
         "site": "pptv",
         "id": "Bzchnwdt3RtibicGQ",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "cf-vanguard-gz",
-        "begin": "2017-10-10T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T12:00:00.000Z"
       }
     ]
   },
@@ -2607,7 +1744,6 @@
     "officialSite": "http://anime.robomasters.com/",
     "begin": "2017-10-13T13:30:00.000Z",
     "end": "2017-11-17T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2616,22 +1752,12 @@
       {
         "site": "qq",
         "id": "7/7iprg7cb998vrwr",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "robomasters",
-        "begin": "2018-04-14T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-14T12:00:00.000Z"
       }
     ]
   },
@@ -2647,7 +1773,6 @@
     "officialSite": "http://www.onyankopon.jp/",
     "begin": "2017-10-09T16:35:00.000Z",
     "end": "2017-12-26T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2656,22 +1781,12 @@
       {
         "site": "nicovideo",
         "id": "onyankopon",
-        "begin": "2017-12-21T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-12-21T15:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "6501",
-        "begin": "2017-10-09T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "7392",
+        "begin": "2017-10-09T17:00:00.000Z"
       }
     ]
   },
@@ -2688,7 +1803,6 @@
     "officialSite": "http://anime.monster-strike.com/",
     "begin": "2017-10-07T11:00:00.000Z",
     "end": "2018-01-06T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2696,43 +1810,23 @@
       },
       {
         "site": "bilibili",
-        "id": "6500",
-        "begin": "2017-10-07T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "7352",
+        "begin": "2017-10-07T11:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhchrd1",
-        "begin": "2017-10-09T09:56:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-09T09:56:05.000Z"
       },
       {
         "site": "qq",
         "id": "v/v3obqqj0prpvpet",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "0f0d786befbfbdefbfbd",
-        "begin": "2017-10-10T03:48:57.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T03:48:57.000Z"
       }
     ]
   },
@@ -2748,7 +1842,6 @@
     "officialSite": "http://youkainingen-bem.com/anime_dle/",
     "begin": "2017-10-04T16:00:00.000Z",
     "end": "2018-03-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2757,12 +1850,7 @@
       {
         "site": "nicovideo",
         "id": "youkainingen-bem",
-        "begin": "2017-10-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-05T03:00:00.000Z"
       }
     ]
   },
@@ -2778,7 +1866,6 @@
     "officialSite": "http://www.precure-movie.com/",
     "begin": "2017-10-28T16:00:00.000Z",
     "end": "2017-10-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2787,12 +1874,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   },
@@ -2804,7 +1886,6 @@
     "officialSite": "http://www.fate-sn.com/",
     "begin": "2017-10-14T16:00:00.000Z",
     "end": "2017-10-14T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2813,12 +1894,7 @@
       {
         "site": "nicovideo",
         "id": "fate-sn1",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2834,7 +1910,6 @@
     "officialSite": "http://yamato2202.net/",
     "begin": "2017-10-14T16:00:00.000Z",
     "end": "2017-10-14T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2843,12 +1918,7 @@
       {
         "site": "youku",
         "id": "7d03efbfbd50efbfbd0c",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2860,7 +1930,6 @@
     "officialSite": "http://tym.iwatobi-sc.com/",
     "begin": "2017-10-28T16:00:00.000Z",
     "end": "2017-10-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2868,13 +1937,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25001",
-        "begin": "2018-04-17T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "114452",
+        "begin": "2018-04-17T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2017/11.json
+++ b/data/items/2017/11.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.honeyworks-movie.jp/",
     "begin": "2017-11-24T15:00:00.000Z",
     "end": "2017-12-29T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,32 +22,17 @@
       {
         "site": "bilibili",
         "id": "6470",
-        "begin": "2017-11-24T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-11-24T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "FSkDgelPvic1g3kY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "itsudatte",
-        "begin": "2018-07-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-31T15:00:00.000Z"
       }
     ]
   },
@@ -64,7 +48,6 @@
     "officialSite": "http://www.gochiusa.com/ova/",
     "begin": "2017-11-11T16:00:00.000Z",
     "end": "2017-11-11T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -73,22 +56,12 @@
       {
         "site": "nicovideo",
         "id": "gochiusa-dms",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "24702",
-        "begin": "2018-08-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "122632",
+        "begin": "2018-08-08T16:00:00.000Z"
       }
     ]
   },
@@ -104,7 +77,6 @@
     "officialSite": "http://haikarasan.net/",
     "begin": "2017-11-11T16:00:00.000Z",
     "end": "2017-11-11T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -113,12 +85,7 @@
       {
         "site": "nicovideo",
         "id": "haikarasan",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2017/12.json
+++ b/data/items/2017/12.json
@@ -11,7 +11,6 @@
     "officialSite": "http://donten-anime.jp/",
     "begin": "2017-12-02T16:00:00.000Z",
     "end": "2017-12-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "nicovideo",
         "id": "donten-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "25450",
-        "begin": "2018-09-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "128432",
+        "begin": "2018-09-01T03:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://touken-hanamaru.jp/movie/",
     "begin": "2017-12-01T16:00:00.000Z",
     "end": "2017-12-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,12 +48,7 @@
       {
         "site": "qq",
         "id": "k/kb42ukton38fpbn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -81,7 +64,6 @@
     "officialSite": "http://www.inazma-delivery.com",
     "begin": "2017-12-08T16:00:00.000Z",
     "end": "2018-03-02T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -90,32 +72,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh71jc5",
-        "begin": "2018-07-04T00:00:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-04T00:00:11.000Z"
       },
       {
         "site": "nicovideo",
         "id": "inazma-delivery2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "712415662cab4b149550",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2018/01.json
+++ b/data/items/2018/01.json
@@ -14,7 +14,6 @@
     "officialSite": "http://mitsuboshi-anime.com/",
     "begin": "2018-01-07T16:30:00.000Z",
     "end": "2018-03-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -22,33 +21,18 @@
       },
       {
         "site": "bilibili",
-        "id": "21744",
-        "begin": "2018-01-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "12392",
+        "begin": "2018-01-07T15:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "rY9p50ib1JWPGRKw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "mitsuboshi-anime",
-        "begin": "2018-01-14T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-14T14:30:00.000Z"
       }
     ]
   },
@@ -64,7 +48,6 @@
     "officialSite": "http://citrus-anime.com/",
     "begin": "2018-01-06T14:30:00.000Z",
     "end": "2018-03-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -72,23 +55,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21557",
-        "begin": "2018-01-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8992",
+        "begin": "2018-01-06T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "citrus-anime",
-        "begin": "2018-01-14T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-14T14:30:00.000Z"
       }
     ]
   },
@@ -104,7 +77,6 @@
     "officialSite": "http://tojinomiko.jp/",
     "begin": "2018-01-05T12:30:00.000Z",
     "end": "2018-06-22T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -112,23 +84,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21750",
-        "begin": "2018-01-05T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "12492",
+        "begin": "2018-01-05T13:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tojinomiko",
-        "begin": "2018-01-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-10T15:00:00.000Z"
       }
     ]
   },
@@ -144,7 +106,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/dagashi/",
     "begin": "2018-01-11T17:28:00.000Z",
     "end": "2018-03-29T17:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -152,23 +113,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21603",
-        "begin": "2018-01-12T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "9052",
+        "begin": "2018-01-12T07:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "dagashi2",
-        "begin": "2018-01-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-15T03:00:00.000Z"
       }
     ]
   },
@@ -185,7 +136,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/takunomi/",
     "begin": "2018-01-11T17:43:00.000Z",
     "end": "2018-03-29T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -193,23 +143,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21594",
-        "begin": "2018-01-12T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "9032",
+        "begin": "2018-01-12T07:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "takunomi",
-        "begin": "2018-01-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-15T03:00:00.000Z"
       }
     ]
   },
@@ -228,7 +168,6 @@
     "officialSite": "http://deathma-anime.com/",
     "begin": "2018-01-11T14:30:00.000Z",
     "end": "2018-03-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -237,22 +176,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1oryd",
-        "begin": "2018-01-11T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-11T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "deathma",
-        "begin": "2018-01-17T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-17T13:30:00.000Z"
       }
     ]
   },
@@ -271,7 +200,6 @@
     "officialSite": "http://www.ryuoh-anime.com/",
     "begin": "2018-01-08T15:30:00.000Z",
     "end": "2018-03-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -279,33 +207,18 @@
       },
       {
         "site": "bilibili",
-        "id": "21554",
-        "begin": "2018-01-08T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "8932",
+        "begin": "2018-01-08T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ryuoh-anime",
-        "begin": "2018-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-10T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "81029050",
-        "begin": "2018-11-30T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-30T16:00:00.000Z"
       }
     ]
   },
@@ -322,7 +235,6 @@
     "officialSite": "http://beatless-anime.jp/",
     "begin": "2018-01-12T16:55:00.000Z",
     "end": "2018-09-28T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -331,12 +243,7 @@
       {
         "site": "youku",
         "id": "496870efbfbdefbfbd67",
-        "begin": "2018-01-12T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-12T17:40:00.000Z"
       }
     ]
   },
@@ -355,7 +262,6 @@
     "officialSite": "http://hakatatonkotsu-anime.com/",
     "begin": "2018-01-12T13:30:00.000Z",
     "end": "2018-03-30T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -363,23 +269,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21769",
-        "begin": "2018-01-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "12872",
+        "begin": "2018-01-12T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hakatatonkotsu",
-        "begin": "2018-01-19T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-19T14:00:00.000Z"
       }
     ]
   },
@@ -398,41 +294,20 @@
     "officialSite": "http://maerchen-anime.com/",
     "begin": "2018-01-11T13:30:00.000Z",
     "end": "2019-04-25T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "220632"
       },
       {
-        "site": "bilibili",
-        "id": "21721",
-        "begin": "2018-01-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "maerchen-anime",
-        "begin": "2018-01-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-12T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80995941",
-        "begin": "2018-11-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-14T16:00:00.000Z"
       }
     ]
   },
@@ -451,7 +326,6 @@
     "officialSite": "http://slow-start.com/",
     "begin": "2018-01-06T15:30:00.000Z",
     "end": "2018-03-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -459,63 +333,33 @@
       },
       {
         "site": "bilibili",
-        "id": "21675",
-        "begin": "2018-01-06T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "9152",
+        "begin": "2018-01-06T17:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "MAvlY8sxod9CwCg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1of4d",
-        "begin": "2018-01-06T16:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-06T16:55:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "slow-start",
-        "begin": "2018-01-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-09T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "ceb92cefbfbdefbfbdef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "80995927",
-        "begin": "2018-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-14T16:00:00.000Z"
       }
     ]
   },
@@ -531,7 +375,6 @@
     "officialSite": "http://touken-hanamaru.jp/",
     "begin": "2018-01-07T15:00:00.000Z",
     "end": "2018-03-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -539,33 +382,18 @@
       },
       {
         "site": "bilibili",
-        "id": "21754",
-        "begin": "2018-01-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "12572",
+        "begin": "2018-01-07T16:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "k/kg45vw37ljteitd",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "touken-hanamaru2",
-        "begin": "2018-01-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-10T15:00:00.000Z"
       }
     ]
   },
@@ -582,7 +410,6 @@
     "officialSite": "http://www.saikikusuo.com/",
     "begin": "2018-01-16T16:35:00.000Z",
     "end": "2018-06-26T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -590,43 +417,23 @@
       },
       {
         "site": "bilibili",
-        "id": "21469",
-        "begin": "2018-01-16T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "8812",
+        "begin": "2018-01-16T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1qb8l",
-        "begin": "2018-01-16T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-16T17:35:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd0877efbfbdefbf",
-        "begin": "2018-01-16T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-16T17:35:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "saikikusuo02",
-        "begin": "2018-01-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-17T15:00:00.000Z"
       }
     ]
   },
@@ -642,7 +449,6 @@
     "officialSite": "http://ramen-koizumi.com/",
     "begin": "2018-01-04T11:00:00.000Z",
     "end": "2018-03-22T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -650,33 +456,18 @@
       },
       {
         "site": "bilibili",
-        "id": "21728",
-        "begin": "2018-01-04T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "11912",
+        "begin": "2018-01-04T11:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ramen-koizumi",
-        "begin": "2018-01-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-08T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbdefbfbd3340efbf",
-        "begin": "2018-01-05T02:09:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-05T02:09:11.000Z"
       }
     ]
   },
@@ -695,7 +486,6 @@
     "officialSite": "http://violet-evergarden.jp/",
     "begin": "2018-01-10T15:00:00.000Z",
     "end": "2018-04-04T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -703,23 +493,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21542",
-        "begin": "2018-01-10T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "8892",
+        "begin": "2018-01-10T16:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80221698",
-        "begin": "2018-04-05T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-05T07:00:00.000Z"
       }
     ]
   },
@@ -738,7 +518,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/miira/",
     "begin": "2018-01-11T16:58:00.000Z",
     "end": "2018-03-29T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -746,23 +525,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21720",
-        "begin": "2018-01-12T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "11732",
+        "begin": "2018-01-12T07:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "miira",
-        "begin": "2018-01-18T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-18T21:00:00.000Z"
       }
     ]
   },
@@ -778,7 +547,6 @@
     "officialSite": "http://takagi3.me/",
     "begin": "2018-01-08T14:00:00.000Z",
     "end": "2018-03-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -787,22 +555,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1ss1p",
-        "begin": "2018-01-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-08T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "takagi3_me",
-        "begin": "2018-01-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-09T16:00:00.000Z"
       }
     ]
   },
@@ -822,7 +580,6 @@
     "officialSite": "http://hakumiko.com/",
     "begin": "2018-01-12T13:30:00.000Z",
     "end": "2018-03-30T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -830,23 +587,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21717",
-        "begin": "2018-01-12T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "11672",
+        "begin": "2018-01-12T13:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hakumiko",
-        "begin": "2018-01-20T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-20T14:00:00.000Z"
       }
     ]
   },
@@ -862,7 +609,6 @@
     "officialSite": "http://yurucamp.jp/",
     "begin": "2018-01-04T14:00:00.000Z",
     "end": "2018-03-22T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -871,22 +617,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1olh1",
-        "begin": "2018-01-04T15:25:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-04T15:25:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yurucamp",
-        "begin": "2018-01-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-08T15:00:00.000Z"
       }
     ]
   },
@@ -905,7 +641,6 @@
     "officialSite": "http://grancrest-anime.jp/",
     "begin": "2018-01-05T15:00:00.000Z",
     "end": "2018-06-22T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -913,33 +648,18 @@
       },
       {
         "site": "bilibili",
-        "id": "21633",
-        "begin": "2018-01-05T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "9092",
+        "begin": "2018-01-05T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1q7h9",
-        "begin": "2018-01-05T16:25:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-05T16:25:04.000Z"
       },
       {
         "site": "nicovideo",
         "id": "grancrest-anime",
-        "begin": "2018-01-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-08T03:00:00.000Z"
       }
     ]
   },
@@ -958,7 +678,6 @@
     "officialSite": "http://hoshiiro.jp/",
     "begin": "2018-01-06T16:00:00.000Z",
     "end": "2018-03-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -966,23 +685,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21719",
-        "begin": "2018-01-06T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "11712",
+        "begin": "2018-01-06T17:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hoshiiro",
-        "begin": "2018-01-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-06T16:30:00.000Z"
       }
     ]
   },
@@ -1001,7 +710,6 @@
     "officialSite": "http://yorimoi.com/",
     "begin": "2018-01-02T14:00:00.000Z",
     "end": "2018-03-27T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1009,33 +717,18 @@
       },
       {
         "site": "bilibili",
-        "id": "21778",
-        "begin": "2018-01-02T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "13032",
+        "begin": "2018-01-02T13:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yorimoi",
-        "begin": "2018-01-02T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-02T15:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80995912",
-        "begin": "2018-07-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-14T16:00:00.000Z"
       }
     ]
   },
@@ -1054,7 +747,6 @@
     "officialSite": "http://darli-fra.jp/",
     "begin": "2018-01-13T14:30:00.000Z",
     "end": "2018-07-07T14:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1063,32 +755,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1sifx",
-        "begin": "2018-01-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-13T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "darli-fra",
-        "begin": "2018-01-16T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-16T03:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "21680",
-        "begin": "2018-01-13T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "9192",
+        "begin": "2018-01-13T17:00:00.000Z"
       }
     ]
   },
@@ -1105,7 +782,6 @@
     "officialSite": "http://yowapeda.com/",
     "begin": "2018-01-08T17:05:00.000Z",
     "end": "2018-06-25T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1113,43 +789,23 @@
       },
       {
         "site": "bilibili",
-        "id": "21781",
-        "begin": "2018-01-08T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "13092",
+        "begin": "2018-01-08T18:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1qfh9",
-        "begin": "2018-01-08T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-08T18:05:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd65efbfbd53efbf",
-        "begin": "2018-01-08T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-08T18:05:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yowapeda_gl",
-        "begin": "2018-01-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-11T03:00:00.000Z"
       }
     ]
   },
@@ -1169,7 +825,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/ccsakura/",
     "begin": "2018-01-06T22:30:00.000Z",
     "end": "2018-06-09T22:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1177,73 +832,38 @@
       },
       {
         "site": "bilibili",
-        "id": "21421",
-        "begin": "2018-01-07T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "8752",
+        "begin": "2018-01-07T01:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1h5d9",
-        "begin": "2018-01-07T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T01:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "321310",
-        "begin": "2018-01-07T01:00:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T01:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "e/enddu63r2aa01la",
-        "begin": "2018-01-07T01:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T01:00:00.000Z"
       },
       {
         "site": "sohu",
         "id": "s2018/mksnyclearcard",
-        "begin": "2018-01-07T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T01:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "54e5babfefbfbdefbfbd",
-        "begin": "2018-01-07T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T01:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ccsakura_clear-card",
-        "begin": "2018-01-10T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-10T09:00:00.000Z"
       }
     ]
   },
@@ -1262,7 +882,6 @@
     "officialSite": "http://sdan-anime.com/index.html",
     "begin": "2018-01-06T13:00:00.000Z",
     "end": "2018-03-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1270,33 +889,18 @@
       },
       {
         "site": "bilibili",
-        "id": "21674",
-        "begin": "2018-01-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "9132",
+        "begin": "2018-01-06T14:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "FiakDgelPvic1g3kY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "sdan-anime",
-        "begin": "2018-01-09T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-09T14:00:00.000Z"
       }
     ]
   },
@@ -1312,7 +916,6 @@
     "officialSite": "http://basilisk-ouka.jp/",
     "begin": "2018-01-08T15:00:00.000Z",
     "end": "2018-06-18T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1320,43 +923,23 @@
       },
       {
         "site": "bilibili",
-        "id": "21718",
-        "begin": "2018-01-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "11692",
+        "begin": "2018-01-08T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1sj25",
-        "begin": "2018-01-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-08T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "basilisk-ouka",
-        "begin": "2018-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-10T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "1911efbfbd5fefbfbdef",
-        "begin": "2018-02-06T10:42:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-06T10:42:45.000Z"
       }
     ]
   },
@@ -1372,7 +955,6 @@
     "officialSite": "http://gakubaby-anime.com/",
     "begin": "2018-01-07T14:00:00.000Z",
     "end": "2018-03-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1381,32 +963,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1okt9",
-        "begin": "2018-01-07T15:25:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T15:25:05.000Z"
       },
       {
         "site": "pptv",
         "id": "iaLSgHobsXJr9eibM",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "gakubaby-anime",
-        "begin": "2018-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-10T03:00:00.000Z"
       }
     ]
   },
@@ -1425,7 +992,6 @@
     "officialSite": "https://damepri-anime.jp/",
     "begin": "2018-01-10T13:30:00.000Z",
     "end": "2018-03-28T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1434,22 +1000,12 @@
       {
         "site": "mgtv",
         "id": "321321",
-        "begin": "2018-01-10T14:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-10T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "damepri",
-        "begin": "2018-01-17T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-17T15:30:00.000Z"
       }
     ]
   },
@@ -1465,7 +1021,6 @@
     "officialSite": "http://tvhoushin-engi.com/",
     "begin": "2018-01-12T13:00:00.000Z",
     "end": "2018-06-29T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1474,12 +1029,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1qpkt",
-        "begin": "2018-01-12T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-12T14:00:00.000Z"
       }
     ]
   },
@@ -1499,7 +1049,6 @@
     "officialSite": "http://killingbites-anime.com/",
     "begin": "2018-01-12T17:25:00.000Z",
     "end": "2018-03-30T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1508,22 +1057,12 @@
       {
         "site": "youku",
         "id": "67d89910efbfbd5c11ef",
-        "begin": "2018-01-12T18:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-12T18:10:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "killingbites-anime",
-        "begin": "2018-02-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-10T03:00:00.000Z"
       }
     ]
   },
@@ -1543,7 +1082,6 @@
     "officialSite": "http://overlord-anime.com/",
     "begin": "2018-01-09T15:30:00.000Z",
     "end": "2018-04-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1551,23 +1089,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21466",
-        "begin": "2018-01-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "8792",
+        "begin": "2018-01-09T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "overlord-anime2",
-        "begin": "2018-01-15T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-15T15:30:00.000Z"
       }
     ]
   },
@@ -1587,7 +1115,6 @@
     "officialSite": "http://itojunji-anime.com/",
     "begin": "2018-01-10T14:30:00.000Z",
     "end": "2018-03-23T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1596,22 +1123,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1anh9",
-        "begin": "2018-01-05T14:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-05T14:55:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "itojunji-anime",
-        "begin": "2018-01-07T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T13:30:00.000Z"
       }
     ]
   },
@@ -1630,7 +1147,6 @@
     "officialSite": "http://7-virtues.net/anime/",
     "begin": "2018-01-26T15:25:00.000Z",
     "end": "2018-03-30T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1639,12 +1155,7 @@
       {
         "site": "nicovideo",
         "id": "7-virtues",
-        "begin": "2018-02-23T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-23T15:30:00.000Z"
       }
     ]
   },
@@ -1660,7 +1171,6 @@
     "officialSite": "http://www.shinkalion.com/",
     "begin": "2018-01-05T22:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1669,22 +1179,7 @@
       {
         "site": "nicovideo",
         "id": "shinkalion",
-        "begin": "2018-01-06T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
-        "site": "bilibili",
-        "id": "23584",
-        "begin": "2018-01-05T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-06T21:00:00.000Z"
       }
     ]
   },
@@ -1703,7 +1198,6 @@
     "officialSite": "http://www.hataoni.jp/",
     "begin": "2018-01-05T12:54:00.000Z",
     "end": "2018-03-30T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1711,23 +1205,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21749",
-        "begin": "2018-01-05T12:54:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "12472",
+        "begin": "2018-01-05T12:54:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hataoni",
-        "begin": "2018-01-05T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-05T13:00:00.000Z"
       }
     ]
   },
@@ -1743,7 +1227,6 @@
     "officialSite": "http://www.koiame-anime.com/",
     "begin": "2018-01-11T15:55:00.000Z",
     "end": "2018-03-29T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1752,12 +1235,7 @@
       {
         "site": "youku",
         "id": "efbfbdefbfbd0360efbf",
-        "begin": "2018-01-11T19:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-11T19:00:00.000Z"
       }
     ]
   },
@@ -1773,7 +1251,6 @@
     "officialSite": "http://ch.nicovideo.jp/mameneko-club",
     "begin": "2018-01-15T03:00:00.000Z",
     "end": "2018-03-26T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1782,12 +1259,7 @@
       {
         "site": "nicovideo",
         "id": "mameneko-club",
-        "begin": "2018-01-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-15T03:00:00.000Z"
       }
     ]
   },
@@ -1803,7 +1275,6 @@
     "officialSite": "http://www.7-taizai.net/",
     "begin": "2018-01-12T21:30:00.000Z",
     "end": "2018-06-29T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1811,23 +1282,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21729",
-        "begin": "2018-01-12T22:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "11932",
+        "begin": "2018-01-12T22:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "7-taizai03",
-        "begin": "2018-01-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-06T03:00:00.000Z"
       }
     ]
   },
@@ -1839,7 +1300,6 @@
     "officialSite": "http://gdmen.net/",
     "begin": "2018-01-09T03:00:00.000Z",
     "end": "2018-03-26T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1848,12 +1308,7 @@
       {
         "site": "nicovideo",
         "id": "gdmen",
-        "begin": "2018-01-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-09T03:00:00.000Z"
       }
     ]
   },
@@ -1870,7 +1325,6 @@
     "officialSite": "http://idolish7.com/aninana/",
     "begin": "2018-01-07T13:30:00.000Z",
     "end": "2018-05-19T13:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1878,43 +1332,23 @@
       },
       {
         "site": "bilibili",
-        "id": "6485",
-        "begin": "2017-11-03T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "6692",
+        "begin": "2017-11-03T04:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1owz1",
-        "begin": "2018-01-01T23:08:42.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-01T23:08:42.000Z"
       },
       {
         "site": "pptv",
         "id": "nJ9591icFNXPWVLw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "idolish7-aninana",
-        "begin": "2018-01-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-08T03:00:00.000Z"
       }
     ]
   },
@@ -1931,7 +1365,6 @@
     "officialSite": "http://kaiju-gk.jp/anime/2nd/",
     "begin": "2018-01-09T12:54:00.000Z",
     "end": "2018-03-27T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1940,42 +1373,22 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh0z2qt",
-        "begin": "2018-01-09T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-01-09T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kaiju-gk-2nd",
-        "begin": "2018-01-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-16T15:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "t/ta18i5s30dwnm3m",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "efbfbd751f66efbfbd01",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1991,7 +1404,6 @@
     "officialSite": "http://fate-extra-lastencore.com/",
     "begin": "2018-01-27T15:00:00.000Z",
     "end": "2018-07-29T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1999,23 +1411,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21464",
-        "begin": "2018-01-27T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "8772",
+        "begin": "2018-01-27T16:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80185145",
-        "begin": "2018-06-30T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-06-30T07:00:00.000Z"
       }
     ]
   },
@@ -2031,7 +1433,6 @@
     "officialSite": "http://kokkoku-anime.com/",
     "begin": "2018-01-07T15:30:00.000Z",
     "end": "2018-03-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2039,13 +1440,8 @@
       },
       {
         "site": "bilibili",
-        "id": "21755",
-        "begin": "2018-01-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "12592",
+        "begin": "2018-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -2061,7 +1457,6 @@
     "officialSite": "http://nigojo.cf-anime.com/",
     "begin": "2018-01-07T16:00:00.000Z",
     "end": "2018-03-25T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2070,12 +1465,7 @@
       {
         "site": "nicovideo",
         "id": "nigojo-cf-anime",
-        "begin": "2018-01-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-07T16:00:00.000Z"
       }
     ]
   },
@@ -2092,7 +1482,6 @@
     "officialSite": "http://devilman-crybaby.com/",
     "begin": "2018-01-05T16:00:00.000Z",
     "end": "2018-01-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2101,12 +1490,7 @@
       {
         "site": "netflix",
         "id": "80174974",
-        "begin": "2018-01-05T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-05T08:00:00.000Z"
       }
     ]
   },
@@ -2122,7 +1506,6 @@
     "officialSite": "",
     "begin": "2018-01-05T17:10:00.000Z",
     "end": "2018-03-23T17:39:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2142,7 +1525,6 @@
     "officialSite": "http://hitorinoshita2.com/",
     "begin": "2018-01-20T18:00:00.000Z",
     "end": "2018-04-03T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2151,42 +1533,22 @@
       {
         "site": "nicovideo",
         "id": "hitorinoshita2",
-        "begin": "2018-01-09T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-09T18:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "22082",
-        "begin": "2018-01-11T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "23292",
+        "begin": "2018-01-11T16:00:01.000Z"
       },
       {
         "site": "qq",
         "id": "r/r38rckf1m8686vc",
-        "begin": "2018-01-11T16:00:01.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-11T16:00:01.000Z"
       },
       {
         "site": "mgtv",
         "id": "319170",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2202,27 +1564,16 @@
     "officialSite": "http://hitorinoshita2.com/",
     "begin": "2018-01-20T18:00:00.000Z",
     "end": "2018-04-03T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
         "id": "6402",
-        "begin": "2017-10-27T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-27T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "3/3enwc74hj562xjd",
-        "begin": "2018-01-20T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-20T18:00:00.000Z"
       }
     ]
   },
@@ -2238,7 +1589,6 @@
     "officialSite": "http://pikachin.com/",
     "begin": "2018-01-06T00:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2247,12 +1597,7 @@
       {
         "site": "nicovideo",
         "id": "pikachin",
-        "begin": "2018-01-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-09T03:00:00.000Z"
       }
     ]
   },
@@ -2268,7 +1613,6 @@
     "officialSite": "http://ginno-guardian.jp/",
     "begin": "2018-01-13T12:00:00.000Z",
     "end": "2018-02-17T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2277,22 +1621,12 @@
       {
         "site": "nicovideo",
         "id": "ginno-guardian2",
-        "begin": "2018-01-13T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-13T13:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd15d385efbfbdef",
-        "begin": "2018-01-11T02:00:07.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-11T02:00:07.000Z"
       }
     ]
   },
@@ -2308,7 +1642,6 @@
     "officialSite": "http://ginno-guardian.jp/",
     "begin": "2018-01-13T12:00:00.000Z",
     "end": "2018-02-17T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2331,7 +1664,6 @@
     "officialSite": "http://emiya-gohan.com",
     "begin": "2018-01-01T12:00:00.000Z",
     "end": "2018-12-01T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2339,23 +1671,13 @@
       },
       {
         "site": "bilibili",
-        "id": "22504",
-        "begin": "2018-01-01T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "33512",
+        "begin": "2018-01-01T13:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "emiya-gohan",
-        "begin": "2018-02-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-01T03:00:00.000Z"
       }
     ]
   },
@@ -2367,7 +1689,6 @@
     "officialSite": "",
     "begin": "2018-01-15T15:00:00.000Z",
     "end": "2018-03-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2376,12 +1697,7 @@
       {
         "site": "nicovideo",
         "id": "sukiyaki_f2",
-        "begin": "2018-01-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-01-28T15:00:00.000Z"
       }
     ]
   },
@@ -2397,7 +1713,6 @@
     "officialSite": "http://shingeki.tv/movie_season2/",
     "begin": "2018-01-13T16:00:00.000Z",
     "end": "2018-01-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2406,12 +1721,7 @@
       {
         "site": "nicovideo",
         "id": "shingeki_movie_season2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2427,7 +1737,6 @@
     "officialSite": "http://yamato2202.net/",
     "begin": "2018-01-27T16:00:00.000Z",
     "end": "2018-01-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2447,7 +1756,6 @@
     "officialSite": "http://www.anime-chu-2.com/",
     "begin": "2018-01-06T16:00:00.000Z",
     "end": "2018-01-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2455,13 +1763,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25045",
-        "begin": "2018-07-17T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "115632",
+        "begin": "2018-07-17T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2018/02.json
+++ b/data/items/2018/02.json
@@ -15,7 +15,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/hugtto_precure/",
     "begin": "2018-02-03T23:30:00.000Z",
     "end": "2019-01-26T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -24,12 +23,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh0tfud",
-        "begin": "2018-02-04T03:22:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-04T03:22:10.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://www6.nhk.or.jp/anime/program/detail.html?i=ganko",
     "begin": "2018-02-03T22:55:00.000Z",
     "end": "2018-03-24T23:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -62,7 +55,6 @@
     "officialSite": "http://www.spiritpact2.com/",
     "begin": "2018-02-24T12:00:00.000Z",
     "end": "2018-05-12T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,32 +63,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh0cu8d",
-        "begin": "2018-03-02T02:03:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-02T02:03:06.000Z"
       },
       {
         "site": "mgtv",
         "id": "321908",
-        "begin": "2018-02-23T02:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-23T02:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "spiritpact2",
-        "begin": "2018-02-24T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-02-24T13:00:00.000Z"
       }
     ]
   },
@@ -112,7 +89,6 @@
     "officialSite": "http://tokires-movie.com/",
     "begin": "2018-02-10T16:00:00.000Z",
     "end": "2018-02-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -121,12 +97,7 @@
       {
         "site": "nicovideo",
         "id": "tokires-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -142,7 +113,6 @@
     "officialSite": "http://www.infini-tforce.com/",
     "begin": "2018-02-24T16:00:00.000Z",
     "end": "2018-02-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -151,12 +121,7 @@
       {
         "site": "youku",
         "id": "092eefbfbdefbfbd0d72",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2018/03.json
+++ b/data/items/2018/03.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/duelmasters/",
     "begin": "2018-03-31T23:30:00.000Z",
     "end": "2019-03-30T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,12 +22,7 @@
       {
         "site": "nicovideo",
         "id": "duelmasters_2018",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -40,7 +34,6 @@
     "officialSite": "https://www.nhk.or.jp/school/cara-tama/",
     "begin": "2018-03-29T15:30:00.000Z",
     "end": "2019-01-28T01:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -61,7 +54,6 @@
     "officialSite": "http://swordgai-anime.com/",
     "begin": "2018-03-23T16:00:00.000Z",
     "end": "2018-03-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -69,43 +61,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23875",
-        "begin": "2018-03-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "79492",
+        "begin": "2018-03-31T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgzccfp",
-        "begin": "2018-03-24T08:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-24T08:55:06.000Z"
       },
       {
         "site": "youku",
         "id": "08b5b5f6e42e11e5a080",
-        "begin": "2018-03-24T08:58:06.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-24T08:58:06.000Z"
       },
       {
         "site": "netflix",
         "id": "80175350",
-        "begin": "2018-03-23T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-23T07:00:00.000Z"
       }
     ]
   },
@@ -123,7 +95,6 @@
     "officialSite": "http://www.b-animation.jp/",
     "begin": "2018-03-02T08:00:00.000Z",
     "end": "2018-03-02T08:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -132,32 +103,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh06dfh",
-        "begin": "2018-04-28T04:41:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-28T04:41:23.000Z"
       },
       {
         "site": "netflix",
         "id": "80097594",
-        "begin": "2018-03-02T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-02T08:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "b91a23ef0f804a75acaf",
-        "begin": "2018-03-13T04:14:51.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-13T04:14:51.000Z"
       }
     ]
   },
@@ -173,7 +129,6 @@
     "officialSite": "http://www.project-aico.com/",
     "begin": "2018-03-09T08:00:00.000Z",
     "end": "2018-03-09T08:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -182,32 +137,17 @@
       {
         "site": "netflix",
         "id": "80161848",
-        "begin": "2018-03-09T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-09T08:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "2968800df8f34b9bb376",
-        "begin": "2018-03-10T05:12:59.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-10T05:12:59.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1tbol",
-        "begin": "2018-05-02T01:28:55.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-02T01:28:55.000Z"
       }
     ]
   },
@@ -223,7 +163,6 @@
     "officialSite": "http://www.precure-superstars.com/",
     "begin": "2018-03-17T16:00:00.000Z",
     "end": "2018-03-17T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -232,12 +171,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhb4tzt",
-        "begin": "2015-08-07T08:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2015-08-07T08:45:07.000Z"
       }
     ]
   },
@@ -256,7 +190,6 @@
     "officialSite": "http://www.project-pandora.jp/",
     "begin": "2018-03-28T14:30:00.000Z",
     "end": "2018-09-19T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -264,53 +197,28 @@
       },
       {
         "site": "bilibili",
-        "id": "23811",
-        "begin": "2018-03-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "77352",
+        "begin": "2018-03-28T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1tbu5",
-        "begin": "2018-03-28T14:55:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-28T14:55:09.000Z"
       },
       {
         "site": "qq",
         "id": "e/e3yh815x8vf82oi",
-        "begin": "2018-03-28T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-28T15:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80221272",
-        "begin": "2018-03-29T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-29T07:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "project-pandora",
-        "begin": "2018-09-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-09-28T15:00:00.000Z"
       }
     ]
   },
@@ -326,7 +234,6 @@
     "officialSite": "http://www.project-pandora.jp/",
     "begin": "2018-03-28T14:30:00.000Z",
     "end": "2018-09-19T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -334,33 +241,18 @@
       },
       {
         "site": "bilibili",
-        "id": "23919",
-        "begin": "2018-03-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "80472",
+        "begin": "2018-03-28T15:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyp57x",
-        "begin": "2018-03-28T14:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-28T14:55:06.000Z"
       },
       {
         "site": "qq",
         "id": "2/225pc9y4ogg0pqq",
-        "begin": "2018-03-28T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-28T15:00:00.000Z"
       }
     ]
   },
@@ -372,7 +264,6 @@
     "officialSite": "",
     "begin": "2018-03-10T16:00:00.000Z",
     "end": "2018-03-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -381,12 +272,7 @@
       {
         "site": "nicovideo",
         "id": "engimon",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -398,7 +284,6 @@
     "officialSite": "",
     "begin": "2018-03-10T16:00:00.000Z",
     "end": "2018-03-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -407,12 +292,7 @@
       {
         "site": "nicovideo",
         "id": "midnight-crazy-trail",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -424,7 +304,6 @@
     "officialSite": "",
     "begin": "2018-03-10T16:00:00.000Z",
     "end": "2018-03-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -440,7 +319,6 @@
     "officialSite": "",
     "begin": "2018-03-10T16:00:00.000Z",
     "end": "2018-03-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -460,7 +338,6 @@
     "officialSite": "http://bungo-stray-dogs.jp/",
     "begin": "2018-03-03T16:00:00.000Z",
     "end": "2018-03-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -469,12 +346,7 @@
       {
         "site": "nicovideo",
         "id": "bungo-stray-dogs-dead-apple",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2018/04.json
+++ b/data/items/2018/04.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.hozukino-reitetsu.com/",
     "begin": "2018-04-07T16:00:00.000Z",
     "end": "2018-06-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -19,23 +18,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23877",
-        "begin": "2018-04-07T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "79292",
+        "begin": "2018-04-07T17:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hozukino-reitetsu2",
-        "begin": "2017-10-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-10T03:00:00.000Z"
       }
     ]
   },
@@ -52,7 +41,6 @@
     "officialSite": "http://tadakoi.tv/",
     "begin": "2018-04-05T13:00:00.000Z",
     "end": "2018-06-28T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -60,23 +48,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23859",
-        "begin": "2018-04-05T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78572",
+        "begin": "2018-04-05T13:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tadakoi",
-        "begin": "2018-04-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-11T15:00:00.000Z"
       }
     ]
   },
@@ -96,7 +74,6 @@
     "officialSite": "http://www.aikatsu.net/",
     "begin": "2018-04-05T09:25:00.000Z",
     "end": "2019-03-28T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -105,12 +82,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh05ogd",
-        "begin": "2018-04-05T11:25:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-05T11:25:08.000Z"
       }
     ]
   },
@@ -130,7 +102,6 @@
     "officialSite": "http://fullmeta-iv.com/",
     "begin": "2018-04-13T11:30:00.000Z",
     "end": "2018-07-18T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -138,43 +109,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23852",
-        "begin": "2018-04-13T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78432",
+        "begin": "2018-04-13T13:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1sayt",
-        "begin": "2018-04-13T13:35:54.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-13T13:35:54.000Z"
       },
       {
         "site": "nicovideo",
         "id": "fullmeta-iv",
-        "begin": "2018-04-20T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-20T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbdefbfbd0e4aefbf",
-        "begin": "2018-04-13T13:00:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-13T13:00:05.000Z"
       }
     ]
   },
@@ -191,7 +142,6 @@
     "officialSite": "http://www.shokugekinosoma.com/",
     "begin": "2018-04-08T15:30:00.000Z",
     "end": "2018-06-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -200,12 +150,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhcadk5",
-        "begin": "2017-10-03T16:25:14.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-10-03T16:25:14.000Z"
       }
     ]
   },
@@ -221,7 +166,6 @@
     "officialSite": "http://lostorage-wixoss.com/",
     "begin": "2018-04-06T15:30:00.000Z",
     "end": "2018-06-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -229,23 +173,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23820",
-        "begin": "2018-04-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "81512",
+        "begin": "2018-04-06T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyopwl",
-        "begin": "2018-04-06T16:25:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-06T16:25:07.000Z"
       }
     ]
   },
@@ -262,7 +196,6 @@
     "officialSite": "http://comic-girls.com/",
     "begin": "2018-04-05T14:00:00.000Z",
     "end": "2018-06-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -270,23 +203,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23829",
-        "begin": "2018-04-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "77812",
+        "begin": "2018-04-05T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "comic-girls",
-        "begin": "2018-04-08T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-08T15:00:00.000Z"
       }
     ]
   },
@@ -305,7 +228,6 @@
     "officialSite": "http://hina-matsuri.net/",
     "begin": "2018-04-06T16:40:00.000Z",
     "end": "2018-06-22T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -313,23 +235,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23850",
-        "begin": "2018-04-06T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78352",
+        "begin": "2018-04-06T12:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hina-matsuri",
-        "begin": "2018-04-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-13T15:30:00.000Z"
       }
     ]
   },
@@ -348,7 +260,6 @@
     "officialSite": "http://mahoushoujyo-anime.com/",
     "begin": "2018-04-06T16:55:00.000Z",
     "end": "2018-06-22T17:32:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -357,22 +268,12 @@
       {
         "site": "youku",
         "id": "e0ba5ab762ab4561bafd",
-        "begin": "2018-04-06T17:58:00.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-06T17:58:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "mahoushoujyo-anime",
-        "begin": "2018-06-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-06-07T03:00:00.000Z"
       }
     ]
   },
@@ -393,7 +294,6 @@
     "officialSite": "http://devilsline.jp/",
     "begin": "2018-04-08T16:35:00.000Z",
     "end": "2018-06-23T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -401,43 +301,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23846",
-        "begin": "2018-04-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78272",
+        "begin": "2018-04-07T15:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh05nlh",
-        "begin": "2018-04-07T15:25:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-07T15:25:06.000Z"
       },
       {
         "site": "youku",
         "id": "573204ca24294b1bbc26",
-        "begin": "2018-04-10T09:19:18.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-10T09:19:18.000Z"
       },
       {
         "site": "nicovideo",
         "id": "devilsline",
-        "begin": "2018-04-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-08T03:00:00.000Z"
       }
     ]
   },
@@ -454,7 +334,6 @@
     "officialSite": "http://caligula-anime.com/",
     "begin": "2018-04-08T14:30:00.000Z",
     "end": "2018-06-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -462,23 +341,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23818",
-        "begin": "2018-04-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "77552",
+        "begin": "2018-04-08T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "caligula-anime",
-        "begin": "2018-04-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-09T15:30:00.000Z"
       }
     ]
   },
@@ -494,7 +363,6 @@
     "officialSite": "http://www.haremking.tv/",
     "begin": "2018-04-10T15:30:00.000Z",
     "end": "2018-07-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -503,12 +371,7 @@
       {
         "site": "nicovideo",
         "id": "haremking4",
-        "begin": "2018-04-17T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-17T15:30:00.000Z"
       }
     ]
   },
@@ -524,7 +387,6 @@
     "officialSite": "http://lastperiod.jp/",
     "begin": "2018-04-11T15:00:00.000Z",
     "end": "2018-06-27T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -533,22 +395,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh05oat",
-        "begin": "2018-04-11T16:31:23.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-11T16:31:23.000Z"
       },
       {
         "site": "nicovideo",
         "id": "lastperiod",
-        "begin": "2018-04-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-12T15:00:00.000Z"
       }
     ]
   },
@@ -567,7 +419,6 @@
     "officialSite": "http://gundam-bd.net/",
     "begin": "2018-04-03T08:55:00.000Z",
     "end": "2018-09-25T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -575,13 +426,8 @@
       },
       {
         "site": "bilibili",
-        "id": "23595",
-        "begin": "2018-04-03T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78132",
+        "begin": "2018-04-03T10:00:00.000Z"
       }
     ]
   },
@@ -599,7 +445,6 @@
     "officialSite": "http://nobunaga-no-shinobi.com/",
     "begin": "2018-04-06T16:35:00.000Z",
     "end": "2018-09-28T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -607,43 +452,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23857",
-        "begin": "2018-04-06T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78532",
+        "begin": "2018-04-06T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyopad",
-        "begin": "2018-04-06T17:30:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-06T17:30:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "nobunaga-no-shinobi03",
-        "begin": "2018-04-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-07T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "beec861dd4a9400fb9c9",
-        "begin": "2018-04-28T11:10:39.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-28T11:10:39.000Z"
       }
     ]
   },
@@ -662,7 +487,6 @@
     "officialSite": "http://tiramisu-anime.com/",
     "begin": "2018-04-02T16:00:00.000Z",
     "end": "2018-06-25T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -670,23 +494,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23861",
-        "begin": "2018-04-02T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78612",
+        "begin": "2018-04-02T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tiramisu-anime",
-        "begin": "2018-11-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-04T15:00:00.000Z"
       }
     ]
   },
@@ -702,7 +516,6 @@
     "officialSite": "http://ch.nicovideo.jp/tokyoghoul_re",
     "begin": "2018-04-03T14:00:00.000Z",
     "end": "2018-06-19T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -711,12 +524,7 @@
       {
         "site": "nicovideo",
         "id": "tokyoghoul_re",
-        "begin": "2018-04-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-11T03:00:00.000Z"
       }
     ]
   },
@@ -737,7 +545,6 @@
     "officialSite": "http://magicalgirl-ore.com/",
     "begin": "2018-04-02T13:00:00.000Z",
     "end": "2018-06-18T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -745,23 +552,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23871",
-        "begin": "2018-04-02T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "78832",
+        "begin": "2018-04-02T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "magicalgirl-ore",
-        "begin": "2018-04-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-04T03:00:00.000Z"
       }
     ]
   },
@@ -777,7 +574,6 @@
     "officialSite": "http://magicalgirl-ore.com/",
     "begin": "2018-04-02T13:00:00.000Z",
     "end": "2018-06-18T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -785,13 +581,8 @@
       },
       {
         "site": "bilibili",
-        "id": "23942",
-        "begin": "2018-04-02T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "82692",
+        "begin": "2018-04-02T14:00:00.000Z"
       }
     ]
   },
@@ -807,31 +598,15 @@
     "officialSite": "http://alice-or-alice.com/index.html",
     "begin": "2018-04-04T13:25:00.000Z",
     "end": "2018-06-20T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "220688"
       },
       {
-        "site": "bilibili",
-        "id": "23824",
-        "begin": "2018-04-04T13:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "alice-or-alice",
-        "begin": "2018-04-04T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-04T13:30:00.000Z"
       }
     ]
   },
@@ -848,7 +623,6 @@
     "officialSite": "http://lost-song.com/",
     "begin": "2018-04-07T16:30:00.000Z",
     "end": "2018-06-23T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -856,33 +630,18 @@
       },
       {
         "site": "bilibili",
-        "id": "23879",
-        "begin": "2018-03-31T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "79332",
+        "begin": "2018-03-31T07:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh06bmt",
-        "begin": "2018-03-31T06:55:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-31T06:55:07.000Z"
       },
       {
         "site": "youku",
         "id": "df3fecb5465b40759289",
-        "begin": "2018-03-31T06:58:19.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-03-31T06:58:19.000Z"
       }
     ]
   },
@@ -898,7 +657,6 @@
     "officialSite": "http://nilad-anime.com/",
     "begin": "2018-04-08T13:00:00.000Z",
     "end": "2018-06-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -906,53 +664,28 @@
       },
       {
         "site": "bilibili",
-        "id": "23848",
-        "begin": "2018-04-01T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78312",
+        "begin": "2018-04-01T13:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1tc0l",
-        "begin": "2018-04-01T12:55:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-01T12:55:07.000Z"
       },
       {
         "site": "mgtv",
         "id": "322880",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "76efbfbd27efbfbdefbf",
-        "begin": "2018-04-01T12:58:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-01T12:58:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "nilad-anime",
-        "begin": "2018-04-14T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-14T15:30:00.000Z"
       }
     ]
   },
@@ -971,7 +704,6 @@
     "officialSite": "http://steinsgate0-anime.com/",
     "begin": "2018-04-11T16:35:00.000Z",
     "end": "2018-09-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -980,22 +712,12 @@
       {
         "site": "nicovideo",
         "id": "steinsgate0",
-        "begin": "2018-04-26T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-26T15:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "g/gvz5bapszkkjbw8",
-        "begin": "2018-04-11T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-11T18:00:00.000Z"
       }
     ]
   },
@@ -1014,7 +736,6 @@
     "officialSite": "http://steinsgate0-anime.com/",
     "begin": "2018-04-11T16:35:00.000Z",
     "end": "2018-09-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1023,12 +744,7 @@
       {
         "site": "qq",
         "id": "q/qrerfaf3wjgrj1w",
-        "begin": "2018-04-11T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-11T18:00:00.000Z"
       }
     ]
   },
@@ -1045,7 +761,6 @@
     "officialSite": "http://wotakoi-anime.com/",
     "begin": "2018-04-12T15:55:00.000Z",
     "end": "2018-06-21T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1053,13 +768,8 @@
       },
       {
         "site": "bilibili",
-        "id": "23856",
-        "begin": "2018-04-12T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78512",
+        "begin": "2018-04-12T17:30:00.000Z"
       }
     ]
   },
@@ -1076,7 +786,6 @@
     "officialSite": "http://www.3dkanojo-anime.com/",
     "begin": "2018-04-03T16:59:00.000Z",
     "end": "2018-06-19T17:39:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1085,22 +794,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgyjath",
-        "begin": "2018-04-03T17:55:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-03T17:55:08.000Z"
       },
       {
         "site": "nicovideo",
         "id": "3dkanojo-anime",
-        "begin": "2018-04-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-06T03:00:00.000Z"
       }
     ]
   },
@@ -1120,7 +819,6 @@
     "officialSite": "http://gungale-online.net/",
     "begin": "2018-04-07T15:00:00.000Z",
     "end": "2018-06-30T03:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1129,22 +827,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh0kgvh",
-        "begin": "2018-04-07T16:25:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-07T16:25:08.000Z"
       },
       {
         "site": "nicovideo",
         "id": "gungale-online",
-        "begin": "2018-04-21T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-21T15:00:00.000Z"
       }
     ]
   },
@@ -1161,7 +849,6 @@
     "officialSite": "http://p5a.jp/",
     "begin": "2018-04-07T15:30:00.000Z",
     "end": "2018-09-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1169,43 +856,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23878",
-        "begin": "2018-04-07T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "79312",
+        "begin": "2018-04-07T17:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhf76lh",
-        "begin": "2018-04-07T16:55:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-07T16:55:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "p5a",
-        "begin": "2018-04-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-09T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "56a34d7c4bb5473485a5",
-        "begin": "2018-04-19T08:47:48.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-19T08:47:48.000Z"
       }
     ]
   },
@@ -1224,7 +891,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/major2nd/",
     "begin": "2018-04-07T08:35:00.000Z",
     "end": "2018-09-22T09:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1232,23 +898,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23821",
-        "begin": "2018-04-07T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "77612",
+        "begin": "2018-04-07T11:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "3acea77735904b2296ad",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1264,31 +920,15 @@
     "officialSite": "http://omagun.com/",
     "begin": "2018-04-02T11:55:00.000Z",
     "end": "2018-06-18T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "237046"
       },
       {
-        "site": "bilibili",
-        "id": "23825",
-        "begin": "2018-04-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
         "site": "youku",
         "id": "86b14eb32cd643ee8602",
-        "begin": "2018-04-17T04:29:31.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-17T04:29:31.000Z"
       }
     ]
   },
@@ -1306,7 +946,6 @@
     "officialSite": "http://www.toei-anim.co.jp/kitaro/",
     "begin": "2018-04-01T00:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1315,22 +954,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh0thmt",
-        "begin": "2018-04-01T03:24:25.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-01T03:24:25.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kitaro6",
-        "begin": "2018-04-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-15T03:00:00.000Z"
       }
     ]
   },
@@ -1346,7 +975,6 @@
     "officialSite": "http://gineiden-anime.com/",
     "begin": "2018-04-03T12:00:00.000Z",
     "end": "2018-06-26T12:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1354,33 +982,18 @@
       },
       {
         "site": "bilibili",
-        "id": "23870",
-        "begin": "2018-04-03T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78812",
+        "begin": "2018-04-03T13:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "gineiden-anime",
-        "begin": "2018-04-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-08T03:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "0WpGxCySAkCjIYk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1396,7 +1009,6 @@
     "officialSite": "http://kamuy-anime.com/",
     "begin": "2018-04-09T14:00:00.000Z",
     "end": "2018-06-25T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1405,22 +1017,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1gx6l",
-        "begin": "2018-04-09T15:25:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-09T15:25:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kamuy-anime",
-        "begin": "2018-07-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-14T03:00:00.000Z"
       }
     ]
   },
@@ -1436,7 +1038,6 @@
     "officialSite": "http://www.butlers-anime.com/",
     "begin": "2018-04-11T16:05:00.000Z",
     "end": "2018-06-27T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1444,63 +1045,33 @@
       },
       {
         "site": "bilibili",
-        "id": "23817",
-        "begin": "2018-04-11T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "77532",
+        "begin": "2018-04-11T16:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1osfx",
-        "begin": "2018-04-11T16:30:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-11T16:30:07.000Z"
       },
       {
         "site": "mgtv",
         "id": "323092",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "butlers",
-        "begin": "2018-04-20T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-20T13:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "u/uliokyyzrtrcl69",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "efbfbd1bc6b0efbfbd3d",
-        "begin": "2018-04-20T08:35:45.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-20T08:35:45.000Z"
       }
     ]
   },
@@ -1516,7 +1087,6 @@
     "officialSite": "http://piano-anime.jp/",
     "begin": "2018-04-08T15:10:00.000Z",
     "end": "2018-07-01T15:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1524,23 +1094,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23851",
-        "begin": "2018-04-08T18:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78372",
+        "begin": "2018-04-08T18:40:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80986797",
-        "begin": "2018-09-28T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-09-28T07:00:00.000Z"
       }
     ]
   },
@@ -1556,7 +1116,6 @@
     "officialSite": "http://hisomaso.com/",
     "begin": "2018-04-12T15:00:00.000Z",
     "end": "2018-06-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1565,12 +1124,7 @@
       {
         "site": "letv",
         "id": "10039077",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1586,7 +1140,6 @@
     "officialSite": "http://www.b-ch.com/ttl/index_html5.php?ttl_c=5991",
     "begin": "2018-04-07T23:30:00.000Z",
     "end": "2018-10-01T00:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1594,33 +1147,18 @@
       },
       {
         "site": "bilibili",
-        "id": "23855",
-        "begin": "2018-04-07T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "78492",
+        "begin": "2018-04-07T16:00:01.000Z"
       },
       {
         "site": "pptv",
         "id": "VpFibicGTKOnjbWcE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "581314d0c9c64af88217",
-        "begin": "2018-06-25T11:13:26.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-06-25T11:13:26.000Z"
       }
     ]
   },
@@ -1637,7 +1175,6 @@
     "officialSite": "http://www.takaratomy-arts.co.jp/specials/prichan/",
     "begin": "2018-04-08T01:00:00.000Z",
     "end": "2019-03-31T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1645,43 +1182,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23841",
-        "begin": "2018-04-08T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78172",
+        "begin": "2018-04-08T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgymz6t",
-        "begin": "2018-04-08T01:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-08T01:55:06.000Z"
       },
       {
         "site": "youku",
         "id": "a104308a08934ec59742",
-        "begin": "2018-04-22T02:05:49.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-22T02:05:49.000Z"
       },
       {
         "site": "nicovideo",
         "id": "prichan",
-        "begin": "2018-04-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-10T15:00:00.000Z"
       }
     ]
   },
@@ -1697,7 +1214,6 @@
     "officialSite": "http://boueibu.com/hk/",
     "begin": "2018-04-08T16:35:00.000Z",
     "end": "2018-07-01T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1705,43 +1221,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23866",
-        "begin": "2018-04-08T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78732",
+        "begin": "2018-04-08T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgymykl",
-        "begin": "2018-04-08T17:30:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-08T17:30:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "boueibu_hk",
-        "begin": "2018-04-22T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-22T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "b1ea43d04db14269b2fe",
-        "begin": "2018-04-26T03:06:53.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-26T03:06:53.000Z"
       }
     ]
   },
@@ -1760,7 +1256,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/sareryu/",
     "begin": "2018-04-05T16:58:00.000Z",
     "end": "2018-06-21T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1769,22 +1264,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhca3al",
-        "begin": "2018-04-05T20:05:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-05T20:05:04.000Z"
       },
       {
         "site": "nicovideo",
         "id": "sareryu",
-        "begin": "2018-04-05T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-05T21:00:00.000Z"
       }
     ]
   },
@@ -1800,7 +1285,6 @@
     "officialSite": "http://kakuriyo-anime.com/",
     "begin": "2018-04-02T13:30:00.000Z",
     "end": "2018-09-24T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1809,12 +1293,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh0gytx",
-        "begin": "2018-04-02T14:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-02T14:55:06.000Z"
       }
     ]
   },
@@ -1830,31 +1309,15 @@
     "officialSite": "http://tachibanakan-anime.com/",
     "begin": "2018-04-03T16:00:00.000Z",
     "end": "2018-06-19T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "232165"
       },
       {
-        "site": "bilibili",
-        "id": "23865",
-        "begin": "2018-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "tachibanakan-anime",
-        "begin": "2018-04-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-10T15:00:00.000Z"
       }
     ]
   },
@@ -1873,7 +1336,6 @@
     "officialSite": "http://kanshu.cf-anime.com/",
     "begin": "2018-04-01T16:00:00.000Z",
     "end": "2018-06-24T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1882,12 +1344,7 @@
       {
         "site": "nicovideo",
         "id": "kanshu",
-        "begin": "2018-04-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-01T16:00:00.000Z"
       }
     ]
   },
@@ -1907,7 +1364,6 @@
     "officialSite": "http://anime-umamusume.jp/",
     "begin": "2018-04-01T16:00:00.000Z",
     "end": "2018-06-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1915,33 +1371,18 @@
       },
       {
         "site": "bilibili",
-        "id": "23834",
-        "begin": "2018-04-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "77972",
+        "begin": "2018-04-01T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "anime-umamusume",
-        "begin": "2018-04-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-07T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "81025716",
-        "begin": "2018-10-14T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-14T16:00:00.000Z"
       }
     ]
   },
@@ -1961,7 +1402,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/captaintsubasa2018/",
     "begin": "2018-04-02T16:35:00.000Z",
     "end": "2019-04-01T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1970,12 +1410,7 @@
       {
         "site": "mgtv",
         "id": "322974",
-        "begin": "2018-04-02T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-02T18:30:00.000Z"
       }
     ]
   },
@@ -1994,7 +1429,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/captaintsubasa2018/",
     "begin": "2018-04-02T16:35:00.000Z",
     "end": "2019-04-01T16:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2003,22 +1437,12 @@
       {
         "site": "mgtv",
         "id": "322751",
-        "begin": "2018-04-02T18:30:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-02T18:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "captaintsubasa2018",
-        "begin": "2018-04-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-06T03:00:00.000Z"
       }
     ]
   },
@@ -2034,7 +1458,6 @@
     "officialSite": "http://akkun-kanojo.jp/",
     "begin": "2018-04-06T14:30:00.000Z",
     "end": "2018-09-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2042,53 +1465,28 @@
       },
       {
         "site": "bilibili",
-        "id": "23838",
-        "begin": "2018-04-06T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78112",
+        "begin": "2018-04-06T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyn0zh",
-        "begin": "2018-04-06T14:25:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-06T14:25:08.000Z"
       },
       {
         "site": "nicovideo",
         "id": "akkun-kanojo",
-        "begin": "2018-04-06T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-06T13:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "rezJR68VhcMmpAw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "33de35a5304245fc8333",
-        "begin": "2018-04-26T03:04:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-26T03:04:00.000Z"
       }
     ]
   },
@@ -2105,7 +1503,6 @@
     "officialSite": "http://rokuhoudou-anime.jp/",
     "begin": "2018-04-10T16:30:00.000Z",
     "end": "2018-06-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2113,23 +1510,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23873",
-        "begin": "2018-04-10T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78872",
+        "begin": "2018-04-10T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "rokuhoudou-anime",
-        "begin": "2018-04-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-17T15:00:00.000Z"
       }
     ]
   },
@@ -2145,7 +1532,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/beyblade/",
     "begin": "2018-04-02T08:55:00.000Z",
     "end": "2019-03-25T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2168,7 +1554,6 @@
     "officialSite": "http://ch.nicovideo.jp/lupin-pt5",
     "begin": "2018-04-03T16:34:00.000Z",
     "end": "2018-09-18T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2177,42 +1562,22 @@
       {
         "site": "pptv",
         "id": "uPnWVLwiaktAzsRk",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "lupin-pt5",
-        "begin": "2018-04-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-04T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "d0c2e735f2d3446889c8",
-        "begin": "2018-04-08T08:53:03.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-08T08:53:03.000Z"
       },
       {
         "site": "bilibili",
-        "id": "23854",
-        "begin": "2018-04-02T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "78472",
+        "begin": "2018-04-02T16:00:01.000Z"
       }
     ]
   },
@@ -2231,7 +1596,6 @@
     "officialSite": "http://anime-pad.com/",
     "begin": "2018-04-02T09:25:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2239,43 +1603,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23882",
-        "begin": "2018-04-02T10:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "79412",
+        "begin": "2018-04-02T10:25:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyp04l",
-        "begin": "2018-04-02T10:20:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-02T10:20:06.000Z"
       },
       {
         "site": "youku",
         "id": "30c74046e30f487eb6a8",
-        "begin": "2018-04-22T13:31:26.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-22T13:31:26.000Z"
       },
       {
         "site": "nicovideo",
         "id": "anime-pad",
-        "begin": "2018-04-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-05T03:00:00.000Z"
       }
     ]
   },
@@ -2287,7 +1631,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/wasimo/",
     "begin": "2018-04-02T09:00:00.000Z",
     "end": "2019-01-07T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2307,7 +1650,6 @@
     "officialSite": "http://gogo-gomachan.com/",
     "begin": "2018-04-03T09:45:00.000Z",
     "end": "2019-02-26T09:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2315,23 +1657,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23862",
-        "begin": "2018-04-03T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78652",
+        "begin": "2018-04-03T12:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyj859",
-        "begin": "2018-04-03T11:55:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-03T11:55:07.000Z"
       }
     ]
   },
@@ -2348,7 +1680,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/waka-okami/",
     "begin": "2018-04-07T22:14:00.000Z",
     "end": "2018-09-23T22:44:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2356,43 +1687,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23867",
-        "begin": "2018-04-07T23:14:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "78752",
+        "begin": "2018-04-07T23:14:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgypo7h",
-        "begin": "2018-04-07T23:10:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-07T23:10:07.000Z"
       },
       {
         "site": "youku",
         "id": "346028a59c344cc78149",
-        "begin": "2018-04-21T14:44:27.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-21T14:44:27.000Z"
       },
       {
         "site": "nicovideo",
         "id": "waka-okami",
-        "begin": "2018-04-14T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-14T15:00:00.000Z"
       }
     ]
   },
@@ -2408,7 +1719,6 @@
     "officialSite": "http://chissweethome.com/",
     "begin": "2018-04-07T22:00:00.000Z",
     "end": "2018-09-29T22:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2417,22 +1727,12 @@
       {
         "site": "mgtv",
         "id": "325000",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgx8wv9",
-        "begin": "2018-08-10T07:00:04.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-10T07:00:04.000Z"
       }
     ]
   },
@@ -2448,7 +1748,6 @@
     "officialSite": "http://neco-neco.jp/",
     "begin": "2018-04-04T09:45:00.000Z",
     "end": "2019-02-27T09:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2468,7 +1767,6 @@
     "officialSite": "http://www.souten-regenesis.com/",
     "begin": "2018-04-09T15:30:00.000Z",
     "end": "2018-06-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2476,43 +1774,23 @@
       },
       {
         "site": "bilibili",
-        "id": "23868",
-        "begin": "2018-04-02T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78772",
+        "begin": "2018-04-02T17:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "mdu0MpoAcK4Rjicc",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "cf2190d0fa6d4ea69e5e",
-        "begin": "2018-04-03T06:46:21.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-03T06:46:21.000Z"
       },
       {
         "site": "nicovideo",
         "id": "souten-regenesis",
-        "begin": "2018-05-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-08T03:00:00.000Z"
       }
     ]
   },
@@ -2528,7 +1806,6 @@
     "officialSite": "http://www.inazuma.jp/ares/",
     "begin": "2018-04-06T08:55:00.000Z",
     "end": "2018-09-28T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2537,32 +1814,17 @@
       {
         "site": "pptv",
         "id": "vPbfXcUrm9k8uiaI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "inazuma2018",
-        "begin": "2018-04-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-13T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "efbfbd1b3aefbfbdefbf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2578,7 +1840,6 @@
     "officialSite": "http://cutiehoney-u.com/",
     "begin": "2018-04-08T12:00:00.000Z",
     "end": "2018-06-24T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2587,12 +1848,7 @@
       {
         "site": "nicovideo",
         "id": "cutiehoney-u",
-        "begin": "2018-04-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-17T03:00:00.000Z"
       }
     ]
   },
@@ -2608,7 +1864,6 @@
     "officialSite": "http://megalobox.com/",
     "begin": "2018-04-05T16:28:00.000Z",
     "end": "2018-06-28T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2616,23 +1871,13 @@
       },
       {
         "site": "bilibili",
-        "id": "23880",
-        "begin": "2018-04-05T18:02:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "79472",
+        "begin": "2018-04-05T18:02:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "megalobox",
-        "begin": "2018-04-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-06T03:00:00.000Z"
       }
     ]
   },
@@ -2648,7 +1893,6 @@
     "officialSite": "https://www.tv-tokyo.co.jp/nana-na/",
     "begin": "2018-04-06T13:48:00.000Z",
     "end": "2018-09-14T12:54:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2657,42 +1901,22 @@
       {
         "site": "nicovideo",
         "id": "nana-na",
-        "begin": "2018-04-06T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-06T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhtelft",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "27048",
-        "begin": "2019-04-11T12:49:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "27601888",
+        "begin": "2019-04-11T12:49:00.000Z"
       },
       {
         "site": "youku",
         "id": "ecfa574023c3440fa38b",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2709,7 +1933,6 @@
     "officialSite": "http://heroaca.com/",
     "begin": "2018-04-07T08:30:00.000Z",
     "end": "2018-09-29T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2717,63 +1940,33 @@
       },
       {
         "site": "bilibili",
-        "id": "23858",
-        "begin": "2018-04-07T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78552",
+        "begin": "2018-04-07T09:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1t7kd",
-        "begin": "2018-04-07T09:25:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-07T09:25:07.000Z"
       },
       {
         "site": "pptv",
         "id": "gMGuLJT6aqgLiafE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "6/6djjzwtxh7u3kw2",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "47f8f41041bc4ef9a46a",
-        "begin": "2018-04-07T09:28:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-07T09:28:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "327148",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2789,31 +1982,15 @@
     "officialSite": "https://www.bs-sptv.com/gurazeni/",
     "begin": "2018-04-06T13:30:00.000Z",
     "end": "2018-06-22T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "211581"
       },
       {
-        "site": "bilibili",
-        "id": "23842",
-        "begin": "2018-04-06T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "gurazeni",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2832,7 +2009,6 @@
     "officialSite": "https://r.gnavi.co.jp/nobu/",
     "begin": "2018-04-13T03:00:00.000Z",
     "end": "2018-09-14T03:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2840,23 +2016,13 @@
       },
       {
         "site": "bilibili",
-        "id": "21785",
-        "begin": "2018-04-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "78692",
+        "begin": "2018-04-13T03:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "nobu_anime",
-        "begin": "2018-04-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-13T03:00:00.000Z"
       }
     ]
   },
@@ -2872,7 +2038,6 @@
     "officialSite": "http://amanchu-anime.com/",
     "begin": "2018-04-07T14:00:00.000Z",
     "end": "2018-06-23T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2880,33 +2045,18 @@
       },
       {
         "site": "bilibili",
-        "id": "23823",
-        "begin": "2018-04-07T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "77652",
+        "begin": "2018-04-07T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "amanchu2",
-        "begin": "2018-04-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-04-11T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "49e7e189ea8a4fd2a39e",
-        "begin": "2018-04-23T00:26:57.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-23T00:26:57.000Z"
       }
     ]
   },
@@ -2922,7 +2072,6 @@
     "officialSite": "http://meisakukun.com/",
     "begin": "2018-04-06T09:20:00.000Z",
     "end": "2019-02-22T09:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2942,7 +2091,6 @@
     "officialSite": "http://jp.frankenstein-family.com/",
     "begin": "2018-04-09T10:30:00.000Z",
     "end": "2018-06-25T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2950,13 +2098,8 @@
       },
       {
         "site": "bilibili",
-        "id": "24174",
-        "begin": "2018-04-10T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "78632",
+        "begin": "2018-04-10T02:00:00.000Z"
       }
     ]
   },
@@ -2972,7 +2115,6 @@
     "officialSite": "http://jp.frankenstein-family.com/",
     "begin": "2018-04-09T10:30:00.000Z",
     "end": "2018-06-25T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2980,23 +2122,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24173",
-        "begin": "2018-04-10T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "88872",
+        "begin": "2018-04-10T02:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "g/g6da8tj74x97ebk",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3012,17 +2144,11 @@
     "officialSite": "http://doreiku-anime.com/",
     "begin": "2018-04-12T16:00:00.000Z",
     "end": "2018-06-28T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
-        "id": "23860",
-        "begin": "2018-04-12T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": false,
-        "exist": true,
-        "comment": ""
+        "id": "78592",
+        "begin": "2018-04-12T17:00:00.000Z"
       },
       {
         "site": "bangumi",
@@ -3031,12 +2157,7 @@
       {
         "site": "nicovideo",
         "id": "doreiku-anime",
-        "begin": "2018-04-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-20T15:00:00.000Z"
       }
     ]
   },
@@ -3053,7 +2174,6 @@
     "officialSite": "http://fumikirijikan.com/",
     "begin": "2018-04-09T16:15:00.000Z",
     "end": "2018-06-25T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3061,53 +2181,28 @@
       },
       {
         "site": "bilibili",
-        "id": "23869",
-        "begin": "2018-04-08T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "78792",
+        "begin": "2018-04-08T16:00:01.000Z"
       },
       {
         "site": "letv",
         "id": "10039053",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "qibbPTbUbia8ksqhI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "e5a0bbe4a72a44178e4e",
-        "begin": "2018-04-11T08:52:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-11T08:52:37.000Z"
       },
       {
         "site": "nicovideo",
         "id": "fumikirijikan",
-        "begin": "2018-04-09T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-09T16:15:00.000Z"
       }
     ]
   },
@@ -3126,7 +2221,6 @@
     "officialSite": "http://tv-aichi.co.jp/fc-buddyfightX/",
     "begin": "2018-04-06T23:00:00.000Z",
     "end": "2018-05-25T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3146,7 +2240,6 @@
     "officialSite": "http://s.mxtv.jp/anime/ladysp/",
     "begin": "2018-04-09T16:20:00.000Z",
     "end": "2018-06-25T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3155,12 +2248,7 @@
       {
         "site": "nicovideo",
         "id": "ladysp",
-        "begin": "2018-04-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-17T03:00:00.000Z"
       }
     ]
   },
@@ -3176,7 +2264,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/youkai-watch-ss/",
     "begin": "2018-04-13T22:00:00.000Z",
     "end": "2019-03-29T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3185,22 +2272,12 @@
       {
         "site": "nicovideo",
         "id": "youkai-watch-ss",
-        "begin": "2018-04-20T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-20T03:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "328224",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3212,7 +2289,6 @@
     "officialSite": "http://kuronekomonroe.net/",
     "begin": "2018-04-16T17:46:00.000Z",
     "end": "2018-07-10T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3232,7 +2308,6 @@
     "officialSite": "http://ch.nicovideo.jp/sns-police",
     "begin": "2018-04-08T02:30:00.000Z",
     "end": "2018-06-03T02:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3241,12 +2316,7 @@
       {
         "site": "nicovideo",
         "id": "sns-police",
-        "begin": "2018-04-27T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-27T14:00:00.000Z"
       }
     ]
   },
@@ -3262,7 +2332,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/four_of_a_kind/",
     "begin": "2018-04-02T16:00:00.000Z",
     "end": "2018-10-07T18:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3271,22 +2340,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgyoxql",
-        "begin": "2018-04-01T18:30:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-01T18:30:07.000Z"
       },
       {
         "site": "youku",
         "id": "7cc4d59f89e7489ba836",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3305,7 +2364,6 @@
     "officialSite": "https://www.netflix.com/title/80198505/",
     "begin": "2018-04-20T07:00:00.000Z",
     "end": "2018-04-20T07:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3314,12 +2372,7 @@
       {
         "site": "netflix",
         "id": "80198505",
-        "begin": "2018-04-20T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-04-20T07:00:00.000Z"
       }
     ]
   },
@@ -3335,7 +2388,6 @@
     "officialSite": "http://liz-bluebird.com/",
     "begin": "2018-04-21T16:00:00.000Z",
     "end": "2018-04-21T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3344,22 +2396,12 @@
       {
         "site": "pptv",
         "id": "JGhFwyuRATibiaIIg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "fc65ffd3afac444683d1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -3375,7 +2417,6 @@
     "officialSite": "http://servamp-movie.jp/",
     "begin": "2018-04-07T16:00:00.000Z",
     "end": "2018-04-07T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -3383,23 +2424,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25951",
-        "begin": "2018-11-01T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "1340832",
+        "begin": "2018-11-01T10:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "servamp-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2018/05.json
+++ b/data/items/2018/05.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.oshiri-tantei.com/",
     "begin": "2018-05-03T00:00:00.000Z",
     "end": "2018-08-25T00:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgypp05",
-        "begin": "2018-05-03T02:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-03T02:55:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "oshiri-tantei",
-        "begin": "2018-05-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-11T03:00:00.000Z"
       }
     ]
   },
@@ -54,7 +43,6 @@
     "officialSite": "http://ch.nicovideo.jp/cf-vanguard",
     "begin": "2018-05-05T13:30:00.000Z",
     "end": "2019-04-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -63,12 +51,7 @@
       {
         "site": "nicovideo",
         "id": "cf-vanguard",
-        "begin": "2018-05-10T11:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-10T11:30:00.000Z"
       }
     ]
   },
@@ -84,17 +67,11 @@
     "officialSite": "http://www.tobe-hero.com/season2/",
     "begin": "2018-05-19T12:00:00.000Z",
     "end": "2018-07-07T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bilibili",
-        "id": "22087",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "23352",
+        "begin": ""
       },
       {
         "site": "bangumi",
@@ -103,12 +80,7 @@
       {
         "site": "nicovideo",
         "id": "TO_BE_HEROINE",
-        "begin": "2018-05-19T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-05-19T13:00:00.000Z"
       }
     ]
   },
@@ -124,7 +96,6 @@
     "officialSite": "",
     "begin": "2018-05-05T16:00:00.000Z",
     "end": "2018-05-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -133,22 +104,12 @@
       {
         "site": "nicovideo",
         "id": "digimon-adventure-tri06",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "efbfbd52efbfbd0befbf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -164,7 +125,6 @@
     "officialSite": "http://yamato2202.net/",
     "begin": "2018-05-25T16:00:00.000Z",
     "end": "2018-05-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -180,7 +140,6 @@
     "officialSite": "http://pp-movie.com/",
     "begin": "2018-05-05T16:00:00.000Z",
     "end": "2018-05-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -189,12 +148,7 @@
       {
         "site": "nicovideo",
         "id": "pp-movie-pretty-rhythm",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2018/06.json
+++ b/data/items/2018/06.json
@@ -11,7 +11,6 @@
     "officialSite": "http://fc-buddyfight.com/",
     "begin": "2018-06-01T23:00:00.000Z",
     "end": "2019-04-27T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -19,13 +18,8 @@
       },
       {
         "site": "bilibili",
-        "id": "24416",
-        "begin": "2018-06-01T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "97272",
+        "begin": "2018-06-01T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2018/07.json
+++ b/data/items/2018/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://never-island.com/",
     "begin": "2018-07-01T13:00:00.000Z",
     "end": "2018-09-16T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "nicovideo",
         "id": "never-island",
-        "begin": "2018-07-01T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-01T13:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "24571",
-        "begin": "2018-07-01T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "102292",
+        "begin": "2018-07-01T13:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://hanebad.com/",
     "begin": "2018-07-01T15:00:00.000Z",
     "end": "2018-09-30T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -59,63 +47,33 @@
       },
       {
         "site": "bilibili",
-        "id": "24589",
-        "begin": "2018-07-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102412",
+        "begin": "2018-07-01T16:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "325020",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgyth2t",
-        "begin": "2018-07-01T15:55:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-01T15:55:08.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hanebad",
-        "begin": "2018-07-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-03T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "e91b287f7ca14d968ae2",
-        "begin": "2018-07-02T02:22:39.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-02T02:22:39.000Z"
       },
       {
         "site": "netflix",
         "id": "81037374",
-        "begin": "2018-12-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-31T16:00:00.000Z"
       }
     ]
   },
@@ -132,7 +90,6 @@
     "officialSite": "http://ch.nicovideo.jp/senjyushi",
     "begin": "2018-07-03T14:00:00.000Z",
     "end": "2018-09-22T03:24:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,23 +97,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24618",
-        "begin": "2018-07-03T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102832",
+        "begin": "2018-07-03T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "senjyushi",
-        "begin": "2018-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -175,7 +122,6 @@
     "officialSite": "http://www.backstreetgirls-anime.toeiad.co.jp/",
     "begin": "2018-07-03T16:00:00.000Z",
     "end": "2018-09-04T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -183,23 +129,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24567",
-        "begin": "2018-07-03T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102512",
+        "begin": "2018-07-03T16:30:00.000Z"
       },
       {
         "site": "netflix",
         "id": "80996957",
-        "begin": "2018-12-12T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-12T08:00:00.000Z"
       }
     ]
   },
@@ -219,7 +155,6 @@
     "officialSite": "http://isekaimaou-anime.com/",
     "begin": "2018-07-05T12:30:00.000Z",
     "end": "2018-09-20T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -227,63 +162,33 @@
       },
       {
         "site": "bilibili",
-        "id": "24627",
-        "begin": "2018-07-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102752",
+        "begin": "2018-07-05T14:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgytgwd",
-        "begin": "2018-07-05T13:55:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-05T13:55:11.000Z"
       },
       {
         "site": "nicovideo",
         "id": "isekaimaou-anime",
-        "begin": "2018-07-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-06T03:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "b/bgf0avtujy3yciw",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "09b858009cc14850b246",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "netflix",
         "id": "81004514",
-        "begin": "2018-12-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-31T16:00:00.000Z"
       }
     ]
   },
@@ -300,7 +205,6 @@
     "officialSite": "http://chiochan.jp/",
     "begin": "2018-07-06T13:00:00.000Z",
     "end": "2018-09-21T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -308,23 +212,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24584",
-        "begin": "2018-07-06T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102552",
+        "begin": "2018-07-06T13:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "chiochan",
-        "begin": "2018-07-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-12T15:00:00.000Z"
       }
     ]
   },
@@ -343,7 +237,6 @@
     "officialSite": "",
     "begin": "2018-07-06T21:30:00.000Z",
     "end": "2019-06-29T22:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -366,7 +259,6 @@
     "officialSite": "http://hataraku-saibou.com/",
     "begin": "2018-07-07T15:00:00.000Z",
     "end": "2018-09-29T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -374,23 +266,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24588",
-        "begin": "2018-07-07T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102392",
+        "begin": "2018-07-07T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hataraku-saibou",
-        "begin": "2018-07-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-09T03:00:00.000Z"
       }
     ]
   },
@@ -407,7 +289,6 @@
     "officialSite": "http://asobiasobase.com/",
     "begin": "2018-07-08T14:30:00.000Z",
     "end": "2018-09-23T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -416,22 +297,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh6yfyh",
-        "begin": "2018-07-08T13:25:11.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-08T13:25:11.000Z"
       },
       {
         "site": "nicovideo",
         "id": "asobiasobase",
-        "begin": "2018-07-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-15T15:00:00.000Z"
       }
     ]
   },
@@ -447,7 +318,6 @@
     "officialSite": "http://cingeki-anime.com/",
     "begin": "2018-07-03T12:54:00.000Z",
     "end": "2018-09-25T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -455,23 +325,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24594",
-        "begin": "2018-07-03T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "103012",
+        "begin": "2018-07-03T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "cingeki-anime03",
-        "begin": "2018-07-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-04T03:00:00.000Z"
       }
     ]
   },
@@ -491,7 +351,6 @@
     "officialSite": "http://www.yamanosusume.com/",
     "begin": "2018-07-02T16:40:00.000Z",
     "end": "2018-09-24T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -499,33 +358,18 @@
       },
       {
         "site": "bilibili",
-        "id": "24605",
-        "begin": "2018-07-02T18:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102152",
+        "begin": "2018-07-02T18:55:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yamanosusume3rd",
-        "begin": "2018-06-04T04:00:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-06-04T04:00:01.000Z"
       },
       {
         "site": "pptv",
         "id": "friaVE3vhUYicycNg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -541,7 +385,6 @@
     "officialSite": "http://planet-with.com/",
     "begin": "2018-07-08T13:30:00.000Z",
     "end": "2018-09-23T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -550,22 +393,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgytgjp",
-        "begin": "2018-07-08T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-08T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "planet-with",
-        "begin": "2018-07-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-13T03:00:00.000Z"
       }
     ]
   },
@@ -584,7 +417,6 @@
     "officialSite": "http://happysugarlife.tv/",
     "begin": "2018-07-13T16:55:00.000Z",
     "end": "2018-09-28T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -593,12 +425,7 @@
       {
         "site": "nicovideo",
         "id": "happysugarlife",
-        "begin": "2018-10-29T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-29T03:00:00.000Z"
       }
     ]
   },
@@ -614,7 +441,6 @@
     "officialSite": "http://grandblue-anime.com/",
     "begin": "2018-07-13T17:25:00.000Z",
     "end": "2018-09-28T18:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -622,23 +448,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24581",
-        "begin": "2018-07-13T17:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102312",
+        "begin": "2018-07-13T17:25:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "grandblue-anime",
-        "begin": "2018-12-21T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-21T03:00:00.000Z"
       }
     ]
   },
@@ -657,7 +473,6 @@
     "officialSite": "http://hi-score-girl.com/",
     "begin": "2018-07-13T15:30:00.000Z",
     "end": "2018-09-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -666,22 +481,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgyterx",
-        "begin": "2018-07-13T18:25:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-13T18:25:10.000Z"
       },
       {
         "site": "netflix",
         "id": "80997338",
-        "begin": "2018-12-24T08:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-24T08:00:00.000Z"
       }
     ]
   },
@@ -700,7 +505,6 @@
     "officialSite": "http://revuestarlight.com/",
     "begin": "2018-07-12T16:28:00.000Z",
     "end": "2018-09-27T17:13:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -708,23 +512,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24622",
-        "begin": "2018-07-13T06:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102892",
+        "begin": "2018-07-13T06:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "revuestarlight",
-        "begin": "2018-07-12T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-12T21:00:00.000Z"
       }
     ]
   },
@@ -740,7 +534,6 @@
     "officialSite": "http://kyototeramachi-holmes.com/",
     "begin": "2018-07-09T17:10:00.000Z",
     "end": "2018-09-24T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -749,22 +542,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgxdbdp",
-        "begin": "2018-07-09T01:27:34.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-09T01:27:34.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kyototeramachi-holmes",
-        "begin": "2018-07-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-10T03:00:00.000Z"
       }
     ]
   },
@@ -780,21 +563,10 @@
     "officialSite": "http://baki-anime.jp/",
     "begin": "2018-07-01T15:30:00.000Z",
     "end": "2018-12-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "199373"
-      },
-      {
-        "site": "bilibili",
-        "id": "24602",
-        "begin": "2018-07-01T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
       }
     ]
   },
@@ -806,7 +578,6 @@
     "officialSite": "http://aguu-anime.com/",
     "begin": "2018-07-09T15:00:00.000Z",
     "end": "2018-09-24T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -815,22 +586,12 @@
       {
         "site": "mgtv",
         "id": "324710",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "aguu-anime",
-        "begin": "2018-07-11T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-11T16:00:00.000Z"
       }
     ]
   },
@@ -847,7 +608,6 @@
     "officialSite": "http://lord-of-vermilion.com/",
     "begin": "2018-07-13T16:05:00.000Z",
     "end": "2018-09-28T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -855,53 +615,28 @@
       },
       {
         "site": "bilibili",
-        "id": "24607",
-        "begin": "2018-07-13T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102852",
+        "begin": "2018-07-13T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6ubnd",
-        "begin": "2018-07-13T17:30:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-13T17:30:08.000Z"
       },
       {
         "site": "qq",
         "id": "2/2jje4zejg4yci94",
-        "begin": "2018-07-13T17:35:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-13T17:35:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "lord-of-vermilion",
-        "begin": "2018-07-21T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-21T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "ecc51c99e1be4a579ba4",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -920,7 +655,6 @@
     "officialSite": "http://jashinchan.com/",
     "begin": "2018-07-09T15:00:00.000Z",
     "end": "2018-09-17T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -928,23 +662,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24630",
-        "begin": "2018-07-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102112",
+        "begin": "2018-07-09T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "jashin_anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -960,7 +684,6 @@
     "officialSite": "http://ch.nicovideo.jp/angolmois",
     "begin": "2018-07-10T15:30:00.000Z",
     "end": "2018-09-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -968,33 +691,18 @@
       },
       {
         "site": "bilibili",
-        "id": "24595",
-        "begin": "2018-07-10T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "102692",
+        "begin": "2018-07-10T17:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "angolmois",
-        "begin": "2018-07-18T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-18T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "6d7c7cd82c1e46bdb213",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1010,7 +718,6 @@
     "officialSite": "http://yume-100-anime.com/",
     "begin": "2018-07-05T15:00:00.000Z",
     "end": "2018-09-20T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1018,23 +725,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24619",
-        "begin": "2018-07-05T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102812",
+        "begin": "2018-07-05T13:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yume-100",
-        "begin": "2018-07-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-09T03:00:00.000Z"
       }
     ]
   },
@@ -1052,7 +749,6 @@
     "officialSite": "http://satsuriku.com/",
     "begin": "2018-07-06T11:30:00.000Z",
     "end": "2018-10-26T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1060,43 +756,23 @@
       },
       {
         "site": "bilibili",
-        "id": "24625",
-        "begin": "2018-07-06T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102792",
+        "begin": "2018-07-06T13:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgytf8l",
-        "begin": "2018-07-06T12:55:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-06T12:55:12.000Z"
       },
       {
         "site": "nicovideo",
         "id": "satsuriku",
-        "begin": "2018-07-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-13T15:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "u/u8rljkriw7yeorg",
-        "begin": "2018-07-06T13:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-06T13:00:00.000Z"
       }
     ]
   },
@@ -1116,7 +792,6 @@
     "officialSite": "http://yuragisou.com/",
     "begin": "2018-07-14T14:30:00.000Z",
     "end": "2018-09-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1125,42 +800,22 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgyth5x",
-        "begin": "2018-07-14T15:55:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-14T15:55:10.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yuragisou",
-        "begin": "2018-07-16T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-16T03:00:00.000Z"
       },
       {
         "site": "netflix",
         "id": "81037377",
-        "begin": "2018-12-31T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-31T16:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "24593",
-        "begin": "2018-07-13T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "141572",
+        "begin": "2018-07-13T16:00:01.000Z"
       }
     ]
   },
@@ -1180,31 +835,15 @@
     "officialSite": "http://sunoharasou-anime.com/",
     "begin": "2018-07-05T12:00:00.000Z",
     "end": "2018-09-20T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "230110"
       },
       {
-        "site": "bilibili",
-        "id": "24583",
-        "begin": "2018-07-05T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "sunoharasou",
-        "begin": "2018-07-08T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-08T13:00:00.000Z"
       }
     ]
   },
@@ -1223,7 +862,6 @@
     "officialSite": "http://ongaku-shoujo.jp/",
     "begin": "2018-07-07T16:00:00.000Z",
     "end": "2018-09-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1231,23 +869,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24632",
-        "begin": "2018-07-07T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102032",
+        "begin": "2018-07-07T17:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ongaku-shoujo",
-        "begin": "2018-07-07T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-07T16:30:00.000Z"
       }
     ]
   },
@@ -1267,7 +895,6 @@
     "officialSite": "http://www.harukana-receive.jp/",
     "begin": "2018-07-06T16:40:00.000Z",
     "end": "2018-09-21T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1276,22 +903,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh6y4sl",
-        "begin": "2018-07-06T13:25:12.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-06T13:25:12.000Z"
       },
       {
         "site": "nicovideo",
         "id": "harukana-receive",
-        "begin": "2018-07-12T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-12T15:30:00.000Z"
       }
     ]
   },
@@ -1303,7 +920,6 @@
     "officialSite": "http://df.iwatobi-sc.com/",
     "begin": "2018-07-11T15:00:00.000Z",
     "end": "2018-09-26T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1311,23 +927,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24570",
-        "begin": "2018-07-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102232",
+        "begin": "2018-07-11T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "free-df",
-        "begin": "2018-07-14T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-14T14:30:00.000Z"
       }
     ]
   },
@@ -1343,7 +949,6 @@
     "officialSite": "https://shingeki.tv/season3/",
     "begin": "2018-07-22T15:35:00.000Z",
     "end": "2018-10-14T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1352,22 +957,12 @@
       {
         "site": "nicovideo",
         "id": "shingeki_season3",
-        "begin": "2018-07-30T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-30T03:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "24629",
-        "begin": "2018-07-22T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "117372",
+        "begin": "2018-07-22T18:05:00.000Z"
       }
     ]
   },
@@ -1383,7 +978,6 @@
     "officialSite": "http://www.tonegawa-anime.com/",
     "begin": "2018-07-03T17:04:00.000Z",
     "end": "2018-12-25T17:09:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1391,23 +985,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24611",
-        "begin": "2018-07-03T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102632",
+        "begin": "2018-07-03T20:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tonegawa-anime",
-        "begin": "2018-07-04T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-04T15:30:00.000Z"
       }
     ]
   },
@@ -1423,7 +1007,6 @@
     "officialSite": "http://shinya-bakabon.com/",
     "begin": "2018-07-10T16:40:00.000Z",
     "end": "2018-09-25T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1431,43 +1014,23 @@
       },
       {
         "site": "bilibili",
-        "id": "24626",
-        "begin": "2018-07-10T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102472",
+        "begin": "2018-07-10T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6ycz5",
-        "begin": "2018-07-10T17:40:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-10T17:40:10.000Z"
       },
       {
         "site": "nicovideo",
         "id": "shinya-bakabon",
-        "begin": "2018-07-15T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-15T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "01856a5271ed4474bfab",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1486,7 +1049,6 @@
     "officialSite": "http://7subaru.jp/",
     "begin": "2018-07-05T16:58:00.000Z",
     "end": "2018-09-20T17:29:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1494,13 +1056,8 @@
       },
       {
         "site": "bilibili",
-        "id": "24609",
-        "begin": "2018-07-06T06:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102732",
+        "begin": "2018-07-06T06:30:00.000Z"
       }
     ]
   },
@@ -1519,7 +1076,6 @@
     "officialSite": "http://hyakuren-anime.com/",
     "begin": "2018-07-07T16:30:00.000Z",
     "end": "2018-09-22T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1527,23 +1083,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24628",
-        "begin": "2018-07-07T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102772",
+        "begin": "2018-07-07T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hyakuren-anime",
-        "begin": "2018-07-10T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-10T16:30:00.000Z"
       }
     ]
   },
@@ -1559,7 +1105,6 @@
     "officialSite": "http://phantowa.com/",
     "begin": "2018-07-09T15:30:00.000Z",
     "end": "2018-09-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1567,33 +1112,18 @@
       },
       {
         "site": "bilibili",
-        "id": "24336",
-        "begin": "2018-07-05T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "95272",
+        "begin": "2018-07-05T04:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "phantowa",
-        "begin": "2018-07-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-10T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "1038efbfbd2fefbfbdef",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1609,7 +1139,6 @@
     "officialSite": "http://phantowa.com/",
     "begin": "2018-07-09T15:30:00.000Z",
     "end": "2018-09-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1618,22 +1147,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh6y6l9",
-        "begin": "2018-07-05T04:15:38.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-05T04:15:38.000Z"
       },
       {
         "site": "bilibili",
-        "id": "24333",
-        "begin": "2018-07-05T04:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "95292",
+        "begin": "2018-07-05T04:00:00.000Z"
       }
     ]
   },
@@ -1649,7 +1168,6 @@
     "officialSite": "http://tsukumogami.jp/",
     "begin": "2018-07-22T15:10:00.000Z",
     "end": "2018-10-14T15:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1657,23 +1175,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24586",
-        "begin": "2018-07-22T17:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102712",
+        "begin": "2018-07-22T17:10:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tsukumogami",
-        "begin": "2019-01-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-31T15:00:00.000Z"
       }
     ]
   },
@@ -1692,7 +1200,6 @@
     "officialSite": "http://www.hataoni.jp/",
     "begin": "2018-07-06T12:54:00.000Z",
     "end": "2018-09-21T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1700,23 +1207,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24613",
-        "begin": "2018-07-06T12:54:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "103072",
+        "begin": "2018-07-06T12:54:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hataoni2",
-        "begin": "2018-07-06T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-06T13:00:00.000Z"
       }
     ]
   },
@@ -1733,7 +1230,6 @@
     "officialSite": "http://bananafish.tv/",
     "begin": "2018-07-05T15:55:00.000Z",
     "end": "2018-12-20T17:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1742,12 +1238,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgytq5h",
-        "begin": "2018-07-06T00:13:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-06T00:13:01.000Z"
       }
     ]
   },
@@ -1763,7 +1254,6 @@
     "officialSite": "http://oneroom-anime.com/",
     "begin": "2018-07-02T16:35:00.000Z",
     "end": "2018-09-24T13:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1771,23 +1261,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24572",
-        "begin": "2018-07-02T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "103032",
+        "begin": "2018-07-02T16:35:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "oneroom2nd",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1806,7 +1286,6 @@
     "officialSite": "http://overlord-anime.com/",
     "begin": "2018-07-10T15:30:00.000Z",
     "end": "2018-10-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1814,23 +1293,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24596",
-        "begin": "2018-07-10T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102252",
+        "begin": "2018-07-10T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "overlord-anime3",
-        "begin": "2018-07-17T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-17T15:30:00.000Z"
       }
     ]
   },
@@ -1847,7 +1316,6 @@
     "officialSite": "http://ch.nicovideo.jp/joshiochi",
     "begin": "2018-07-01T16:00:00.000Z",
     "end": "2018-08-26T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1856,12 +1324,7 @@
       {
         "site": "nicovideo",
         "id": "joshiochi",
-        "begin": "2018-07-01T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-01T16:00:00.000Z"
       }
     ]
   },
@@ -1877,7 +1340,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/yamishibai/",
     "begin": "2018-07-06T19:00:00.000Z",
     "end": "2018-09-28T19:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1885,43 +1347,23 @@
       },
       {
         "site": "bilibili",
-        "id": "24635",
-        "begin": "2018-07-06T19:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "103092",
+        "begin": "2018-07-06T19:55:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yamishibai6",
-        "begin": "2018-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-07T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6yfr1",
-        "begin": "2018-07-06T20:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-06T20:00:10.000Z"
       },
       {
         "site": "youku",
         "id": "90a4a55ffbf547329da5",
-        "begin": "2018-07-06T19:58:01.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-06T19:58:01.000Z"
       }
     ]
   },
@@ -1937,7 +1379,6 @@
     "officialSite": "",
     "begin": "2018-07-03T16:35:00.000Z",
     "end": "2018-09-18T16:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1953,7 +1394,6 @@
     "officialSite": "",
     "begin": "2018-07-12T17:42:00.000Z",
     "end": "2019-07-18T17:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1973,7 +1413,6 @@
     "officialSite": "http://sirius-the-jaeger.com/",
     "begin": "2018-07-12T15:30:00.000Z",
     "end": "2018-09-27T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1981,43 +1420,23 @@
       },
       {
         "site": "bilibili",
-        "id": "24620",
-        "begin": "2018-07-11T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "102272",
+        "begin": "2018-07-11T16:00:01.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrgytf5h",
-        "begin": "2018-07-12T15:25:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-12T15:25:10.000Z"
       },
       {
         "site": "qq",
         "id": "5/5tbi0vej2cqtofj",
-        "begin": "2018-07-12T15:30:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-12T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "0028141ea8f64ac0970e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2034,7 +1453,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/gintama/",
     "begin": "2018-07-08T16:35:00.000Z",
     "end": "2018-10-07T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2043,12 +1461,7 @@
       {
         "site": "youku",
         "id": "cc0026e0962411de83b1",
-        "begin": "2011-10-28T04:57:52.000Z",
-        "official": false,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2011-10-28T04:57:52.000Z"
       }
     ]
   },
@@ -2064,7 +1477,6 @@
     "officialSite": "http://fanworks.co.jp/news/20180625_ani/",
     "begin": "2018-07-09T12:54:00.000Z",
     "end": "2018-12-17T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2073,22 +1485,12 @@
       {
         "site": "nicovideo",
         "id": "anitsuke2",
-        "begin": "2018-07-09T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-09T13:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "m/maa2g8kqchabbgl",
-        "begin": "2017-07-02T04:00:00.000Z",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2017-07-02T04:00:00.000Z"
       }
     ]
   },
@@ -2104,7 +1506,6 @@
     "officialSite": "http://fairilu.jp/",
     "begin": "2018-07-06T23:15:00.000Z",
     "end": "2019-01-05T23:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2113,32 +1514,17 @@
       {
         "site": "nicovideo",
         "id": "fairilu",
-        "begin": "2018-07-28T22:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-28T22:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "24579",
-        "begin": "2018-07-06T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "127092",
+        "begin": "2018-07-06T16:00:01.000Z"
       },
       {
         "site": "pptv",
         "id": "WY9o5k60JGLFQ6s",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2157,7 +1543,6 @@
     "officialSite": "https://anime.bang-dream.com/pico/",
     "begin": "2018-07-06T13:45:00.000Z",
     "end": "2018-09-28T13:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2166,32 +1551,17 @@
       {
         "site": "pptv",
         "id": "6ywJhib9VxQNm5Ew",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "girls-band-party-pico",
-        "begin": "2018-08-23T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-23T11:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "24569",
-        "begin": "2018-07-06T13:45:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "135252",
+        "begin": "2018-07-06T13:45:00.000Z"
       }
     ]
   },
@@ -2207,7 +1577,6 @@
     "officialSite": "http://www.zombie-girl.net/",
     "begin": "2018-07-04T16:00:00.000Z",
     "end": "2018-07-04T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2216,12 +1585,7 @@
       {
         "site": "nicovideo",
         "id": "aruzombie-sainan",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2237,7 +1601,6 @@
     "officialSite": "http://swordgai-anime.com/",
     "begin": "2018-07-31T16:00:00.000Z",
     "end": "2018-07-31T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2245,13 +1608,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25002",
-        "begin": "2018-07-31T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "114472",
+        "begin": "2018-07-31T07:00:00.000Z"
       }
     ]
   },
@@ -2267,7 +1625,6 @@
     "officialSite": "http://iyapan-anime.com/",
     "begin": "2018-07-14T09:30:00.000Z",
     "end": "2018-08-18T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2276,12 +1633,7 @@
       {
         "site": "nicovideo",
         "id": "iyapan-anime",
-        "begin": "2018-07-21T09:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-07-21T09:30:00.000Z"
       }
     ]
   },
@@ -2293,7 +1645,6 @@
     "officialSite": "http://k-project.jpn.com/",
     "begin": "2018-07-07T16:00:00.000Z",
     "end": "2018-08-04T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2302,12 +1653,7 @@
       {
         "site": "nicovideo",
         "id": "k-seven-stories",
-        "begin": "2018-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -2323,7 +1669,6 @@
     "officialSite": "http://www.spacebug-special.com/",
     "begin": "2018-07-08T01:30:00.000Z",
     "end": "2019-01-06T01:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2332,12 +1677,7 @@
       {
         "site": "nicovideo",
         "id": "space-bug",
-        "begin": "2018-07-09T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-09T14:00:00.000Z"
       }
     ]
   },
@@ -2353,7 +1693,6 @@
     "officialSite": "https://torays.tales-ch.jp/special/shortAnime/",
     "begin": "2018-07-20T16:00:00.000Z",
     "end": "2018-07-21T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2362,12 +1701,7 @@
       {
         "site": "nicovideo",
         "id": "tales-of-the-rays-theater",
-        "begin": "2018-07-21T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-21T12:00:00.000Z"
       }
     ]
   },
@@ -2383,7 +1717,6 @@
     "officialSite": "",
     "begin": "2018-07-01T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2392,12 +1725,7 @@
       {
         "site": "youku",
         "id": "6e7ec73857014aca8d26",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2413,7 +1741,6 @@
     "officialSite": "http://www.pokemon-movie.jp/",
     "begin": "2018-07-13T16:00:00.000Z",
     "end": "2018-07-13T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2422,12 +1749,7 @@
       {
         "site": "youku",
         "id": "34d5a5beda334772994f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2443,7 +1765,6 @@
     "officialSite": "http://nekoparaova.com/ex/index.html",
     "begin": "2018-07-27T16:00:00.000Z",
     "end": "2018-07-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2451,13 +1772,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25152",
-        "begin": "2018-07-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "119312",
+        "begin": "2018-07-26T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2018/08.json
+++ b/data/items/2018/08.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "2018-08-10T16:00:00.000Z",
     "end": "2019-01-15T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -19,33 +18,18 @@
       },
       {
         "site": "bilibili",
-        "id": "25235",
-        "begin": "2018-08-10T02:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "121632",
+        "begin": "2018-08-10T02:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh5d28h",
-        "begin": "2018-08-10T02:00:10.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-10T02:00:10.000Z"
       },
       {
         "site": "youku",
         "id": "2b3198dba4224afeb63c",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -61,7 +45,6 @@
     "officialSite": "http://mahouritsu.com/",
     "begin": "2018-08-03T16:00:00.000Z",
     "end": "2018-10-19T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -70,22 +53,12 @@
       {
         "site": "qq",
         "id": "g/gfjzjo0ea0f5oqn",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "mahouritsu",
-        "begin": "2018-09-03T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-09-03T15:30:00.000Z"
       }
     ]
   },
@@ -101,7 +74,6 @@
     "officialSite": "",
     "begin": "2018-08-04T16:00:00.000Z",
     "end": "2018-09-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,12 +82,7 @@
       {
         "site": "nicovideo",
         "id": "k-seven-stories",
-        "begin": "2018-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -131,7 +98,6 @@
     "officialSite": "",
     "begin": "2018-08-25T16:00:00.000Z",
     "end": "2018-08-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,12 +106,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrgxoyjx",
-        "begin": "2018-08-26T03:54:40.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-08-26T03:54:40.000Z"
       }
     ]
   },
@@ -161,7 +122,6 @@
     "officialSite": "http://nonnontv.com/movie/",
     "begin": "2018-08-25T16:00:00.000Z",
     "end": "2018-08-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -169,23 +129,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26632",
-        "begin": "2019-02-27T01:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "16899731",
+        "begin": "2019-02-27T01:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "97eeedf898794a38bbc3",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -201,7 +151,6 @@
     "officialSite": "http://www.7-taizai-movie.net/",
     "begin": "2018-08-18T16:00:00.000Z",
     "end": "2018-08-18T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -210,12 +159,7 @@
       {
         "site": "nicovideo",
         "id": "7-taizai-movie",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2018/09.json
+++ b/data/items/2018/09.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "2018-09-01T16:00:00.000Z",
     "end": "2018-10-06T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "k-seven-stories",
-        "begin": "2018-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://coco-tama.com/",
     "begin": "2018-09-06T08:55:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "nicovideo",
         "id": "coco-tama",
-        "begin": "2018-09-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-09-11T03:00:00.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "http://dabudeka.com/",
     "begin": "2018-09-30T13:30:00.000Z",
     "end": "2018-12-30T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -79,13 +66,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25605",
-        "begin": "2018-09-30T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "140652",
+        "begin": "2018-09-30T14:00:00.000Z"
       }
     ]
   },
@@ -101,7 +83,6 @@
     "officialSite": "http://kimisui-anime.com/",
     "begin": "2018-09-01T16:00:00.000Z",
     "end": "2018-09-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,12 +91,7 @@
       {
         "site": "nicovideo",
         "id": "kimisui-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -131,7 +107,6 @@
     "officialSite": "http://flcl-anime.com/alterna/",
     "begin": "2018-09-07T16:00:00.000Z",
     "end": "2018-09-07T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,12 +115,7 @@
       {
         "site": "nicovideo",
         "id": "flcl_alterna_progre",
-        "begin": "2019-02-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-01T03:00:00.000Z"
       }
     ]
   },
@@ -161,7 +131,6 @@
     "officialSite": "http://flcl-anime.com/progre/",
     "begin": "2018-09-28T16:00:00.000Z",
     "end": "2018-09-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,12 +139,7 @@
       {
         "site": "nicovideo",
         "id": "flcl_alterna_progre",
-        "begin": "2019-02-01T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-01T03:00:00.000Z"
       }
     ]
   }

--- a/data/items/2018/10.json
+++ b/data/items/2018/10.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.precure-superstars.com/",
     "begin": "2018-10-27T16:00:00.000Z",
     "end": "2018-10-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "nicovideo",
         "id": "futariha-precure",
-        "begin": "2018-10-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-12T15:00:00.000Z"
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "",
     "begin": "2018-10-06T16:00:00.000Z",
     "end": "2018-11-03T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "nicovideo",
         "id": "k-seven-stories",
-        "begin": "2018-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -71,7 +59,6 @@
     "officialSite": "http://haikarasan.net/",
     "begin": "2018-10-19T16:00:00.000Z",
     "end": "2018-10-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -95,7 +82,6 @@
     "officialSite": "http://jojo-animation.com/",
     "begin": "2018-10-05T16:05:00.000Z",
     "end": "2019-07-28T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -103,13 +89,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25681",
-        "begin": "2018-10-05T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "135652",
+        "begin": "2018-10-05T17:35:00.000Z"
       }
     ]
   },
@@ -125,7 +106,6 @@
     "officialSite": "http://releasethespyce.jp/",
     "begin": "2018-10-07T14:30:00.000Z",
     "end": "2018-12-22T18:08:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -133,23 +113,13 @@
       },
       {
         "site": "acfun",
-        "url": "http://www.acfun.cn/bangumi/aa5022156",
-        "begin": "2018-10-07T18:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5022156",
+        "begin": "2018-10-07T18:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "releasethespyce",
-        "begin": "2018-10-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-09T03:00:00.000Z"
       }
     ]
   },
@@ -166,7 +136,6 @@
     "officialSite": "http://akanesasushojo.com/",
     "begin": "2018-10-01T10:30:00.000Z",
     "end": "2018-12-17T11:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -174,23 +143,13 @@
       },
       {
         "site": "acfun",
-        "url": "http://www.acfun.cn/bangumi/aa5022158",
-        "begin": "2018-10-01T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": true,
-        "exist": true,
-        "comment": ""
+        "id": "5022158",
+        "begin": "2018-10-01T11:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "akanesasushojo",
-        "begin": "2018-10-01T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-01T10:30:00.000Z"
       }
     ]
   },
@@ -206,7 +165,6 @@
     "officialSite": "http://sidem-wakemini.com/",
     "begin": "2018-10-09T12:54:00.000Z",
     "end": "2018-12-25T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -214,23 +172,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25623",
-        "begin": "2018-10-09T13:54:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139472",
+        "begin": "2018-10-09T13:54:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "sidem-wakemini",
-        "begin": "2018-10-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-10T03:00:00.000Z"
       }
     ]
   },
@@ -247,7 +195,6 @@
     "officialSite": "http://gridman.net/",
     "begin": "2018-10-06T15:00:00.000Z",
     "end": "2018-12-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -256,22 +203,12 @@
       {
         "site": "qq",
         "id": "o/o28lfr4elqppz6q",
-        "begin": "2018-10-06T18:00:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-06T18:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ssss-gridman",
-        "begin": "2018-10-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-13T15:00:00.000Z"
       }
     ]
   },
@@ -290,7 +227,6 @@
     "officialSite": "http://tiramisu-anime.com/",
     "begin": "2018-10-01T16:00:00.000Z",
     "end": "2018-12-24T16:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -298,23 +234,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25806",
-        "begin": "2018-10-01T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "140332",
+        "begin": "2018-10-01T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "tiramisu-anime2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -334,7 +260,6 @@
     "officialSite": "http://www.ten-sura.com/",
     "begin": "2018-10-01T15:00:00.000Z",
     "end": "2019-03-25T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -342,53 +267,28 @@
       },
       {
         "site": "bilibili",
-        "id": "25739",
-        "begin": "2018-10-01T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139252",
+        "begin": "2018-10-01T16:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "3/3qpalo6ldy0i4bf",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh707nd",
-        "begin": "2018-10-01T16:25:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-01T16:25:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ten-sura",
-        "begin": "2018-10-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-03T03:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "327848",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -408,7 +308,6 @@
     "officialSite": "https://sao-alicization.net/",
     "begin": "2018-10-06T15:00:00.000Z",
     "end": "2019-03-30T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -416,33 +315,18 @@
       },
       {
         "site": "bilibili",
-        "id": "25510",
-        "begin": "2018-10-06T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "130412",
+        "begin": "2018-10-06T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1temd",
-        "begin": "2018-10-06T16:25:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-06T16:25:08.000Z"
       },
       {
         "site": "nicovideo",
         "id": "sao-alicization",
-        "begin": "2018-10-13T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-13T16:00:00.000Z"
       }
     ]
   },
@@ -458,7 +342,6 @@
     "officialSite": "http://toaru-project.com/index_3/",
     "begin": "2018-10-05T13:00:00.000Z",
     "end": "2019-04-05T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -466,43 +349,23 @@
       },
       {
         "site": "bilibili",
-        "id": "25617",
-        "begin": "2018-10-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "134912",
+        "begin": "2018-10-05T14:30:00.000Z"
       },
       {
         "site": "qq",
         "id": "u/u3r3qhz2icswkw1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh1tfn9",
-        "begin": "2018-10-05T14:25:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-05T14:25:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "index_3",
-        "begin": "2018-10-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-11T03:00:00.000Z"
       }
     ]
   },
@@ -518,7 +381,6 @@
     "officialSite": "http://juliet-anime.com/",
     "begin": "2018-10-05T16:25:00.000Z",
     "end": "2018-12-21T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -527,22 +389,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh5ky7t",
-        "begin": "2018-10-05T18:25:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-05T18:25:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "juliet-anime",
-        "begin": "2018-12-21T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-21T03:00:00.000Z"
       }
     ]
   },
@@ -561,7 +413,6 @@
     "officialSite": "http://www.goblinslayer.jp/",
     "begin": "2018-10-06T16:30:00.000Z",
     "end": "2018-12-25T03:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -570,22 +421,12 @@
       {
         "site": "nicovideo",
         "id": "goblin-slayer",
-        "begin": "2018-10-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-06T16:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh709x1",
-        "begin": "2018-10-06T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-06T16:30:00.000Z"
       }
     ]
   },
@@ -601,7 +442,6 @@
     "officialSite": "http://ao-buta.com/",
     "begin": "2018-10-03T17:20:00.000Z",
     "end": "2018-12-26T17:50:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -609,33 +449,18 @@
       },
       {
         "site": "bilibili",
-        "id": "25733",
-        "begin": "2018-10-03T18:50:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "134932",
+        "begin": "2018-10-03T18:50:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6z4oh",
-        "begin": "2018-10-03T18:45:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-03T18:45:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ao-buta",
-        "begin": "2018-10-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-07T03:00:00.000Z"
       }
     ]
   },
@@ -652,31 +477,15 @@
     "officialSite": "http://uzamaid.com/",
     "begin": "2018-10-05T16:40:00.000Z",
     "end": "2018-12-21T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "242670"
       },
       {
-        "site": "bilibili",
-        "id": "25613",
-        "begin": "2018-10-05T15:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "uzamaid",
-        "begin": "2018-10-13T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-13T15:30:00.000Z"
       }
     ]
   },
@@ -692,7 +501,6 @@
     "officialSite": "http://kamuy-anime.com/",
     "begin": "2018-10-08T14:00:00.000Z",
     "end": "2018-12-24T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -701,12 +509,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh1gx6l",
-        "begin": "2018-10-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-08T15:30:00.000Z"
       }
     ]
   },
@@ -723,7 +526,6 @@
     "officialSite": "http://soraumi-anime.com/",
     "begin": "2018-10-03T15:00:00.000Z",
     "end": "2018-12-19T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -731,33 +533,18 @@
       },
       {
         "site": "acfun",
-        "url": "http://www.acfun.cn/bangumi/aa5022159",
-        "begin": "2018-10-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5022159",
+        "begin": "2018-10-03T16:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "25687",
-        "begin": "2018-10-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "140752",
+        "begin": "2018-10-03T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "soraumi-anime",
-        "begin": "2018-10-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-10T03:00:00.000Z"
       }
     ]
   },
@@ -777,7 +564,6 @@
     "officialSite": "https://zombielandsaga.com/",
     "begin": "2018-10-04T15:00:00.000Z",
     "end": "2018-12-20T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -785,33 +571,18 @@
       },
       {
         "site": "acfun",
-        "url": "http://www.acfun.cn/bangumi/aa5022161",
-        "begin": "2018-10-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5022161",
+        "begin": "2018-10-04T16:30:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "25689",
-        "begin": "2018-10-04T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "140772",
+        "begin": "2018-10-04T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "zombielandsaga",
-        "begin": "2018-10-07T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-07T13:00:00.000Z"
       }
     ]
   },
@@ -827,7 +598,6 @@
     "officialSite": "http://hinomaru-zumou.com/",
     "begin": "2018-10-05T13:00:00.000Z",
     "end": "2019-03-29T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -836,42 +606,22 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh6z4f9",
-        "begin": "2018-10-05T14:55:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-05T14:55:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hinomaru-zumou",
-        "begin": "2018-10-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-11T03:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "25730",
-        "begin": "2018-10-05T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "139672",
+        "begin": "2018-10-05T13:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "e1be99b8f2b34a68a701",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -890,7 +640,6 @@
     "officialSite": "http://yagakimi.com/",
     "begin": "2018-10-05T12:30:00.000Z",
     "end": "2018-12-28T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -898,23 +647,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25622",
-        "begin": "2018-10-05T14:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "138832",
+        "begin": "2018-10-05T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "yagakimi",
-        "begin": "2018-10-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-11T15:30:00.000Z"
       }
     ]
   },
@@ -930,7 +669,6 @@
     "officialSite": "http://iroduku.jp/",
     "begin": "2018-10-05T16:55:00.000Z",
     "end": "2018-12-28T18:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -939,12 +677,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh70a9p",
-        "begin": "2018-10-05T17:20:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-05T17:20:06.000Z"
       }
     ]
   },
@@ -961,7 +694,6 @@
     "officialSite": "http://kyuketsukisan-anime.com/",
     "begin": "2018-10-06T13:00:00.000Z",
     "end": "2018-12-21T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -969,23 +701,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25619",
-        "begin": "2018-10-05T13:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139632",
+        "begin": "2018-10-05T13:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kyuketsukisan-anime",
-        "begin": "2018-10-13T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-13T16:30:00.000Z"
       }
     ]
   },
@@ -1001,7 +723,6 @@
     "officialSite": "http://animayell.com/",
     "begin": "2018-10-07T15:00:00.000Z",
     "end": "2018-12-23T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1009,43 +730,23 @@
       },
       {
         "site": "bilibili",
-        "id": "25624",
-        "begin": "2018-10-07T16:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139392",
+        "begin": "2018-10-07T16:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh5b6h5",
-        "begin": "2018-10-07T15:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-07T15:55:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "animayell",
-        "begin": "2018-10-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-11T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "6f30448090fa4a56a061",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1062,7 +763,6 @@
     "officialSite": "http://imo-imo.jp/",
     "begin": "2018-10-10T16:35:00.000Z",
     "end": "2018-12-19T12:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1070,23 +770,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25717",
-        "begin": "2018-10-10T14:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139612",
+        "begin": "2018-10-10T14:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "imo-imo",
-        "begin": "2018-10-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-17T15:00:00.000Z"
       }
     ]
   },
@@ -1102,7 +792,6 @@
     "officialSite": "http://beelmama.com/",
     "begin": "2018-10-10T17:50:00.000Z",
     "end": "2018-12-26T18:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1110,33 +799,18 @@
       },
       {
         "site": "bilibili",
-        "id": "25697",
-        "begin": "2018-10-10T18:50:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139272",
+        "begin": "2018-10-10T18:50:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh707kx",
-        "begin": "2018-10-10T18:45:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-10T18:45:08.000Z"
       },
       {
         "site": "nicovideo",
         "id": "beelmama",
-        "begin": "2018-10-15T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-15T03:00:00.000Z"
       }
     ]
   },
@@ -1152,7 +826,6 @@
     "officialSite": "http://ch.nicovideo.jp/dakaretai-1st",
     "begin": "2018-10-05T15:00:00.000Z",
     "end": "2018-12-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1161,12 +834,7 @@
       {
         "site": "nicovideo",
         "id": "dakaretai-1st",
-        "begin": "2018-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -1182,7 +850,6 @@
     "officialSite": "http://ulysses-anime.jp/",
     "begin": "2018-10-07T13:00:00.000Z",
     "end": "2018-12-30T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1191,22 +858,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh707zp",
-        "begin": "2018-10-07T13:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-07T13:55:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "ulysses-anime",
-        "begin": "2018-10-11T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-11T15:30:00.000Z"
       }
     ]
   },
@@ -1223,31 +880,15 @@
     "officialSite": "http://conception-anime.com/",
     "begin": "2018-10-09T16:30:00.000Z",
     "end": "2018-12-25T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "245531"
       },
       {
-        "site": "bilibili",
-        "id": "25607",
-        "begin": "2018-10-09T16:30:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "conception-anime",
-        "begin": "2018-11-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-04T15:00:00.000Z"
       }
     ]
   },
@@ -1264,7 +905,6 @@
     "officialSite": "http://gaikotsu-honda-anime.com/",
     "begin": "2018-10-07T15:30:00.000Z",
     "end": "2018-12-23T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1272,53 +912,28 @@
       },
       {
         "site": "bilibili",
-        "id": "25663",
-        "begin": "2018-10-07T16:45:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "134952",
+        "begin": "2018-10-07T16:45:00.000Z"
       },
       {
         "site": "qq",
         "id": "x/xhuchai0qv1s0gy",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh70aed",
-        "begin": "2018-10-07T16:40:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-07T16:40:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "gaikotsu-honda-anime",
-        "begin": "2018-10-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-07T15:30:00.000Z"
       },
       {
         "site": "youku",
         "id": "39abc53891a1483d906e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1334,7 +949,6 @@
     "officialSite": "http://www.marv.jp/special/tokyoghoul/",
     "begin": "2018-10-09T14:00:00.000Z",
     "end": "2018-12-18T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1342,13 +956,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25727",
-        "begin": "2018-10-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "140692",
+        "begin": "2018-10-09T15:00:00.000Z"
       }
     ]
   },
@@ -1364,7 +973,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/gakuen_basara/",
     "begin": "2018-10-04T16:28:00.000Z",
     "end": "2018-12-20T17:08:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1372,23 +980,13 @@
       },
       {
         "site": "acfun",
-        "url": "http://www.acfun.cn/bangumi/aa5022160",
-        "begin": "2018-10-04T18:20:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5022160",
+        "begin": "2018-10-04T18:20:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "gakuen_basara",
-        "begin": "2018-11-18T11:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-18T11:00:00.000Z"
       }
     ]
   },
@@ -1407,7 +1005,6 @@
     "officialSite": "http://himotehouse.com/",
     "begin": "2018-10-07T15:45:00.000Z",
     "end": "2018-12-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1416,22 +1013,12 @@
       {
         "site": "nicovideo",
         "id": "himotehouse_anime",
-        "begin": "2018-10-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-11T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "9fd74b2316b7497496d5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1447,7 +1034,6 @@
     "officialSite": "http://rerided.com/",
     "begin": "2018-10-03T16:05:00.000Z",
     "end": "2018-12-19T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1455,23 +1041,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25610",
-        "begin": "2018-09-22T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "139372",
+        "begin": "2018-09-22T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "rerided",
-        "begin": "2018-10-04T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-04T03:00:00.000Z"
       }
     ]
   },
@@ -1487,7 +1063,6 @@
     "officialSite": "https://devidol.com",
     "begin": "2018-10-04T16:05:00.000Z",
     "end": "2018-12-20T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1496,12 +1071,7 @@
       {
         "site": "nicovideo",
         "id": "devidol",
-        "begin": "2018-10-04T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-04T16:35:00.000Z"
       }
     ]
   },
@@ -1517,7 +1087,6 @@
     "officialSite": "http://senran2.tv/",
     "begin": "2018-10-12T17:10:00.000Z",
     "end": "2018-12-28T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1526,12 +1095,7 @@
       {
         "site": "nicovideo",
         "id": "senran2",
-        "begin": "2018-10-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-17T03:00:00.000Z"
       }
     ]
   },
@@ -1551,7 +1115,6 @@
     "officialSite": "http://www.mercstoria.jp/",
     "begin": "2018-10-11T14:30:00.000Z",
     "end": "2018-12-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1559,33 +1122,18 @@
       },
       {
         "site": "bilibili",
-        "id": "25699",
-        "begin": "2018-10-11T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139452",
+        "begin": "2018-10-11T14:30:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh40p5h",
-        "begin": "2018-10-11T14:25:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-11T14:25:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "mercstoria",
-        "begin": "2018-10-15T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-15T15:00:00.000Z"
       }
     ]
   },
@@ -1604,7 +1152,6 @@
     "officialSite": "http://hangyakusei-anime.com/",
     "begin": "2018-10-25T13:00:00.000Z",
     "end": "2018-12-27T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1612,23 +1159,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25720",
-        "begin": "2018-10-25T13:00:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139412",
+        "begin": "2018-10-25T13:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hangyakusei-anime",
-        "begin": "2018-10-28T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-28T15:30:00.000Z"
       }
     ]
   },
@@ -1649,7 +1186,6 @@
     "officialSite": "http://www.nhk.or.jp/anime/radiant/",
     "begin": "2018-10-06T08:35:00.000Z",
     "end": "2019-02-23T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1658,12 +1194,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh73tp5",
-        "begin": "2018-10-06T10:25:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-06T10:25:07.000Z"
       }
     ]
   },
@@ -1679,7 +1210,6 @@
     "officialSite": "http://tsurune.com/",
     "begin": "2018-10-14T15:10:00.000Z",
     "end": "2019-01-20T15:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1687,13 +1217,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25696",
-        "begin": "2018-10-21T17:10:00.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139292",
+        "begin": "2018-10-21T17:10:00.000Z"
       }
     ]
   },
@@ -1709,7 +1234,6 @@
     "officialSite": "http://ch.nicovideo.jp/jingaisan",
     "begin": "2018-10-02T16:00:00.000Z",
     "end": "2018-12-18T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1718,42 +1242,22 @@
       {
         "site": "nicovideo",
         "id": "jingaisan",
-        "begin": "2018-10-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-09T15:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "25711",
-        "begin": "2018-10-02T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "142612",
+        "begin": "2018-10-02T16:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "MHpT0TmfD02wLpY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "c14cdbcdd5ea4405b61c",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1770,7 +1274,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/bbh/",
     "begin": "2018-10-02T08:55:00.000Z",
     "end": "2019-03-26T09:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1779,12 +1282,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh5b5nt",
-        "begin": "2018-10-02T10:55:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-02T10:55:06.000Z"
       }
     ]
   },
@@ -1800,7 +1298,6 @@
     "officialSite": "http://kazetsuyo-anime.com/",
     "begin": "2018-10-02T16:34:00.000Z",
     "end": "2019-03-26T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1808,43 +1305,23 @@
       },
       {
         "site": "bilibili",
-        "id": "25742",
-        "begin": "2018-10-02T17:29:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139352",
+        "begin": "2018-10-02T17:29:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh6z5bd",
-        "begin": "2018-10-02T17:25:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-02T17:25:06.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kazetsuyo-anime",
-        "begin": "2018-10-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-04T15:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "326589",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1863,7 +1340,6 @@
     "officialSite": "http://kitsune-no-koe.com/",
     "begin": "2018-10-10T17:00:00.000Z",
     "end": "2018-12-21T13:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1872,22 +1348,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh6lqht",
-        "begin": "2018-10-18T23:30:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-18T23:30:07.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kitsunenokoe",
-        "begin": "2018-10-11T16:10:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-11T16:10:00.000Z"
       }
     ]
   },
@@ -1906,7 +1372,6 @@
     "officialSite": "",
     "begin": "2018-10-11T13:30:00.000Z",
     "end": "2019-06-27T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1914,13 +1379,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25615",
-        "begin": "2018-10-10T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139432",
+        "begin": "2018-10-10T15:00:00.000Z"
       }
     ]
   },
@@ -1936,7 +1396,6 @@
     "officialSite": "http://ingressanime.com/",
     "begin": "2018-10-17T15:55:00.000Z",
     "end": "2018-12-26T15:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1945,22 +1404,12 @@
       {
         "site": "pptv",
         "id": "sib7HRa0Tg8Ekogo",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "e4e6b437e16746fa82f8",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1976,7 +1425,6 @@
     "officialSite": "http://xuanyuansword.net/",
     "begin": "2018-10-01T17:20:00.000Z",
     "end": "2018-12-24T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1985,22 +1433,12 @@
       {
         "site": "nicovideo",
         "id": "xuanyuansword",
-        "begin": "2018-10-05T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-05T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "ac807426248b4f689137",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2016,7 +1454,6 @@
     "officialSite": "https://www.yte.co.jp/program/detail.php?id=107",
     "begin": "2018-10-03T13:24:00.000Z",
     "end": "2018-12-19T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2024,23 +1461,13 @@
       },
       {
         "site": "bilibili",
-        "id": "24365",
-        "begin": "2018-10-03T13:24:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "96092",
+        "begin": "2018-10-03T13:24:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "horamimi",
-        "begin": "2018-10-04T13:55:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-04T13:55:00.000Z"
       }
     ]
   },
@@ -2056,7 +1483,6 @@
     "officialSite": "http://www.ytv.co.jp/animegyakuten/",
     "begin": "2018-10-06T08:30:00.000Z",
     "end": "2019-01-19T09:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2064,23 +1490,13 @@
       },
       {
         "site": "bilibili",
-        "id": "25740",
-        "begin": "2018-10-06T10:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "139332",
+        "begin": "2018-10-06T10:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrh40qo1",
-        "begin": "2018-10-06T09:55:08.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-06T09:55:08.000Z"
       }
     ]
   },
@@ -2096,7 +1512,6 @@
     "officialSite": "http://www.souten-regenesis.com/",
     "begin": "2018-10-08T16:30:00.000Z",
     "end": "2018-12-24T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2105,32 +1520,17 @@
       {
         "site": "pptv",
         "id": "1h36eOBGtvRX1T0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "53bb422602a14473ae69",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "25848",
-        "begin": "2018-10-01T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "140972",
+        "begin": "2018-10-01T17:00:00.000Z"
       }
     ]
   },
@@ -2146,7 +1546,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/BAKUMATSU/",
     "begin": "2018-10-04T17:13:00.000Z",
     "end": "2018-12-20T17:38:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2155,12 +1554,7 @@
       {
         "site": "nicovideo",
         "id": "anime_BAKUMATSU",
-        "begin": "2018-10-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-05T15:00:00.000Z"
       }
     ]
   },
@@ -2176,7 +1570,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/inazuma2018/",
     "begin": "2018-10-05T08:55:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2185,22 +1578,12 @@
       {
         "site": "nicovideo",
         "id": "inazuma_orion",
-        "begin": "2018-10-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-10T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "edc6e8528cf84a46b09a",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2216,7 +1599,6 @@
     "officialSite": "",
     "begin": "2018-10-05T22:55:00.000Z",
     "end": "2019-03-29T22:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2236,7 +1618,6 @@
     "officialSite": "http://vap.co.jp/chitosechan/",
     "begin": "2018-10-05T16:35:00.000Z",
     "end": "2019-03-29T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2245,12 +1626,7 @@
       {
         "site": "nicovideo",
         "id": "chitosechan",
-        "begin": "2018-10-06T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-06T03:00:00.000Z"
       }
     ]
   },
@@ -2266,21 +1642,10 @@
     "officialSite": "http://ch.nicovideo.jp/gurazeni",
     "begin": "2018-10-05T13:30:00.000Z",
     "end": "2018-12-21T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "251060"
-      },
-      {
-        "site": "bilibili",
-        "id": "25666",
-        "begin": "2018-10-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
       }
     ]
   },
@@ -2299,7 +1664,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/fairytail/",
     "begin": "2018-10-06T22:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2308,22 +1672,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhbp78p",
-        "begin": "2018-10-06T23:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-06T23:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "fairytail_final",
-        "begin": "2018-10-08T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-08T03:00:00.000Z"
       }
     ]
   },
@@ -2339,7 +1693,6 @@
     "officialSite": "https://shucap.cf-anime.com/",
     "begin": "2018-10-07T16:00:00.000Z",
     "end": "2018-12-23T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2348,12 +1701,7 @@
       {
         "site": "nicovideo",
         "id": "syu_capu",
-        "begin": "2018-10-07T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2018-10-07T16:00:00.000Z"
       }
     ]
   },
@@ -2372,7 +1720,6 @@
     "officialSite": "http://hashiyoka.com/",
     "begin": "2018-10-08T17:40:00.000Z",
     "end": "2018-10-29T17:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2381,22 +1728,12 @@
       {
         "site": "youku",
         "id": "ecfc18d9505348439c17",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "25856",
-        "begin": "2018-10-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "2435657",
+        "begin": "2018-10-07T16:00:01.000Z"
       }
     ]
   },
@@ -2412,7 +1749,6 @@
     "officialSite": "",
     "begin": "2018-10-08T16:25:00.000Z",
     "end": "2018-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2434,7 +1770,6 @@
     "officialSite": "http://www.sonokano.com/",
     "begin": "2018-10-06T15:35:00.000Z",
     "end": "2018-12-22T15:40:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2443,12 +1778,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh45j41",
-        "begin": "2018-10-06T16:25:07.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-06T16:25:07.000Z"
       }
     ]
   },
@@ -2464,7 +1794,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/aigan_kaiju/",
     "begin": "2018-10-07T16:00:00.000Z",
     "end": "2019-09-22T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2473,32 +1802,17 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh40qeh",
-        "begin": "2018-10-06T22:54:06.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-10-06T22:54:06.000Z"
       },
       {
         "site": "bilibili",
-        "id": "25851",
-        "begin": "2018-10-07T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "141052",
+        "begin": "2018-10-07T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "025a041ead444cad8b64",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2510,7 +1824,6 @@
     "officialSite": "https://www.seizeiganbare.jp",
     "begin": "2018-10-27T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2519,12 +1832,7 @@
       {
         "site": "nicovideo",
         "id": "seizeiganbare02",
-        "begin": "2018-11-05T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-11-05T15:00:00.000Z"
       }
     ]
   },
@@ -2540,7 +1848,6 @@
     "officialSite": "http://yamato2202.net",
     "begin": "2018-10-05T16:00:00.000Z",
     "end": "2019-03-29T16:23:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2549,12 +1856,7 @@
       {
         "site": "pptv",
         "id": "ticLbWcEnl9U4th4",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2570,7 +1872,6 @@
     "officialSite": "http://www.thunderboltfantasy.com/season2/",
     "begin": "2018-10-01T16:00:00.000Z",
     "end": "2018-12-24T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2579,12 +1880,7 @@
       {
         "site": "youku",
         "id": "20ec0115cf6d4e5ab5e1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -2600,7 +1896,6 @@
     "officialSite": "http://roosterteeth.com/show/rwby",
     "begin": "2018-10-27T16:00:00.000Z",
     "end": "2019-01-26T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -2608,13 +1903,8 @@
       },
       {
         "site": "bilibili",
-        "id": "25955",
-        "begin": "2018-10-26T16:00:01.000Z",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "2430940",
+        "begin": "2018-10-26T16:00:01.000Z"
       }
     ]
   }

--- a/data/items/2018/11.json
+++ b/data/items/2018/11.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "2018-11-03T16:00:00.000Z",
     "end": "2018-12-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "nicovideo",
         "id": "k-seven-stories",
-        "begin": "2018-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-07T03:00:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "24978",
-        "begin": "2018-11-03T16:00:00.000Z",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "113852",
+        "begin": "2018-11-03T16:00:00.000Z"
       }
     ]
   },
@@ -51,7 +40,6 @@
     "officialSite": "http://itachiland.com/okojoandyamane/",
     "begin": "2018-07-19T15:00:00.000Z",
     "end": "2019-01-08T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -71,7 +59,6 @@
     "officialSite": "http://yamato2202.net/",
     "begin": "2018-11-02T16:00:00.000Z",
     "end": "2018-11-02T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -80,12 +67,7 @@
       {
         "site": "pptv",
         "id": "1xz5d99FtfNW1Dw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -101,7 +83,6 @@
     "officialSite": "http://eurekaseven.jp/",
     "begin": "2018-11-10T16:00:00.000Z",
     "end": "2018-11-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -110,12 +91,7 @@
       {
         "site": "nicovideo",
         "id": "anemone-eurekaseven",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -131,7 +107,6 @@
     "officialSite": "http://kaiju-gk.jp/anime/black/",
     "begin": "2018-11-23T16:00:00.000Z",
     "end": "2018-11-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -140,12 +115,7 @@
       {
         "site": "nicovideo",
         "id": "kaiju-girls-black",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -161,7 +131,6 @@
     "officialSite": "http://www.monogatari-series.com/zokuowarimonogatari",
     "begin": "2018-11-10T16:00:00.000Z",
     "end": "2018-11-10T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -170,12 +139,7 @@
       {
         "site": "nicovideo",
         "id": "zokuowarimonogatari",
-        "begin": "2019-05-20T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-05-20T03:00:00.000Z"
       }
     ]
   }

--- a/data/items/2018/12.json
+++ b/data/items/2018/12.json
@@ -7,7 +7,6 @@
     "officialSite": "",
     "begin": "2018-12-01T16:00:00.000Z",
     "end": "2018-12-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -16,12 +15,7 @@
       {
         "site": "nicovideo",
         "id": "k-seven-stories",
-        "begin": "2018-07-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-07-07T03:00:00.000Z"
       }
     ]
   },
@@ -37,7 +31,6 @@
     "officialSite": "https://www.saintia-sho.com/",
     "begin": "2018-12-10T10:00:00.000Z",
     "end": "2019-02-25T10:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -46,22 +39,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrh40fa5",
-        "begin": "2018-12-10T11:25:09.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-10T11:25:09.000Z"
       },
       {
         "site": "pptv",
         "id": "9zgVkicth0Q9y8Fg",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -77,7 +60,6 @@
     "officialSite": "http://www.saikikusuo.com/spot/anime/",
     "begin": "2018-12-27T22:35:00.000Z",
     "end": "2018-12-27T23:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -86,42 +68,22 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhvm9yx",
-        "begin": "2018-12-27T23:30:16.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-27T23:30:16.000Z"
       },
       {
         "site": "bilibili",
-        "id": "26347",
-        "begin": "2018-12-28T00:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "5195852",
+        "begin": "2018-12-28T00:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "saikikusuo_final",
-        "begin": "2018-12-28T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2018-12-28T15:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "f41aa66f58ee4943a067",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -137,7 +99,6 @@
     "officialSite": "https://p5a.jp/",
     "begin": "2018-12-30T15:00:00.000Z",
     "end": "2018-12-30T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -145,23 +106,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26354",
-        "begin": "2018-12-30T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "5581418",
+        "begin": "2018-12-30T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "p5a_DarkSun",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2019/01.json
+++ b/data/items/2019/01.json
@@ -11,7 +11,6 @@
     "officialSite": "http://www.domekano-anime.com/",
     "begin": "2019-01-11T16:55:00.000Z",
     "end": "2019-03-29T17:04:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,22 +19,12 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhw1vqx",
-        "begin": "2019-01-30T11:46:53.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-30T11:46:53.000Z"
       },
       {
         "site": "nicovideo",
         "id": "domekano",
-        "begin": "2019-02-11T16:40:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-11T16:40:00.000Z"
       }
     ]
   },
@@ -54,7 +43,6 @@
     "officialSite": "http://magical-five.jp/",
     "begin": "2019-01-11T17:25:00.000Z",
     "end": "2019-03-29T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -63,32 +51,17 @@
       {
         "site": "pptv",
         "id": "1x36eOBGtvRX1T0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "magical-five",
-        "begin": "2019-02-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-12T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "572d17108f574e25b36e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -104,7 +77,6 @@
     "officialSite": "",
     "begin": "2019-01-12T14:30:00.000Z",
     "end": "2019-03-30T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -112,23 +84,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26274",
-        "begin": "2019-01-12T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5267730",
+        "begin": "2019-01-12T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kaguya_love",
-        "begin": "2019-01-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-14T03:00:00.000Z"
       }
     ]
   },
@@ -144,7 +106,6 @@
     "officialSite": "http://endro.jp/",
     "begin": "2019-01-12T16:00:00.000Z",
     "end": "2019-03-30T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -153,22 +114,12 @@
       {
         "site": "nicovideo",
         "id": "endro",
-        "begin": "2019-01-12T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-12T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "0hbicfeVLuiclc2kI",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -187,7 +138,6 @@
     "officialSite": "https://pasumemotv.com/",
     "begin": "2019-01-07T15:30:00.000Z",
     "end": "2019-03-25T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -196,32 +146,17 @@
       {
         "site": "nicovideo",
         "id": "pasumemotv",
-        "begin": "2019-01-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-09T15:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "328057",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "pptv",
         "id": "8zwZlic9l1RN29Fw",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -237,7 +172,6 @@
     "officialSite": "http://wz-anime.net/",
     "begin": "2019-01-05T16:30:00.000Z",
     "end": "2019-03-30T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -245,23 +179,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26301",
-        "begin": "2019-01-05T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5346052",
+        "begin": "2019-01-05T17:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "wz-anime",
-        "begin": "2019-02-16T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-16T16:30:00.000Z"
       }
     ]
   },
@@ -277,7 +201,6 @@
     "officialSite": "http://mononokean.tv/",
     "begin": "2019-01-06T13:00:00.000Z",
     "end": "2019-03-30T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -285,33 +208,18 @@
       },
       {
         "site": "bilibili",
-        "id": "26300",
-        "begin": "2019-01-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5267026",
+        "begin": "2019-01-05T14:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "328007",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "mononokean2",
-        "begin": "2019-01-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-11T03:00:00.000Z"
       }
     ]
   },
@@ -327,7 +235,6 @@
     "officialSite": "http://watatentv.com/",
     "begin": "2019-01-08T13:00:00.000Z",
     "end": "2019-03-26T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -335,23 +242,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26291",
-        "begin": "2019-01-08T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4316442",
+        "begin": "2019-01-08T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "watatentv",
-        "begin": "2019-01-08T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-08T16:00:00.000Z"
       }
     ]
   },
@@ -367,7 +264,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/5hanayome/",
     "begin": "2019-01-10T16:33:00.000Z",
     "end": "2019-03-28T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -375,23 +271,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26283",
-        "begin": "2019-01-10T17:33:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4316382",
+        "begin": "2019-01-10T17:33:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "5hanayome",
-        "begin": "2019-01-11T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-11T15:00:00.000Z"
       }
     ]
   },
@@ -410,7 +296,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/grimmsnotes/",
     "begin": "2019-01-10T17:03:00.000Z",
     "end": "2019-03-28T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -418,23 +303,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26280",
-        "begin": "2019-01-11T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5871233",
+        "begin": "2019-01-11T07:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "grimmsnotes_anime",
-        "begin": "2019-01-10T21:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-10T21:00:00.000Z"
       }
     ]
   },
@@ -451,7 +326,6 @@
     "officialSite": "http://egaonodaika.com/",
     "begin": "2019-01-07T13:30:00.000Z",
     "end": "2019-03-22T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -459,23 +333,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26304",
-        "begin": "2019-01-04T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4760998",
+        "begin": "2019-01-04T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "egaonodaika",
-        "begin": "2019-01-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-09T15:00:00.000Z"
       }
     ]
   },
@@ -492,7 +356,6 @@
     "officialSite": "http://minitoji.jp/",
     "begin": "2019-01-07T12:54:00.000Z",
     "end": "2019-03-16T17:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -501,42 +364,22 @@
       {
         "site": "pptv",
         "id": "UJt08lrAMG7RT7c",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "minitoji",
-        "begin": "2019-01-08T19:05:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-08T19:05:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhvgkj9",
-        "begin": "2019-01-25T06:12:37.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-25T06:12:37.000Z"
       },
       {
         "site": "youku",
         "id": "6c9d09af744242ef9f83",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -552,7 +395,6 @@
     "officialSite": "http://shieldhero-anime.jp/",
     "begin": "2019-01-09T16:05:00.000Z",
     "end": "2019-06-26T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -560,23 +402,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26284",
-        "begin": "2019-01-02T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4316482",
+        "begin": "2019-01-02T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "shieldhero-anime",
-        "begin": "2019-01-16T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-16T15:00:00.000Z"
       }
     ]
   },
@@ -595,7 +427,6 @@
     "officialSite": "http://gaf-anime.jp/",
     "begin": "2019-01-10T14:00:00.000Z",
     "end": "2019-03-28T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -604,22 +435,12 @@
       {
         "site": "nicovideo",
         "id": "gaf-anime",
-        "begin": "2019-01-16T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-16T16:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "UJpz8VmicL23QTrY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -635,7 +456,6 @@
     "officialSite": "http://kakegurui-anime.com/",
     "begin": "2019-01-08T17:30:00.000Z",
     "end": "2019-03-26T18:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -644,22 +464,12 @@
       {
         "site": "pptv",
         "id": "HVEibvCSKibjiabGYE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "655d921f47634e31b2f9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -675,7 +485,6 @@
     "officialSite": "http://kemurikusa.com/",
     "begin": "2019-01-09T13:30:00.000Z",
     "end": "2019-03-27T13:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -683,23 +492,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26285",
-        "begin": "2019-01-09T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4316422",
+        "begin": "2019-01-09T13:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kemurikusa",
-        "begin": "2019-01-22T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-22T15:00:00.000Z"
       }
     ]
   },
@@ -715,7 +514,6 @@
     "officialSite": "http://hizaue.com/",
     "begin": "2019-01-09T14:30:00.000Z",
     "end": "2019-03-27T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -723,23 +521,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26289",
-        "begin": "2019-01-09T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4762694",
+        "begin": "2019-01-09T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hizaue",
-        "begin": "2019-01-13T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-13T15:00:00.000Z"
       }
     ]
   },
@@ -755,7 +543,6 @@
     "officialSite": "http://mobpsycho100.com/",
     "begin": "2019-01-07T14:00:00.000Z",
     "end": "2019-04-01T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -763,13 +550,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26297",
-        "begin": "2019-01-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4762734",
+        "begin": "2019-01-07T15:30:00.000Z"
       }
     ]
   },
@@ -786,7 +568,6 @@
     "officialSite": "",
     "begin": "2019-01-13T13:30:00.000Z",
     "end": "2019-03-31T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -795,32 +576,17 @@
       {
         "site": "nicovideo",
         "id": "kotobuki-anime",
-        "begin": "2019-01-26T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-26T13:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "2BHibfORKuvhb2UE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "4f231cec4d2a4191af96",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -837,7 +603,6 @@
     "officialSite": "http://manaria.jp/",
     "begin": "2019-01-20T15:30:00.000Z",
     "end": "2019-03-24T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -845,23 +610,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26271",
-        "begin": "2019-01-20T16:45:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4315722",
+        "begin": "2019-01-20T16:45:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "manaria",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -880,7 +635,6 @@
     "officialSite": "http://www.miss-ueno.com/",
     "begin": "2019-01-06T15:30:00.000Z",
     "end": "2019-03-24T15:45:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -888,23 +642,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26298",
-        "begin": "2019-01-06T16:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4762714",
+        "begin": "2019-01-06T16:15:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "miss-ueno",
-        "begin": "2019-01-09T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-09T15:00:00.000Z"
       }
     ]
   },
@@ -920,7 +664,6 @@
     "officialSite": "http://anime.bang-dream.com/2nd/",
     "begin": "2019-01-03T14:00:00.000Z",
     "end": "2019-03-28T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -928,23 +671,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26305",
-        "begin": "2019-01-03T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4762002",
+        "begin": "2019-01-03T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "bang-dream_2nd",
-        "begin": "2019-01-10T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-10T13:30:00.000Z"
       }
     ]
   },
@@ -960,7 +693,6 @@
     "officialSite": "http://neverland-anime.com/",
     "begin": "2019-01-10T15:55:00.000Z",
     "end": "2019-03-28T16:55:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -968,23 +700,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26281",
-        "begin": "2019-01-10T17:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5267750",
+        "begin": "2019-01-10T17:25:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "neverland-anime",
-        "begin": "2019-01-11T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-11T03:00:00.000Z"
       }
     ]
   },
@@ -1000,7 +722,6 @@
     "officialSite": "http://rainycocoa.jp/anime/",
     "begin": "2019-01-08T16:35:00.000Z",
     "end": "2019-03-26T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1008,23 +729,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26294",
-        "begin": "2019-01-08T16:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5873044",
+        "begin": "2019-01-08T16:35:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "rainycocoa_sideG",
-        "begin": "2019-01-08T16:40:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-08T16:40:00.000Z"
       }
     ]
   },
@@ -1040,7 +751,6 @@
     "officialSite": "http://date-a-live-anime.com/",
     "begin": "2019-01-11T16:40:00.000Z",
     "end": "2019-03-29T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1048,43 +758,23 @@
       },
       {
         "site": "bilibili",
-        "id": "26308",
-        "begin": "2019-01-11T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4762754",
+        "begin": "2019-01-11T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "date-a-live3",
-        "begin": "2019-01-17T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-17T15:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "g/gtn6ik9kapbiqm0",
-        "begin": "2019-01-11T14:00:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-11T14:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "c2442ed22d944c79969f",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1100,7 +790,6 @@
     "officialSite": "http://colorful-pastrale.com/",
     "begin": "2019-01-12T13:00:00.000Z",
     "end": "2019-03-30T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1109,22 +798,12 @@
       {
         "site": "nicovideo",
         "id": "colorful-pastrale",
-        "begin": "2019-01-12T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-12T13:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "wQ3qaNA2puRHxS0",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1140,7 +819,6 @@
     "officialSite": "http://meikoi.com/tv-anime/",
     "begin": "2019-01-09T14:30:00.000Z",
     "end": "2019-03-27T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1148,23 +826,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26307",
-        "begin": "2018-12-31T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "5268246",
+        "begin": "2018-12-31T15:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "meikoi-anime",
-        "begin": "2019-01-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-10T03:00:00.000Z"
       }
     ]
   },
@@ -1180,7 +848,6 @@
     "officialSite": "http://bpro-anime.com/",
     "begin": "2019-01-11T15:00:00.000Z",
     "end": "2019-03-29T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1188,33 +855,18 @@
       },
       {
         "site": "bilibili",
-        "id": "26277",
-        "begin": "2019-01-11T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5269634",
+        "begin": "2019-01-11T16:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "bpro-anime2",
-        "begin": "2019-01-14T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-14T03:00:00.000Z"
       },
       {
         "site": "pptv",
         "id": "8ToTkflfzw1w7lY",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1230,7 +882,6 @@
     "officialSite": "http://kemono-friends.jp/anime/",
     "begin": "2019-01-14T17:05:00.000Z",
     "end": "2019-04-01T17:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1238,43 +889,23 @@
       },
       {
         "site": "bilibili",
-        "id": "26295",
-        "begin": "2019-01-14T18:05:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5345112",
+        "begin": "2019-01-14T18:05:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kemono-friends2",
-        "begin": "2019-01-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-07T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhvma21",
-        "begin": "2019-01-14T18:00:05.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-14T18:00:05.000Z"
       },
       {
         "site": "youku",
         "id": "f4e60d496a0d48039eea",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1294,7 +925,6 @@
     "officialSite": "",
     "begin": "2019-01-08T14:00:00.000Z",
     "end": "2019-03-26T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1302,23 +932,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26350",
-        "begin": "2019-01-08T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "5268038",
+        "begin": "2019-01-08T14:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "cirpri-anime",
-        "begin": "2019-01-13T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-13T13:00:00.000Z"
       }
     ]
   },
@@ -1334,7 +954,6 @@
     "officialSite": "http://boogiepop-anime.com/",
     "begin": "2019-01-04T13:00:00.000Z",
     "end": "2019-03-29T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1342,23 +961,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26303",
-        "begin": "2019-01-04T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4316462",
+        "begin": "2019-01-04T13:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "boogiepop-anime",
-        "begin": "2019-01-10T16:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-10T16:30:00.000Z"
       }
     ]
   },
@@ -1374,7 +983,6 @@
     "officialSite": "http://www.3dkanojo-anime.com/",
     "begin": "2019-01-08T16:59:00.000Z",
     "end": "2019-03-26T17:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1394,7 +1002,6 @@
     "officialSite": "http://dimension-hs.com/",
     "begin": "2019-01-10T13:00:00.000Z",
     "end": "2019-03-28T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1403,12 +1010,7 @@
       {
         "site": "nicovideo",
         "id": "dimension-hs",
-        "begin": "2019-01-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-13T03:00:00.000Z"
       }
     ]
   },
@@ -1420,7 +1022,6 @@
     "officialSite": "http://pso2.jp/players/community/anime/pso2comi/",
     "begin": "2019-01-08T06:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1440,7 +1041,6 @@
     "officialSite": "http://piano-anime.jp/",
     "begin": "2019-01-27T15:10:00.000Z",
     "end": "2019-04-14T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1448,13 +1048,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26268",
-        "begin": "2019-01-27T18:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4315702",
+        "begin": "2019-01-27T18:00:00.000Z"
       }
     ]
   },
@@ -1470,7 +1065,6 @@
     "officialSite": "http://revisions.jp/",
     "begin": "2019-01-09T16:05:00.000Z",
     "end": "2019-03-27T16:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1478,13 +1072,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26286",
-        "begin": "2019-01-09T18:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4316402",
+        "begin": "2019-01-09T18:55:00.000Z"
       }
     ]
   },
@@ -1500,7 +1089,6 @@
     "officialSite": "https://dororo-anime.com/",
     "begin": "2019-01-07T13:00:00.000Z",
     "end": "2019-06-24T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1508,13 +1096,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26146",
-        "begin": "2019-01-07T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "4312482",
+        "begin": "2019-01-07T14:00:00.000Z"
       }
     ]
   },
@@ -1530,7 +1113,6 @@
     "officialSite": "http://papashita.cf-anime.com/",
     "begin": "2019-01-06T15:00:00.000Z",
     "end": "2019-02-24T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1539,12 +1121,7 @@
       {
         "site": "nicovideo",
         "id": "papashita",
-        "begin": "2019-01-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-06T16:00:00.000Z"
       }
     ]
   },
@@ -1560,7 +1137,6 @@
     "officialSite": "https://virtualsan-looking.jp/",
     "begin": "2019-01-09T16:00:00.000Z",
     "end": "2019-03-27T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1569,22 +1145,12 @@
       {
         "site": "nicovideo",
         "id": "VTubers",
-        "begin": "2019-01-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": "2019-01-09T15:30:00.000Z"
       },
       {
         "site": "pptv",
         "id": "vibicIRq4UhMIlows",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1596,7 +1162,6 @@
     "officialSite": "http://www.boitore-dansi.com/wp/",
     "begin": "2019-01-04T15:55:00.000Z",
     "end": "2019-06-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1605,12 +1170,7 @@
       {
         "site": "nicovideo",
         "id": "morikawa",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1626,7 +1186,6 @@
     "officialSite": "http://ekodachan.com/",
     "begin": "2019-01-08T16:00:00.000Z",
     "end": "2019-03-26T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1647,7 +1206,6 @@
     "officialSite": "",
     "begin": "2019-01-11T13:30:00.000Z",
     "end": "2019-03-29T13:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1656,22 +1214,12 @@
       {
         "site": "pptv",
         "id": "vfHeXMQqmtg7uSE",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "hulaingbabies",
-        "begin": "2019-01-18T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-01-18T03:00:00.000Z"
       }
     ]
   },
@@ -1687,7 +1235,6 @@
     "officialSite": "https://www.lupin-3rd.net/",
     "begin": "2019-01-25T12:00:00.000Z",
     "end": "2019-01-25T12:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",

--- a/data/items/2019/02.json
+++ b/data/items/2019/02.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.toei-anim.co.jp/tv/startwinkle_precure/",
     "begin": "2019-02-02T23:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,12 +22,7 @@
       {
         "site": "iqiyi",
         "id": "a_19rrhul389",
-        "begin": "2019-02-03T03:32:28.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-03T03:32:28.000Z"
       }
     ]
   },
@@ -40,7 +34,6 @@
     "officialSite": "http://tsunoanime.jp/",
     "begin": "2019-02-26T19:28:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -49,12 +42,7 @@
       {
         "site": "nicovideo",
         "id": "tsunoanime",
-        "begin": "2019-02-21T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-02-21T13:00:00.000Z"
       }
     ]
   },
@@ -70,7 +58,6 @@
     "officialSite": "",
     "begin": "2019-02-16T16:00:00.000Z",
     "end": "2019-02-16T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -78,33 +65,18 @@
       },
       {
         "site": "bilibili",
-        "id": "26619",
-        "begin": "2019-02-16T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "16179187",
+        "begin": "2019-02-16T16:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "80a9fe723ec04a909a0e",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "movie-heine",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -116,7 +88,6 @@
     "officialSite": "",
     "begin": "2019-02-02T16:00:00.000Z",
     "end": "2019-04-20T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -125,12 +96,7 @@
       {
         "site": "nicovideo",
         "id": "horamimi2",
-        "begin": "2019-04-12T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-12T13:30:00.000Z"
       }
     ]
   }

--- a/data/items/2019/03.json
+++ b/data/items/2019/03.json
@@ -11,7 +11,6 @@
     "officialSite": "http://yamato2202.net/",
     "begin": "2019-03-01T16:00:00.000Z",
     "end": "2019-03-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "pptv",
         "id": "ibjUiaoAhu3hxicicWU",
-        "begin": "",
-        "official": false,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -37,7 +31,6 @@
     "officialSite": "http://www.cannonbusters.com/",
     "begin": "2019-03-01T16:00:00.000Z",
     "end": "2019-03-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -45,13 +38,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26782",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "22020937",
+        "begin": ""
       }
     ]
   },
@@ -67,7 +55,6 @@
     "officialSite": "http://movie.trinity-7.com/",
     "begin": "2019-03-29T16:00:00.000Z",
     "end": "2019-03-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -75,33 +62,18 @@
       },
       {
         "site": "bilibili",
-        "id": "26927",
-        "begin": "2019-03-29T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24662313",
+        "begin": "2019-03-29T03:00:00.000Z"
       },
       {
         "site": "youku",
         "id": "dbcb0550bf3b4e8699fa",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "movie-trinity-7-hlcl",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -117,7 +89,6 @@
     "officialSite": "http://grisaia-pt.com/gptanime/",
     "begin": "2019-03-15T16:00:00.000Z",
     "end": "2019-03-15T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -126,12 +97,7 @@
       {
         "site": "nicovideo",
         "id": "grisaia-pt",
-        "begin": "2019-04-17T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-17T03:00:00.000Z"
       }
     ]
   }

--- a/data/items/2019/04.json
+++ b/data/items/2019/04.json
@@ -14,7 +14,6 @@
     "officialSite": "http://www.aikatsu.net/",
     "begin": "2019-04-04T09:25:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,12 +22,7 @@
       {
         "site": "mgtv",
         "id": "329073",
-        "begin": "2019-04-04T10:30:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-04T10:30:00.000Z"
       }
     ]
   },
@@ -44,7 +38,6 @@
     "officialSite": "http://kenja-no-mago.jp/",
     "begin": "2019-04-10T14:30:00.000Z",
     "end": "2019-06-26T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -52,43 +45,23 @@
       },
       {
         "site": "bilibili",
-        "id": "26794",
-        "begin": "2019-04-10T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "22503880",
+        "begin": "2019-04-10T15:30:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "329075",
-        "begin": "2019-04-10T15:30:01.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-10T15:30:01.000Z"
       },
       {
         "site": "qq",
         "id": "b/bnuzcobdr4lporv",
-        "begin": "2019-04-10T15:30:01.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-10T15:30:01.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kenja-no-mago",
-        "begin": "2019-04-20T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-20T15:00:00.000Z"
       }
     ]
   },
@@ -105,7 +78,6 @@
     "officialSite": "",
     "begin": "2019-04-06T15:30:00.000Z",
     "end": "2019-06-29T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -113,23 +85,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26767",
-        "begin": "2019-04-06T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "21986963",
+        "begin": "2019-04-06T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "boku-ben",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -141,7 +103,6 @@
     "officialSite": "",
     "begin": "2019-04-08T16:35:00.000Z",
     "end": "2019-07-01T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -150,12 +111,7 @@
       {
         "site": "nicovideo",
         "id": "shiny_seven_stars",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -171,7 +127,6 @@
     "officialSite": "http://nankoko-anime.com/",
     "begin": "2019-04-07T16:05:00.000Z",
     "end": "2019-06-23T16:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -180,12 +135,7 @@
       {
         "site": "nicovideo",
         "id": "nandekokonisenseiga",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -201,31 +151,15 @@
     "officialSite": "http://isekai-quartet.com/",
     "begin": "2019-04-09T15:30:00.000Z",
     "end": "2019-06-25T15:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "262865"
       },
       {
-        "site": "bilibili",
-        "id": "26768",
-        "begin": "2019-04-09T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "isekai-quartet",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -243,7 +177,6 @@
     "officialSite": "http://hitoribocchi.jp/",
     "begin": "2019-04-05T17:25:00.000Z",
     "end": "2019-06-21T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -251,23 +184,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26818",
-        "begin": "2019-04-05T18:55:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "23200609",
+        "begin": "2019-04-05T18:55:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "hitoribocchi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -283,7 +206,6 @@
     "officialSite": "http://senryu-girl-official.com/",
     "begin": "2019-04-05T16:55:00.000Z",
     "end": "2019-06-21T17:10:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -291,23 +213,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26870",
-        "begin": "2019-04-05T18:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24069719",
+        "begin": "2019-04-05T18:10:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "senryu-girl",
-        "begin": "2019-04-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-07T03:00:00.000Z"
       }
     ]
   },
@@ -329,7 +241,6 @@
     "officialSite": "http://aochan-anime.com/",
     "begin": "2019-04-05T17:10:00.000Z",
     "end": "2019-06-21T17:25:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -337,23 +248,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26953",
-        "begin": "2019-04-06T18:25:00.000Z",
-        "official": true,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "25826974",
+        "begin": "2019-04-06T18:25:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "aochan-anime",
-        "begin": "2019-04-07T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-07T03:00:00.000Z"
       }
     ]
   },
@@ -369,7 +270,6 @@
     "officialSite": "",
     "begin": "2019-04-05T16:23:00.000Z",
     "end": "2019-09-20T16:53:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -377,43 +277,23 @@
       },
       {
         "site": "bilibili",
-        "id": "26766",
-        "begin": "2019-04-05T17:23:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "21984454",
+        "begin": "2019-04-05T17:23:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "fruba",
-        "begin": "2019-04-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-13T03:00:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhuwmw1",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "bdfeb430c54f4fdb8e4d",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -429,7 +309,6 @@
     "officialSite": "http://senkosan.com/",
     "begin": "2019-04-10T13:30:00.000Z",
     "end": "2019-06-26T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -438,22 +317,12 @@
       {
         "site": "nicovideo",
         "id": "senkosan",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5rs71cp7oy0429e",
-        "begin": "2019-04-10T15:00:00.000Z",
-        "official": null,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-10T15:00:00.000Z"
       }
     ]
   },
@@ -472,31 +341,15 @@
     "officialSite": "http://yuno-anime.com/",
     "begin": "2019-04-02T14:00:00.000Z",
     "end": "2019-09-24T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "204135"
       },
       {
-        "site": "bilibili",
-        "id": "26771",
-        "begin": "2019-04-02T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "yu-no",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -512,7 +365,6 @@
     "officialSite": "",
     "begin": "2019-04-07T14:30:00.000Z",
     "end": "2019-06-23T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -520,23 +372,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26871",
-        "begin": "2019-04-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24072002",
+        "begin": "2019-04-07T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "shoumetsutoshi-anime",
-        "begin": "2019-06-30T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-06-30T15:00:00.000Z"
       }
     ]
   },
@@ -555,7 +397,6 @@
     "officialSite": "http://ch.nicovideo.jp/kimetsu",
     "begin": "2019-04-06T14:30:00.000Z",
     "end": "2019-09-28T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -563,23 +404,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26801",
-        "begin": "2019-04-06T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "22718131",
+        "begin": "2019-04-06T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "kimetsu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -595,7 +426,6 @@
     "officialSite": "http://cingeki-anime.com/",
     "begin": "2019-04-02T12:54:00.000Z",
     "end": "2019-06-25T13:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -603,23 +433,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26876",
-        "begin": "2019-04-02T13:54:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24101539",
+        "begin": "2019-04-02T13:54:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "cingeki-anime-cs",
-        "begin": "2019-04-03T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-03T03:00:00.000Z"
       }
     ]
   },
@@ -635,7 +455,6 @@
     "officialSite": "http://choukadou-anime.com/",
     "begin": "2019-04-08T15:00:00.000Z",
     "end": "2019-06-22T14:15:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -644,12 +463,7 @@
       {
         "site": "nicovideo",
         "id": "choukadou-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -665,7 +479,6 @@
     "officialSite": "http://joshikau-anime.com/",
     "begin": "2019-04-06T14:15:00.000Z",
     "end": "2019-06-22T14:20:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -674,12 +487,7 @@
       {
         "site": "nicovideo",
         "id": "joshikau-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -695,7 +503,6 @@
     "officialSite": "http://nobutsuma-anime.com/",
     "begin": "2019-04-06T14:20:00.000Z",
     "end": "2019-06-22T14:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -704,12 +511,7 @@
       {
         "site": "nicovideo",
         "id": "nobutsuma-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -725,7 +527,6 @@
     "officialSite": "https://www.fairygone.com/",
     "begin": "2019-04-07T15:00:00.000Z",
     "end": "2019-06-23T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -734,12 +535,7 @@
       {
         "site": "nicovideo",
         "id": "fairygone",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -755,7 +551,6 @@
     "officialSite": "https://robihachi.jp/",
     "begin": "2019-04-08T14:30:00.000Z",
     "end": "2019-06-24T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -763,23 +558,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26917",
-        "begin": "2019-04-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24554900",
+        "begin": "2019-04-08T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "robihachi",
-        "begin": "2019-04-13T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-13T03:00:00.000Z"
       }
     ]
   },
@@ -798,7 +583,6 @@
     "officialSite": "http://hangyakusei-anime.com/",
     "begin": "2019-04-04T13:00:00.000Z",
     "end": "2019-06-27T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -806,13 +590,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26880",
-        "begin": "2019-04-04T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24105504",
+        "begin": "2019-04-04T13:00:00.000Z"
       }
     ]
   },
@@ -828,7 +607,6 @@
     "officialSite": "https://namuami-utena-anime.com/",
     "begin": "2019-04-08T11:00:00.000Z",
     "end": "2019-06-24T11:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -837,12 +615,7 @@
       {
         "site": "nicovideo",
         "id": "namuami-utena",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -858,7 +631,6 @@
     "officialSite": "http://yatogame.nagoya/",
     "begin": "2019-04-04T10:53:00.000Z",
     "end": "2019-06-20T11:54:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -867,12 +639,7 @@
       {
         "site": "nicovideo",
         "id": "yatogame",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -891,7 +658,6 @@
     "officialSite": "http://bungo-stray-dogs.jp/",
     "begin": "2019-04-12T13:30:00.000Z",
     "end": "2019-06-28T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -899,23 +665,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26769",
-        "begin": "2019-04-12T13:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "21988886",
+        "begin": "2019-04-12T13:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "bungo-stray-dogs3",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -934,7 +690,6 @@
     "officialSite": "http://onepunchman-anime.net/",
     "begin": "2019-04-09T16:35:00.000Z",
     "end": "2019-07-02T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -943,12 +698,7 @@
       {
         "site": "youku",
         "id": "2a5659587f87497d9aab",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -967,7 +717,6 @@
     "officialSite": "http://diaace.com/",
     "begin": "2019-04-02T08:55:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -975,23 +724,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26809",
-        "begin": "2019-04-02T10:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "22940468",
+        "begin": "2019-04-02T10:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "diaace_2",
-        "begin": "2019-04-10T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-10T03:00:00.000Z"
       }
     ]
   },
@@ -1010,7 +749,6 @@
     "officialSite": "http://gunjyo-magumeru.com/",
     "begin": "2019-04-07T13:00:00.000Z",
     "end": "2019-06-30T13:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1031,7 +769,6 @@
     "officialSite": "",
     "begin": "2019-04-07T16:35:00.000Z",
     "end": "2019-07-07T17:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1039,43 +776,23 @@
       },
       {
         "site": "bilibili",
-        "id": "26775",
-        "begin": "2019-04-07T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "21993464",
+        "begin": "2019-04-07T17:35:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "anime-hachinai",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhtelyx",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "ffea8e86e41d49448e39",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1091,7 +808,6 @@
     "officialSite": "http://w-witch.jp/501_takeoff/",
     "begin": "2019-04-09T15:45:00.000Z",
     "end": "2019-06-25T15:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1100,22 +816,12 @@
       {
         "site": "nicovideo",
         "id": "501_takeoff",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "26941",
-        "begin": "2019-04-09T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "25380076",
+        "begin": "2019-04-09T16:00:01.000Z"
       }
     ]
   },
@@ -1127,7 +833,6 @@
     "officialSite": "http://www.gonjiro.jp/",
     "begin": "2019-04-06T01:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1150,31 +855,15 @@
     "officialSite": "http://sarazanmai.com/",
     "begin": "2019-04-11T15:55:00.000Z",
     "end": "2019-06-20T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
         "id": "239646"
       },
       {
-        "site": "bilibili",
-        "id": "26802",
-        "begin": "2019-04-11T19:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
-      },
-      {
         "site": "nicovideo",
         "id": "sarazanmai-anime",
-        "begin": "2019-04-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-12T03:00:00.000Z"
       }
     ]
   },
@@ -1190,7 +879,6 @@
     "officialSite": "",
     "begin": "2019-04-07T16:00:00.000Z",
     "end": "2019-05-26T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1199,12 +887,7 @@
       {
         "site": "nicovideo",
         "id": "araiya_san",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1220,7 +903,6 @@
     "officialSite": "http://www.bakugan.jp/",
     "begin": "2019-04-01T08:55:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1229,12 +911,7 @@
       {
         "site": "nicovideo",
         "id": "bakugan-bp",
-        "begin": "2019-04-09T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-09T03:00:00.000Z"
       }
     ]
   },
@@ -1251,7 +928,6 @@
     "officialSite": "",
     "begin": "2019-04-06T08:30:00.000Z",
     "end": "2019-09-14T09:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1259,13 +935,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26770",
-        "begin": "2019-04-06T09:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "21989385",
+        "begin": "2019-04-06T09:00:00.000Z"
       }
     ]
   },
@@ -1277,7 +948,6 @@
     "officialSite": "http://www9.nhk.or.jp/anime/wasimo/",
     "begin": "2019-04-01T09:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1298,7 +968,6 @@
     "officialSite": "http://gogo-gomachan.com/",
     "begin": "2019-04-02T09:45:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1306,13 +975,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26879",
-        "begin": "2019-04-02T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24104767",
+        "begin": "2019-04-02T12:00:00.000Z"
       }
     ]
   },
@@ -1328,7 +992,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/BAKUMATSU/",
     "begin": "2019-04-04T17:00:00.000Z",
     "end": "2019-06-20T17:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1337,12 +1000,7 @@
       {
         "site": "nicovideo",
         "id": "BAKUMATSU2",
-        "begin": "2019-04-12T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-12T15:00:00.000Z"
       }
     ]
   },
@@ -1358,7 +1016,6 @@
     "officialSite": "http://neco-neco.jp/",
     "begin": "2019-04-03T09:45:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1378,7 +1035,6 @@
     "officialSite": "http://www.konooto-anime.jp/",
     "begin": "2019-04-06T16:00:00.000Z",
     "end": "2019-06-29T16:30:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1386,13 +1042,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26959",
-        "begin": "2019-04-06T17:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "26334240",
+        "begin": "2019-04-06T17:30:00.000Z"
       }
     ]
   },
@@ -1408,7 +1059,6 @@
     "officialSite": "http://www.tv-tokyo.co.jp/anime/youkai-watch2019/",
     "begin": "2019-04-05T09:25:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1417,12 +1067,7 @@
       {
         "site": "nicovideo",
         "id": "youkai-watch2019",
-        "begin": "2019-04-12T03:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-04-12T03:00:00.000Z"
       }
     ]
   },
@@ -1438,7 +1083,6 @@
     "officialSite": "http://meisakukun.com/",
     "begin": "2019-04-05T09:20:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1461,7 +1105,6 @@
     "officialSite": "http://www.shopro.co.jp/tv/duelmasters/",
     "begin": "2019-04-06T23:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1470,12 +1113,7 @@
       {
         "site": "nicovideo",
         "id": "duelmasters_2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1495,7 +1133,6 @@
     "officialSite": "http://caroleandtuesday.com/?lang=ja",
     "begin": "2019-04-10T16:05:00.000Z",
     "end": "2019-09-25T16:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1503,13 +1140,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26875",
-        "begin": "2019-04-10T20:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24097891",
+        "begin": "2019-04-10T20:30:00.000Z"
       }
     ]
   },
@@ -1525,7 +1157,6 @@
     "officialSite": "https://www.tv-tokyo.co.jp/nana-na/",
     "begin": "2019-04-11T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1533,33 +1164,18 @@
       },
       {
         "site": "bilibili",
-        "id": "26881",
-        "begin": "2019-04-11T11:53:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "24106241",
+        "begin": "2019-04-11T11:53:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhtelfh",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "bcab283f16ea4d5eae68",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1575,7 +1191,6 @@
     "officialSite": "http://occultkoumuin.com/",
     "begin": "2019-04-07T15:30:00.000Z",
     "end": "2019-06-23T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1583,23 +1198,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26777",
-        "begin": "2019-04-07T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "21995182",
+        "begin": "2019-04-07T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "occultkoumuin",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1615,7 +1220,6 @@
     "officialSite": "http://anime.heros-ultraman.com/",
     "begin": "2019-04-01T16:00:00.000Z",
     "end": "2019-04-01T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1623,53 +1227,28 @@
       },
       {
         "site": "bilibili",
-        "id": "26765",
-        "begin": "2019-04-02T07:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "21971025",
+        "begin": "2019-04-02T07:00:00.000Z"
       },
       {
         "site": "mgtv",
         "id": "328949",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhw1m3t",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "4/431dr5aajasaqm5",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "3df0638b94344805a758",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1685,7 +1264,6 @@
     "officialSite": "http://hoshiiro.jp/",
     "begin": "2019-04-01T13:00:00.000Z",
     "end": "2019-04-01T14:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1694,12 +1272,7 @@
       {
         "site": "nicovideo",
         "id": "hoshiiro-sp",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1715,7 +1288,6 @@
     "officialSite": "",
     "begin": "2019-04-28T15:10:00.000Z",
     "end": "2019-06-30T15:35:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1723,13 +1295,8 @@
       },
       {
         "site": "bilibili",
-        "id": "26963",
-        "begin": "2019-04-28T17:40:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "26360655",
+        "begin": "2019-04-28T17:40:00.000Z"
       }
     ]
   },
@@ -1745,7 +1312,6 @@
     "officialSite": "http://www.gundam-the-origin.net/tv/index.html",
     "begin": "2019-04-28T15:35:00.000Z",
     "end": "2019-07-22T16:05:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1761,7 +1327,6 @@
     "officialSite": "http://laidbackers.com/",
     "begin": "2019-04-05T16:00:00.000Z",
     "end": "2019-04-05T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1770,12 +1335,7 @@
       {
         "site": "nicovideo",
         "id": "laidbackers",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2019/05.json
+++ b/data/items/2019/05.json
@@ -14,7 +14,6 @@
     "officialSite": "http://anime.cf-vanguard.com/",
     "begin": "2019-05-10T23:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -23,12 +22,7 @@
       {
         "site": "nicovideo",
         "id": "cf-vanguard-2019",
-        "begin": "2019-05-16T12:00:00.000Z",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": "2019-05-16T12:00:00.000Z"
       }
     ]
   },
@@ -44,7 +38,6 @@
     "officialSite": "http://mirutights.jp/",
     "begin": "2019-05-11T16:00:00.000Z",
     "end": "2019-07-27T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -53,12 +46,7 @@
       {
         "site": "nicovideo",
         "id": "mirutights",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -70,7 +58,6 @@
     "officialSite": "https://www.wakige-anime.com/",
     "begin": "2019-05-29T15:00:00.000Z",
     "end": "2019-05-29T15:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -79,12 +66,7 @@
       {
         "site": "nicovideo",
         "id": "wakige-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2019/06.json
+++ b/data/items/2019/06.json
@@ -11,7 +11,6 @@
     "officialSite": "",
     "begin": "2019-06-14T16:00:00.000Z",
     "end": "2019-06-14T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "netflix",
         "id": "80198505",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://7seeds.jp/",
     "begin": "2019-06-28T16:00:00.000Z",
     "end": "2019-06-28T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -50,12 +43,7 @@
       {
         "site": "netflix",
         "id": "80183051",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/items/2019/07.json
+++ b/data/items/2019/07.json
@@ -11,7 +11,6 @@
     "officialSite": "http://uchinoko-anime.com/",
     "begin": "2019-07-04T14:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -20,12 +19,7 @@
       {
         "site": "qq",
         "id": "e/er0k7wjhbw8f4vj",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -41,7 +35,6 @@
     "officialSite": "http://danmachi.com/danmachi2/",
     "begin": "2019-07-05T15:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -49,33 +42,18 @@
       },
       {
         "site": "bilibili",
-        "id": "27999",
-        "begin": "2019-07-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221395",
+        "begin": "2019-07-06T16:00:01.000Z"
       },
       {
         "site": "nicovideo",
         "id": "danmachi2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhshzg5",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -94,7 +72,6 @@
     "officialSite": "http://www.symphogear-xv.com/",
     "begin": "2019-07-06T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -103,12 +80,7 @@
       {
         "site": "nicovideo",
         "id": "symphogear-xv",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -124,7 +96,6 @@
     "officialSite": "",
     "begin": "2019-07-12T13:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -132,23 +103,13 @@
       },
       {
         "site": "bilibili",
-        "id": "28002",
-        "begin": "2019-07-11T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221399",
+        "begin": "2019-07-11T16:00:01.000Z"
       },
       {
         "site": "nicovideo",
         "id": "toaru-accelerator",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -164,7 +125,6 @@
     "officialSite": "",
     "begin": "2019-07-12T15:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -172,33 +132,18 @@
       },
       {
         "site": "acfun",
-        "url": "https://www.acfun.cn/bangumi/aa5024869",
-        "begin": "2019-07-12T15:59:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "id": "5024869",
+        "begin": "2019-07-12T15:59:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "okaasan-online",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "28003",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "28221400",
+        "begin": ""
       }
     ]
   },
@@ -214,7 +159,6 @@
     "officialSite": "http://takagi3.me/",
     "begin": "2019-07-07T14:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -222,23 +166,13 @@
       },
       {
         "site": "bilibili",
-        "id": "28006",
-        "begin": "2019-07-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221403",
+        "begin": "2019-07-06T16:00:01.000Z"
       },
       {
         "site": "nicovideo",
         "id": "takagi3_me2",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -257,7 +191,6 @@
     "officialSite": "http://jyoshimuda.com/",
     "begin": "2019-07-05T12:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -266,22 +199,12 @@
       {
         "site": "nicovideo",
         "id": "jyoshimuda",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "28016",
-        "begin": "2019-07-05T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221415",
+        "begin": "2019-07-05T14:00:00.000Z"
       }
     ]
   },
@@ -297,7 +220,6 @@
     "officialSite": "",
     "begin": "2019-07-08T11:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -306,22 +228,12 @@
       {
         "site": "nicovideo",
         "id": "hensuki",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "28015",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "28221414",
+        "begin": ""
       }
     ]
   },
@@ -337,7 +249,6 @@
     "officialSite": "",
     "begin": "2019-07-08T14:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -345,23 +256,13 @@
       },
       {
         "site": "bilibili",
-        "id": "27995",
-        "begin": "2019-07-08T15:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221390",
+        "begin": "2019-07-08T15:30:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "arifureta",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -377,7 +278,6 @@
     "officialSite": "http://isekai-cheat-magician.com/",
     "begin": "2019-07-10T13:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -386,22 +286,12 @@
       {
         "site": "nicovideo",
         "id": "isekai-cheat-magician",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "5/5inc5xigj39zzgq",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -417,7 +307,6 @@
     "officialSite": "http://maousama-anime.com/",
     "begin": "2019-07-03T15:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -425,23 +314,13 @@
       },
       {
         "site": "bilibili",
-        "id": "28004",
-        "begin": "2019-07-03T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221401",
+        "begin": "2019-07-03T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "maousama-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -460,7 +339,6 @@
     "officialSite": "",
     "begin": "2019-07-03T13:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -469,22 +347,12 @@
       {
         "site": "nicovideo",
         "id": "dumbbell-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "28013",
-        "begin": "2019-07-03T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221412",
+        "begin": "2019-07-03T14:30:00.000Z"
       }
     ]
   },
@@ -501,7 +369,6 @@
     "officialSite": "http://www.nhg-anime.com/",
     "begin": "2019-07-07T13:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -509,43 +376,23 @@
       },
       {
         "site": "bilibili",
-        "id": "28000",
-        "begin": "2019-07-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221396",
+        "begin": "2019-07-06T16:00:01.000Z"
       },
       {
         "site": "nicovideo",
         "id": "nhg-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "u/uvb5v1z056az20y",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rri0l9d5",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -561,7 +408,6 @@
     "officialSite": "http://tejina-senpai.jp/",
     "begin": "2019-07-02T14:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -569,13 +415,8 @@
       },
       {
         "site": "bilibili",
-        "id": "28019",
-        "begin": "2019-07-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221418",
+        "begin": "2019-07-02T14:30:00.000Z"
       }
     ]
   },
@@ -591,7 +432,6 @@
     "officialSite": "http://sounandesuka.jp/",
     "begin": "2019-07-02T14:15:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -599,23 +439,13 @@
       },
       {
         "site": "acfun",
-        "url": "https://www.acfun.cn/bangumi/aa5024886",
-        "begin": "2019-07-02T15:15:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "id": "5024886",
+        "begin": "2019-07-02T15:15:00.000Z"
       },
       {
         "site": "bilibili",
-        "id": "28012",
-        "begin": "2019-07-02T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221411",
+        "begin": "2019-07-02T14:30:00.000Z"
       }
     ]
   },
@@ -634,7 +464,6 @@
     "officialSite": "",
     "begin": "2019-07-05T16:55:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -642,23 +471,13 @@
       },
       {
         "site": "acfun",
-        "url": "https://www.acfun.cn/bangumi/aa5024870",
-        "begin": "2019-07-05T17:25:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "id": "5024870",
+        "begin": "2019-07-05T17:25:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "granbelm",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -674,7 +493,6 @@
     "officialSite": "http://araoto-anime.com/",
     "begin": "2019-07-05T17:25:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -683,22 +501,12 @@
       {
         "site": "nicovideo",
         "id": "araoto-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "28022",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "28221421",
+        "begin": ""
       }
     ]
   },
@@ -714,7 +522,6 @@
     "officialSite": "http://fireforce-anime.jp/",
     "begin": "2019-07-05T16:25:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -722,23 +529,13 @@
       },
       {
         "site": "bilibili",
-        "id": "27959",
-        "begin": "2019-07-05T17:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221335",
+        "begin": "2019-07-05T17:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "fireforce-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -758,7 +555,6 @@
     "officialSite": "http://katsu-kami.com/",
     "begin": "2019-07-01T14:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -766,23 +562,13 @@
       },
       {
         "site": "bilibili",
-        "id": "28005",
-        "begin": "2019-07-01T15:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221402",
+        "begin": "2019-07-01T15:00:00.000Z"
       },
       {
         "site": "qq",
         "id": "v/v06da82h1gv4kfy",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -798,7 +584,6 @@
     "officialSite": "",
     "begin": "2019-07-05T13:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -807,42 +592,22 @@
       {
         "site": "nicovideo",
         "id": "dr-stone",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhsfl9t",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "qq",
         "id": "b/bqv9nc6qhdqd8xg",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "bilibili",
-        "id": "27993",
-        "begin": "2019-07-05T14:30:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221387",
+        "begin": "2019-07-05T14:30:00.000Z"
       }
     ]
   },
@@ -858,7 +623,6 @@
     "officialSite": "",
     "begin": "2019-07-07T13:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -867,12 +631,7 @@
       {
         "site": "nicovideo",
         "id": "rst-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -891,7 +650,6 @@
     "officialSite": "",
     "begin": "2019-07-07T13:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -899,33 +657,18 @@
       },
       {
         "site": "bilibili",
-        "id": "27997",
-        "begin": "2019-07-06T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221392",
+        "begin": "2019-07-06T16:00:01.000Z"
       },
       {
         "site": "qq",
         "id": "m/ma1qf0ko6p095l9",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "nicovideo",
         "id": "ensemblestars-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -941,7 +684,6 @@
     "officialSite": "http://www.tbs.co.jp/anime/machikado/",
     "begin": "2019-07-11T16:28:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -949,23 +691,13 @@
       },
       {
         "site": "bilibili",
-        "id": "28007",
-        "begin": "2019-07-11T17:28:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221404",
+        "begin": "2019-07-11T17:28:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "machikado",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -984,7 +716,6 @@
     "officialSite": "http://astra-anime.com/",
     "begin": "2019-07-03T12:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -992,23 +723,13 @@
       },
       {
         "site": "bilibili",
-        "id": "28017",
-        "begin": "2019-07-03T13:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221416",
+        "begin": "2019-07-03T13:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "astra-anime",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1027,7 +748,6 @@
     "officialSite": "http://copcraft.tv/",
     "begin": "2019-07-08T15:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1035,23 +755,13 @@
       },
       {
         "site": "bilibili",
-        "id": "28011",
-        "begin": "2019-07-07T16:00:01.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221410",
+        "begin": "2019-07-07T16:00:01.000Z"
       },
       {
         "site": "nicovideo",
         "id": "copcraft",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1067,7 +777,6 @@
     "officialSite": "",
     "begin": "2019-07-07T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1076,12 +785,7 @@
       {
         "site": "nicovideo",
         "id": "yubinetsu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1097,7 +801,6 @@
     "officialSite": "",
     "begin": "2019-07-01T13:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1105,13 +808,8 @@
       },
       {
         "site": "bilibili",
-        "id": "28048",
-        "begin": "2019-07-01T14:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221479",
+        "begin": "2019-07-01T14:00:00.000Z"
       }
     ]
   },
@@ -1127,7 +825,6 @@
     "officialSite": "http://given-anime.com/",
     "begin": "2019-07-11T16:10:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1135,13 +832,8 @@
       },
       {
         "site": "bilibili",
-        "id": "28008",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "28221405",
+        "begin": ""
       }
     ]
   },
@@ -1157,7 +849,6 @@
     "officialSite": "",
     "begin": "2019-07-14T16:35:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1165,23 +856,13 @@
       },
       {
         "site": "bilibili",
-        "id": "27992",
-        "begin": "2019-07-14T17:35:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28221385",
+        "begin": "2019-07-14T17:35:00.000Z"
       },
       {
         "site": "iqiyi",
         "id": "a_19rri0k0st",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1197,7 +878,6 @@
     "officialSite": "http://wakanobu.com/",
     "begin": "2019-07-08T12:30:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1206,12 +886,7 @@
       {
         "site": "nicovideo",
         "id": "wakanobu",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1227,7 +902,6 @@
     "officialSite": "",
     "begin": "2019-07-07T18:13:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1235,23 +909,13 @@
       },
       {
         "site": "bilibili",
-        "id": "28023",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "id": "28221422",
+        "begin": ""
       },
       {
         "site": "youku",
         "id": "dacf06c693894b869384",
-        "begin": "",
-        "official": null,
-        "premuiumOnly": null,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1263,7 +927,6 @@
     "officialSite": "https://pirikarakochan.com/",
     "begin": "2019-07-06T21:15:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1272,12 +935,7 @@
       {
         "site": "nicovideo",
         "id": "pirikarakochan",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1293,7 +951,6 @@
     "officialSite": "http://anime.elmelloi.com/",
     "begin": "2019-07-06T15:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1301,23 +958,13 @@
       },
       {
         "site": "bilibili",
-        "id": "26363",
-        "begin": "2019-07-05T16:00:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "5912238",
+        "begin": "2019-07-05T16:00:00.000Z"
       },
       {
         "site": "nicovideo",
         "id": "anime_elmelloi",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1333,7 +980,6 @@
     "officialSite": "http://vinlandsaga.jp/",
     "begin": "2019-07-07T15:10:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1341,13 +987,8 @@
       },
       {
         "site": "bilibili",
-        "id": "27395",
-        "begin": "2019-07-07T16:10:00.000Z",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": true,
-        "comment": ""
+        "id": "28220475",
+        "begin": "2019-07-07T16:10:00.000Z"
       }
     ]
   },
@@ -1359,7 +1000,6 @@
     "officialSite": "https://www.waresyo.com/",
     "begin": "2019-07-01T16:00:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1379,7 +1019,6 @@
     "officialSite": "",
     "begin": "2019-07-19T16:00:00.000Z",
     "end": "2019-07-19T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1388,22 +1027,12 @@
       {
         "site": "netflix",
         "id": "80186926",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       },
       {
         "site": "iqiyi",
         "id": "a_19rrhvm9ul",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": false,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1419,7 +1048,6 @@
     "officialSite": "http://kengan.net/",
     "begin": "2019-07-31T16:00:00.000Z",
     "end": "2019-07-31T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1428,12 +1056,7 @@
       {
         "site": "netflix",
         "id": "80992228",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": null,
-        "comment": ""
+        "begin": ""
       }
     ]
   },
@@ -1445,7 +1068,6 @@
     "officialSite": "https://www.ntv.co.jp/tryknights/",
     "begin": "2019-07-30T16:29:00.000Z",
     "end": "",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1465,7 +1087,6 @@
     "officialSite": "http://nep-anime.tv/",
     "begin": "2019-07-08T16:00:00.000Z",
     "end": "2019-07-08T16:00:00.000Z",
-    "comment": "",
     "sites": [
       {
         "site": "bangumi",
@@ -1474,12 +1095,7 @@
       {
         "site": "nicovideo",
         "id": "nep-anime-ova",
-        "begin": "",
-        "official": true,
-        "premuiumOnly": true,
-        "censored": null,
-        "exist": false,
-        "comment": ""
+        "begin": ""
       }
     ]
   }

--- a/data/sites/info.json
+++ b/data/sites/info.json
@@ -1,10 +1,6 @@
 {
   "bangumi": {
     "title": "番组计划",
-    "urlTemplate": "http://bangumi.tv/subject/{{id}}"
-  },
-  "saraba1st": {
-    "title": "Stage1st",
-    "urlTemplate": "https://bbs.saraba1st.com/2b/thread-{{id}}-1-1.html"
+    "urlTemplate": "https://bangumi.tv/subject/{{id}}"
   }
 }

--- a/data/sites/onair.json
+++ b/data/sites/onair.json
@@ -1,15 +1,11 @@
 {
   "acfun": {
     "title": "AcFun",
-    "urlTemplate": "http://www.acfun.cn/v/ab{{id}}"
+    "urlTemplate": "https://www.acfun.cn/bangumi/aa{{id}}"
   },
   "bilibili": {
     "title": "哔哩哔哩",
-    "urlTemplate": "https://bangumi.bilibili.com/anime/{{id}}"
-  },
-  "tucao": {
-    "title": "TUCAO",
-    "urlTemplate": "http://www.tucao.tv/index.php?m=search&c=index&a=init2&q={{id}}"
+    "urlTemplate": "https://www.bilibili.com/bangumi/media/md{{id}}/"
   },
   "sohu": {
     "title": "搜狐视频",
@@ -18,10 +14,6 @@
   "youku": {
     "title": "优酷",
     "urlTemplate": "https://list.youku.com/show/id_z{{id}}.html"
-  },
-  "tudou": {
-    "title": "土豆",
-    "urlTemplate": "https://www.tudou.com/albumcover/{{id}}.html"
   },
   "qq": {
     "title": "腾讯视频",
@@ -38,10 +30,6 @@
   "pptv": {
     "title": "PPTV",
     "urlTemplate": "http://v.pptv.com/page/{{id}}.html"
-  },
-  "kankan": {
-    "title": "响巢看看",
-    "urlTemplate": "http://movie.kankan.com/movie/{{id}}"
   },
   "mgtv": {
     "title": "芒果tv",

--- a/data/sites/resource.json
+++ b/data/sites/resource.json
@@ -2,9 +2,5 @@
   "dmhy": {
     "title": "动漫花园",
     "urlTemplate": "https://share.dmhy.org/topics/list?keyword={{id}}"
-  },
-  "nyaa": {
-    "title": "nyaa",
-    "urlTemplate": "https://www.nyaa.se/?page=search&term={{id}}"
   }
 }

--- a/script/schema/item.js
+++ b/script/schema/item.js
@@ -45,7 +45,7 @@ module.exports = Joi.object().keys({
     officialSite: Joi.string().uri().required().allow(''),
     begin: ISOJoi.string().isoString().required().allow(''),
     end: ISOJoi.string().isoString().required().allow(''),
-    comment: Joi.string().required().trim().allow(''),
+    comment: Joi.string().trim().allow(''),
     sites: Joi.array().items(Joi.object()
         .keys({
             site: Joi.string().valid(Object.keys(allSite)),
@@ -58,11 +58,7 @@ module.exports = Joi.object().keys({
         .when(Joi.object().keys({ site: Joi.valid(Object.keys(onairSite)) }).unknown(), {
             then: Joi.object().keys({
                 begin: ISOJoi.string().isoString().required().allow(''),
-                official: Joi.boolean().required().allow(null),
-                premuiumOnly: Joi.boolean().required().allow(null),
-                censored: Joi.boolean().required().allow(null),
-                exist: Joi.boolean().required().allow(null),
-                comment: Joi.string().trim().required().allow('')
+                comment: Joi.string().trim().allow('')
             })
         }))
 });


### PR DESCRIPTION
本分支做了以下修改：
* item.comment 改为非必填字段
* site.comment 改为非必填字段
* 删除 site.official 字段
* 删除 site.premuiumOnly 字段
* 删除 site.censored 字段
* 删除 site.exist 字段
* 删除所有 tucao 数据
* 删除所有 tudou 数据
* 删除所有 kankan 数据
* 删除所有 saraba1st 数据
* 更改 acfun 的 urlTemplate，所有旧数据都删除
* 更改 bilibili 的 urlTemplate，替换为新 ID 的过程中有 300+ 条 404，删除

另外对应修改了校验函数和文档说明。

修改前后数据大小分别为 2.7M 和 1.9M。