### PR TITLE
漏抓补全

### DIFF
--- a/data/items/2025/07.json
+++ b/data/items/2025/07.json
@@ -6844,5 +6844,49 @@
         "id": "19418"
       }
     ]
+  },
+  {
+    "title": "劇場版 鬼滅の刃 無限城編 第一章 猗窩座再来",
+    "titleTranslate": {
+      "zh-Hans": [
+        "剧场版 鬼灭之刃 无限城篇 第一章 猗窝座再袭"
+      ],
+      "zh-Hant": [
+        "劇場版 鬼滅之刃 無限城篇 第一章 猗窩座再來"
+      ],
+      "en": [
+        "Demon Slayer: Kimetsu no Yaiba - The Movie: Infinity Castle - Part 1: Akaza Returns",
+        "Demon Slayer: Kimetsu no Yaiba Infinity Castle"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://kimetsu.com/anime/mugenjyohen_movie/",
+    "begin": "2025-07-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2025-07-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "501958"
+      },
+      {
+        "site": "mal",
+        "id": "59192"
+      },
+      {
+        "site": "aniList",
+        "id": "178788"
+      },
+      {
+        "site": "anidb",
+        "id": "18699"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/1311031"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- 补全漏抓的 2025 剧场版：**劇場版 鬼滅の刃 無限城編 第一章 猗窩座再来**
- bangumi: [501958](https://bgm.tv/subject/501958)
- 外站 ID：
  - MAL: [59192](https://myanimelist.net/anime/59192)
  - AniList: [178788](https://anilist.co/anime/178788)
  - AniDB: [18699](https://anidb.net/anime/18699)
  - TMDB: [movie/1311031](https://www.themoviedb.org/movie/1311031)

## 说明

我弄了个基于 bangumi-data 的BT网站，由于数据存在可能缺少的问题，比如这两次的剧场版。
我想请问是我单独维护个分支定期pr呢还是为了时效性我和字幕组发现了缺少立刻pr补全比较好？

