### PR TITLE
fix wrong dates for youtube sites

### DIFF
--- a/data/items/2025/04.json
+++ b/data/items/2025/04.json
@@ -486,8 +486,8 @@
       {
         "site": "tropics",
         "id": "PLoGVqODys23B_EJysSGFgJ-2DogVjmibK",
-        "begin": "2025-01-23T15:07:19.000Z",
-        "broadcast": "R/2025-01-23T15:07:19.000Z/P7D"
+        "begin": "2025-04-06T08:30:00.000Z",
+        "broadcast": "R/2025-04-06T08:30:00.000Z/P7D"
       },
       {
         "site": "viu",
@@ -799,26 +799,30 @@
       {
         "site": "muse_hk",
         "id": "PLuxqoToY7UchG5qaXo4vW36Mmcmp0vU_P",
-        "begin": "2025-03-29T11:30:06.000Z",
-        "broadcast": "R/2025-03-29T11:30:06.000Z/P7D"
+        "begin": "2025-03-25T11:30:00.000Z",
+        "broadcast": "R/2025-04-26T17:30:00.000Z/P7D",
+        "comment": "首播两集连播，第三集2025-03-29T11:30:00.000Z放送"
       },
       {
         "site": "gamer_hk",
         "id": "141990",
         "begin": "2025-03-25T11:30:00.000Z",
-        "broadcast": "R/2025-03-25T11:30:00.000Z/P7D"
+        "broadcast": "R/2025-04-26T17:30:00.000Z/P7D",
+        "comment": "首播两集连播，第三集2025-03-29T11:30:00.000Z放送"
       },
       {
         "site": "gamer",
         "id": "141990",
         "begin": "2025-03-25T11:30:00.000Z",
-        "broadcast": "R/2025-03-25T11:30:00.000Z/P7D"
+        "broadcast": "R/2025-04-26T17:30:00.000Z/P7D",
+        "comment": "首播两集连播，第三集2025-03-29T11:30:00.000Z放送"
       },
       {
         "site": "muse_tw",
         "id": "PL12UaAf_xzfrAXdQM7XbncyNsk3KcdtYA",
-        "begin": "2025-03-29T11:30:06.000Z",
-        "broadcast": "R/2025-03-29T11:30:06.000Z/P7D"
+        "begin": "2025-03-25T11:30:00.000Z",
+        "broadcast": "R/2025-04-26T17:30:00.000Z/P7D",
+        "comment": "首播两集连播，第三集2025-03-29T11:30:00.000Z放送"
       },
       {
         "site": "danime",
@@ -1968,14 +1972,14 @@
       {
         "site": "ani_one",
         "id": "PLC18xlbCdwtQwOYx91oOXo2kRquxWIWHX",
-        "begin": "2025-04-03T04:27:43.000Z",
-        "broadcast": "R/2025-04-03T04:27:43.000Z/P7D"
+        "begin": "2025-04-05T14:30:00.000Z",
+        "broadcast": "R/2025-04-05T14:30:00.000Z/P7D"
       },
       {
         "site": "ani_one_asia",
         "id": "PLxSscENEp7JjTeCHu-bW77tOzPZpxcgoE",
-        "begin": "2025-04-03T04:19:57.000Z",
-        "broadcast": "R/2025-04-03T04:19:57.000Z/P7D"
+        "begin": "2025-04-05T14:30:00.000Z",
+        "broadcast": "R/2025-04-05T14:30:00.000Z/P7D"
       },
       {
         "site": "disneyplus",
@@ -2752,8 +2756,8 @@
       {
         "site": "tropics",
         "id": "PLoGVqODys23A7iyLoAhCf4T5ScP4YKoX6",
-        "begin": "2025-03-28T03:41:37.000Z",
-        "broadcast": "R/2025-03-28T03:41:37.000Z/P7D"
+        "begin": "2025-04-11T15:30:00.000Z",
+        "broadcast": "R/2025-04-11T15:30:00.000Z/P7D"
       },
       {
         "site": "gamer",
@@ -2825,8 +2829,8 @@
       {
         "site": "ani_one",
         "id": "PLC18xlbCdwtTqp3iJxP3e_hRj_brl1HhG",
-        "begin": "2025-04-04T15:49:43.000Z",
-        "broadcast": "R/2025-04-04T15:49:43.000Z/P7D"
+        "begin": "2025-04-07T15:00:00.000Z",
+        "broadcast": "R/2025-04-07T15:00:00.000Z/P7D"
       },
       {
         "site": "danime",
@@ -2849,8 +2853,8 @@
       {
         "site": "ani_one_asia",
         "id": "PLxSscENEp7Ji6xNpTPVde69l-VVcWyhVR",
-        "begin": "2025-04-03T07:05:50.000Z",
-        "broadcast": "R/2025-04-03T07:05:50.000Z/P7D"
+        "begin": "2025-04-07T15:00:00.000Z",
+        "broadcast": "R/2025-04-07T15:00:00.000Z/P7D"
       },
       {
         "site": "viu",


### PR DESCRIPTION
发现油管域名的站点，由于PV过滤不完善、视频发布时间与公开时间不一致等原因，造成相关时间数据大量错误
正在尝试对 `helper\lib\crawlers\youtube.js` 进行完善
目前先人工核实并修改了202504的相关数据