### PR TITLE
漏抓补全：日本商业剧场版长片

### DIFF
--- a/data/items/1959/02.json
+++ b/data/items/1959/02.json
@@ -1,0 +1,31 @@
+[
+  {
+    "title": "ひょうたんすずめ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "葫芦雀"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1959-02-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1959-02-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "532742"
+      },
+      {
+        "site": "mal",
+        "id": "16007"
+      },
+      {
+        "site": "anidb",
+        "id": "4933"
+      }
+    ]
+  }
+]

--- a/data/items/1967/07.json
+++ b/data/items/1967/07.json
@@ -1,0 +1,48 @@
+[
+  {
+    "title": "トッポ・ジージョのボタン戦争",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1967-07-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1967-07-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "188710"
+      },
+      {
+        "site": "anidb",
+        "id": "9192"
+      }
+    ]
+  },
+  {
+    "title": "ひょっこりひょうたん島",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.toei-anim.co.jp/lineup/movie/movie_hyoutan/",
+    "begin": "1967-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1967-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "265326"
+      },
+      {
+        "site": "mal",
+        "id": "22887"
+      },
+      {
+        "site": "anidb",
+        "id": "2207"
+      }
+    ]
+  }
+]

--- a/data/items/1971/03.json
+++ b/data/items/1971/03.json
@@ -92,5 +92,34 @@
         "id": "9164"
       }
     ]
+  },
+  {
+    "title": "忍風カムイ外伝 月日貝の巻",
+    "titleTranslate": {
+      "zh-Hans": [
+        "忍风卡姆依外传 月日贝之卷"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1971-03-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1971-03-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "289176"
+      },
+      {
+        "site": "mal",
+        "id": "30965"
+      },
+      {
+        "site": "anidb",
+        "id": "7111"
+      }
+    ]
   }
 ]

--- a/data/items/1973/03.json
+++ b/data/items/1973/03.json
@@ -89,5 +89,30 @@
         "id": "3758"
       }
     ]
+  },
+  {
+    "title": "日本漫画映画発達史・アニメ新画帖",
+    "titleTranslate": {
+      "zh-Hans": [
+        "日本漫画电影发展史·动画新画帖"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1973-03-30T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1973-03-30T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "311311"
+      },
+      {
+        "site": "anidb",
+        "id": "6977"
+      }
+    ]
   }
 ]

--- a/data/items/1974/07.json
+++ b/data/items/1974/07.json
@@ -80,5 +80,34 @@
         "broadcast": "R/2017-02-06T09:15:05.000Z/P7D"
       }
     ]
+  },
+  {
+    "title": "ジャックと豆の木",
+    "titleTranslate": {
+      "zh-Hans": [
+        "杰克与豌豆"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1974-07-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1974-07-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "448680"
+      },
+      {
+        "site": "mal",
+        "id": "3720"
+      },
+      {
+        "site": "anidb",
+        "id": "4293"
+      }
+    ]
   }
 ]

--- a/data/items/1976/09.json
+++ b/data/items/1976/09.json
@@ -40,5 +40,34 @@
         "id": "3932"
       }
     ]
+  },
+  {
+    "title": "ちびっこカムのぼうけん",
+    "titleTranslate": {
+      "zh-Hans": [
+        "小卡姆的冒险"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1976-09-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1976-09-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "311634"
+      },
+      {
+        "site": "mal",
+        "id": "24923"
+      },
+      {
+        "site": "anidb",
+        "id": "8641"
+      }
+    ]
   }
 ]

--- a/data/items/1978/03.json
+++ b/data/items/1978/03.json
@@ -192,5 +192,34 @@
         "id": "2199"
       }
     ]
+  },
+  {
+    "title": "世界名作童話 おやゆび姫",
+    "titleTranslate": {
+      "zh-Hans": [
+        "世界名作童话 拇指姑娘"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1978-03-17T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1978-03-17T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "189650"
+      },
+      {
+        "site": "mal",
+        "id": "3755"
+      },
+      {
+        "site": "anidb",
+        "id": "2227"
+      }
+    ]
   }
 ]

--- a/data/items/1979/03.json
+++ b/data/items/1979/03.json
@@ -123,5 +123,34 @@
         "id": "7376"
       }
     ]
+  },
+  {
+    "title": "龍の子太郎",
+    "titleTranslate": {
+      "zh-Hans": [
+        "龙子太郎"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://lineup.toei-anim.co.jp/ja/movie/movie_tatsunoko/",
+    "begin": "1979-03-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1979-03-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "84042"
+      },
+      {
+        "site": "mal",
+        "id": "1208"
+      },
+      {
+        "site": "anidb",
+        "id": "2230"
+      }
+    ]
   }
 ]

--- a/data/items/1979/07.json
+++ b/data/items/1979/07.json
@@ -131,5 +131,34 @@
         "id": "movie/280725"
       }
     ]
+  },
+  {
+    "title": "北極のムーシカ・ミーシカ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "小白熊"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1979-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1979-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "84098"
+      },
+      {
+        "site": "mal",
+        "id": "7729"
+      },
+      {
+        "site": "anidb",
+        "id": "6229"
+      }
+    ]
   }
 ]

--- a/data/items/1979/09.json
+++ b/data/items/1979/09.json
@@ -1,0 +1,60 @@
+[
+  {
+    "title": "エースをねらえ!",
+    "titleTranslate": {
+      "zh-Hans": [
+        "网球甜心 剧场版"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1979-09-07T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1979-09-07T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "75855"
+      },
+      {
+        "site": "mal",
+        "id": "313"
+      },
+      {
+        "site": "anidb",
+        "id": "1074"
+      }
+    ]
+  },
+  {
+    "title": "野球狂の詩 北の狼南の虎",
+    "titleTranslate": {
+      "zh-Hans": [
+        "野球狂之诗 北之狼南之虎"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1979-09-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1979-09-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "109272"
+      },
+      {
+        "site": "mal",
+        "id": "10563"
+      },
+      {
+        "site": "anidb",
+        "id": "7663"
+      }
+    ]
+  }
+]

--- a/data/items/1980/07.json
+++ b/data/items/1980/07.json
@@ -78,5 +78,34 @@
         "id": "8372"
       }
     ]
+  },
+  {
+    "title": "11ぴきのねこ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "11只猫"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1980-07-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1980-07-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "414669"
+      },
+      {
+        "site": "mal",
+        "id": "6071"
+      },
+      {
+        "site": "anidb",
+        "id": "4944"
+      }
+    ]
   }
 ]

--- a/data/items/1981/01.json
+++ b/data/items/1981/01.json
@@ -142,5 +142,34 @@
         "id": "5581"
       }
     ]
+  },
+  {
+    "title": "限りなき楽園",
+    "titleTranslate": {
+      "zh-Hans": [
+        "无尽乐园"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1980-12-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1980-12-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "312028"
+      },
+      {
+        "site": "mal",
+        "id": "23569"
+      },
+      {
+        "site": "anidb",
+        "id": "8543"
+      }
+    ]
   }
 ]

--- a/data/items/1981/03.json
+++ b/data/items/1981/03.json
@@ -392,5 +392,63 @@
         "id": "2621"
       }
     ]
+  },
+  {
+    "title": "世界名作童話 白鳥の湖",
+    "titleTranslate": {
+      "zh-Hans": [
+        "世界名作童话 天鹅湖"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-03-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-03-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "113676"
+      },
+      {
+        "site": "mal",
+        "id": "3186"
+      },
+      {
+        "site": "anidb",
+        "id": "2245"
+      }
+    ]
+  },
+  {
+    "title": "怪物くん 怪物ランドへの招待",
+    "titleTranslate": {
+      "zh-Hans": [
+        "怪物太郎 前往怪物岛的招待"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-03-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-03-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "424332"
+      },
+      {
+        "site": "mal",
+        "id": "22977"
+      },
+      {
+        "site": "anidb",
+        "id": "7539"
+      }
+    ]
   }
 ]

--- a/data/items/1981/04.json
+++ b/data/items/1981/04.json
@@ -255,5 +255,34 @@
         "id": "3835"
       }
     ]
+  },
+  {
+    "title": "フリテンくん",
+    "titleTranslate": {
+      "zh-Hans": [
+        "碰丁先生传"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-04-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-04-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "326201"
+      },
+      {
+        "site": "mal",
+        "id": "20093"
+      },
+      {
+        "site": "anidb",
+        "id": "7708"
+      }
+    ]
   }
 ]

--- a/data/items/1981/07.json
+++ b/data/items/1981/07.json
@@ -233,5 +233,34 @@
         "id": "2029"
       }
     ]
+  },
+  {
+    "title": "グリックの冒険",
+    "titleTranslate": {
+      "zh-Hans": [
+        "松鼠的冒险"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "296869"
+      },
+      {
+        "site": "mal",
+        "id": "7252"
+      },
+      {
+        "site": "anidb",
+        "id": "6634"
+      }
+    ]
   }
 ]

--- a/data/items/1981/08.json
+++ b/data/items/1981/08.json
@@ -96,5 +96,95 @@
         "id": "9991"
       }
     ]
+  },
+  {
+    "title": "21エモン 宇宙へいらっしゃい!",
+    "titleTranslate": {
+      "zh-Hans": [
+        "21卫门:欢迎来到宇宙!"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-07-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-07-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "312001"
+      },
+      {
+        "site": "mal",
+        "id": "6073"
+      },
+      {
+        "site": "anidb",
+        "id": "5323"
+      }
+    ]
+  },
+  {
+    "title": "ドラえもん ぼく、桃太郎のなんなのさ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "哆啦A梦:我是桃太郎的什么呢?"
+      ],
+      "en": [
+        "Doraemon Movie: Boku, Momotarou no Nanna no Sa"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-07-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-07-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "121739"
+      },
+      {
+        "site": "mal",
+        "id": "2650"
+      },
+      {
+        "site": "anidb",
+        "id": "3113"
+      }
+    ]
+  },
+  {
+    "title": "ゆき",
+    "titleTranslate": {
+      "zh-Hans": [
+        "雪"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-08-08T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-08-08T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "128530"
+      },
+      {
+        "site": "mal",
+        "id": "8598"
+      },
+      {
+        "site": "anidb",
+        "id": "4726"
+      }
+    ]
   }
 ]

--- a/data/items/1981/10.json
+++ b/data/items/1981/10.json
@@ -372,5 +372,34 @@
         "id": "2882"
       }
     ]
+  },
+  {
+    "title": "蓮如とその母",
+    "titleTranslate": {
+      "zh-Hans": [
+        "莲如与母亲"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-10-06T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-10-06T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220070"
+      },
+      {
+        "site": "mal",
+        "id": "7473"
+      },
+      {
+        "site": "anidb",
+        "id": "7043"
+      }
+    ]
   }
 ]

--- a/data/items/1981/12.json
+++ b/data/items/1981/12.json
@@ -47,5 +47,34 @@
         "id": "4371"
       }
     ]
+  },
+  {
+    "title": "シュンマオ物語 タオタオ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "熊猫的故事"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1981-12-27T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1981-12-27T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "66303"
+      },
+      {
+        "site": "mal",
+        "id": "24603"
+      },
+      {
+        "site": "anidb",
+        "id": "6562"
+      }
+    ]
   }
 ]

--- a/data/items/1982/01.json
+++ b/data/items/1982/01.json
@@ -1,0 +1,31 @@
+[
+  {
+    "title": "セロ弾きのゴーシュ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "大提琴手高修"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1982-01-22T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1982-01-22T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "17351"
+      },
+      {
+        "site": "mal",
+        "id": "1049"
+      },
+      {
+        "site": "anidb",
+        "id": "1196"
+      }
+    ]
+  }
+]

--- a/data/items/1982/03.json
+++ b/data/items/1982/03.json
@@ -262,5 +262,88 @@
         "id": "4955"
       }
     ]
+  },
+  {
+    "title": "1000年女王",
+    "titleTranslate": {
+      "zh-Hans": [
+        "千年女王"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1982-03-12T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1982-03-12T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "80823"
+      },
+      {
+        "site": "mal",
+        "id": "1549"
+      },
+      {
+        "site": "anidb",
+        "id": "764"
+      }
+    ]
+  },
+  {
+    "title": "怪物くん デーモンの剣",
+    "titleTranslate": {
+      "zh-Hans": [
+        "怪物太郎 恶魔之剑"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1982-03-12T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1982-03-12T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220081"
+      },
+      {
+        "site": "mal",
+        "id": "22975"
+      },
+      {
+        "site": "anidb",
+        "id": "7540"
+      }
+    ]
+  },
+  {
+    "title": "象のいない動物園",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1982-03-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1982-03-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220080"
+      },
+      {
+        "site": "mal",
+        "id": "11097"
+      },
+      {
+        "site": "anidb",
+        "id": "6386"
+      }
+    ]
   }
 ]

--- a/data/items/1982/07.json
+++ b/data/items/1982/07.json
@@ -238,5 +238,63 @@
         "id": "3159"
       }
     ]
+  },
+  {
+    "title": "伝説巨神イデオン 接触篇",
+    "titleTranslate": {
+      "zh-Hans": [
+        "传说巨神伊迪安 接触篇"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1982-07-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1982-07-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "23305"
+      },
+      {
+        "site": "mal",
+        "id": "2760"
+      },
+      {
+        "site": "anidb",
+        "id": "1808"
+      }
+    ]
+  },
+  {
+    "title": "伝説巨神イデオン 発動篇",
+    "titleTranslate": {
+      "zh-Hans": [
+        "传说巨神伊迪安 发动篇"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1982-07-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1982-07-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "23304"
+      },
+      {
+        "site": "mal",
+        "id": "2761"
+      },
+      {
+        "site": "anidb",
+        "id": "1809"
+      }
+    ]
   }
 ]

--- a/data/items/1982/08.json
+++ b/data/items/1982/08.json
@@ -1,0 +1,31 @@
+[
+  {
+    "title": "テクノポリス21C",
+    "titleTranslate": {
+      "zh-Hans": [
+        "特搜机械队21C"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1982-08-06T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1982-08-06T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "108279"
+      },
+      {
+        "site": "mal",
+        "id": "5090"
+      },
+      {
+        "site": "anidb",
+        "id": "1862"
+      }
+    ]
+  }
+]

--- a/data/items/1983/03.json
+++ b/data/items/1983/03.json
@@ -239,5 +239,63 @@
         "id": "2722"
       }
     ]
+  },
+  {
+    "title": "幻魔大戦",
+    "titleTranslate": {
+      "zh-Hans": [
+        "幻魔大战"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1983-03-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1983-03-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "8364"
+      },
+      {
+        "site": "mal",
+        "id": "1626"
+      },
+      {
+        "site": "anidb",
+        "id": "1472"
+      }
+    ]
+  },
+  {
+    "title": "忍者ハットリくん ニンニンふるさと大作戦の巻",
+    "titleTranslate": {
+      "zh-Hans": [
+        "忍者哈特利 家乡大作战之卷"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1983-03-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1983-03-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "424333"
+      },
+      {
+        "site": "mal",
+        "id": "23647"
+      },
+      {
+        "site": "anidb",
+        "id": "2608"
+      }
+    ]
   }
 ]

--- a/data/items/1983/04.json
+++ b/data/items/1983/04.json
@@ -475,5 +475,59 @@
         "id": "2542"
       }
     ]
+  },
+  {
+    "title": "ノエルの不思議な冒険",
+    "titleTranslate": {
+      "zh-Hans": [
+        "神奇的太空旅行"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1983-04-28T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1983-04-28T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "104004"
+      },
+      {
+        "site": "mal",
+        "id": "9303"
+      },
+      {
+        "site": "anidb",
+        "id": "7336"
+      }
+    ]
+  },
+  {
+    "title": "プロ野球を10倍楽しく見る方法",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1983-04-28T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1983-04-28T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "381168"
+      },
+      {
+        "site": "mal",
+        "id": "18339"
+      },
+      {
+        "site": "anidb",
+        "id": "6607"
+      }
+    ]
   }
 ]

--- a/data/items/1983/08.json
+++ b/data/items/1983/08.json
@@ -47,5 +47,34 @@
         "id": "5293"
       }
     ]
+  },
+  {
+    "title": "青い海と少年",
+    "titleTranslate": {
+      "zh-Hans": [
+        "青色海洋与少年"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1983-07-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1983-07-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "381160"
+      },
+      {
+        "site": "mal",
+        "id": "24869"
+      },
+      {
+        "site": "anidb",
+        "id": "9064"
+      }
+    ]
   }
 ]

--- a/data/items/1984/03.json
+++ b/data/items/1984/03.json
@@ -343,5 +343,92 @@
         "id": "1753"
       }
     ]
+  },
+  {
+    "title": "冒険者たち ガンバと7匹のなかま",
+    "titleTranslate": {
+      "zh-Hans": [
+        "冒险者们 刚巴与七位伙伴"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1984-03-03T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1984-03-03T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "314865"
+      },
+      {
+        "site": "mal",
+        "id": "28983"
+      },
+      {
+        "site": "anidb",
+        "id": "3142"
+      }
+    ]
+  },
+  {
+    "title": "少年ケニヤ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "少年肯尼亚"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1984-03-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1984-03-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "110780"
+      },
+      {
+        "site": "mal",
+        "id": "2311"
+      },
+      {
+        "site": "anidb",
+        "id": "2279"
+      }
+    ]
+  },
+  {
+    "title": "忍者ハットリくん+パーマン 超能力ウォーズ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "忍者哈特利+小超人帕门 超能力战争"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1984-03-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1984-03-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "313462"
+      },
+      {
+        "site": "mal",
+        "id": "29235"
+      },
+      {
+        "site": "anidb",
+        "id": "4742"
+      }
+    ]
   }
 ]

--- a/data/items/1984/08.json
+++ b/data/items/1984/08.json
@@ -47,5 +47,63 @@
         "id": "2312"
       }
     ]
+  },
+  {
+    "title": "地球物語 テレパス2500",
+    "titleTranslate": {
+      "zh-Hans": [
+        "地球物语"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1984-08-03T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1984-08-03T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "82821"
+      },
+      {
+        "site": "mal",
+        "id": "8563"
+      },
+      {
+        "site": "anidb",
+        "id": "6687"
+      }
+    ]
+  },
+  {
+    "title": "黒い雨に打たれて",
+    "titleTranslate": {
+      "zh-Hans": [
+        "遭逢黑雨的拍打"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1984-08-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1984-08-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "101546"
+      },
+      {
+        "site": "mal",
+        "id": "19135"
+      },
+      {
+        "site": "anidb",
+        "id": "4132"
+      }
+    ]
   }
 ]

--- a/data/items/1984/09.json
+++ b/data/items/1984/09.json
@@ -1,0 +1,35 @@
+[
+  {
+    "title": "カッくんカフェ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "角君咖啡"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1984-09-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1984-09-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "528839"
+      },
+      {
+        "site": "mal",
+        "id": "23613"
+      },
+      {
+        "site": "anidb",
+        "id": "6694"
+      },
+      {
+        "site": "aniList",
+        "id": "182144"
+      }
+    ]
+  }
+]

--- a/data/items/1985/03.json
+++ b/data/items/1985/03.json
@@ -438,5 +438,63 @@
         "id": "3275"
       }
     ]
+  },
+  {
+    "title": "ボビーに首ったけ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "回首再见她"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1985-03-08T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1985-03-08T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "63013"
+      },
+      {
+        "site": "mal",
+        "id": "3120"
+      },
+      {
+        "site": "anidb",
+        "id": "3546"
+      }
+    ]
+  },
+  {
+    "title": "忍者ハットリくん+パーマン 忍者怪獣ジッポウVSミラクル卵",
+    "titleTranslate": {
+      "zh-Hans": [
+        "忍者哈特利+小超人帕门 忍者怪兽吉彭vs奇迹蛋"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1985-03-15T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1985-03-15T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "313512"
+      },
+      {
+        "site": "mal",
+        "id": "29233"
+      },
+      {
+        "site": "anidb",
+        "id": "9025"
+      }
+    ]
   }
 ]

--- a/data/items/1985/07.json
+++ b/data/items/1985/07.json
@@ -370,5 +370,34 @@
         "id": "movie/1300685"
       }
     ]
+  },
+  {
+    "title": "キャプテン翼 ヨーロッパ大決戦",
+    "titleTranslate": {
+      "zh-Hans": [
+        "足球小将:欧洲大决战"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1985-07-12T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1985-07-12T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "312253"
+      },
+      {
+        "site": "mal",
+        "id": "2118"
+      },
+      {
+        "site": "anidb",
+        "id": "2337"
+      }
+    ]
   }
 ]

--- a/data/items/1985/10.json
+++ b/data/items/1985/10.json
@@ -270,5 +270,34 @@
         "id": "movie/529667"
       }
     ]
+  },
+  {
+    "title": "妖精フローレンス",
+    "titleTranslate": {
+      "zh-Hans": [
+        "妖精芙罗伦丝"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1985-10-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1985-10-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "307259"
+      },
+      {
+        "site": "mal",
+        "id": "4943"
+      },
+      {
+        "site": "anidb",
+        "id": "5479"
+      }
+    ]
   }
 ]

--- a/data/items/1985/12.json
+++ b/data/items/1985/12.json
@@ -246,5 +246,63 @@
         "id": "732"
       }
     ]
+  },
+  {
+    "title": "キャプテン翼 危うし!全日本Jr.",
+    "titleTranslate": {
+      "zh-Hans": [
+        "足球小将:危险!全日本少年队"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1985-12-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1985-12-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "312255"
+      },
+      {
+        "site": "mal",
+        "id": "2119"
+      },
+      {
+        "site": "anidb",
+        "id": "3560"
+      }
+    ]
+  },
+  {
+    "title": "雪国の王子さま",
+    "titleTranslate": {
+      "zh-Hans": [
+        "雪之国的王子"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1985-12-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1985-12-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "382981"
+      },
+      {
+        "site": "mal",
+        "id": "23345"
+      },
+      {
+        "site": "anidb",
+        "id": "9063"
+      }
+    ]
   }
 ]

--- a/data/items/1986/03.json
+++ b/data/items/1986/03.json
@@ -410,5 +410,63 @@
         "id": "3660"
       }
     ]
+  },
+  {
+    "title": "アリオン",
+    "titleTranslate": {
+      "zh-Hans": [
+        "亚里安"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-03-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-03-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "24683"
+      },
+      {
+        "site": "mal",
+        "id": "791"
+      },
+      {
+        "site": "anidb",
+        "id": "398"
+      }
+    ]
+  },
+  {
+    "title": "プロゴルファー猿 スーパーGOLFワールドへの挑戦!!",
+    "titleTranslate": {
+      "zh-Hans": [
+        "球场小神将:到超级高尔夫世界的挑战!!"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-03-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-03-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "189444"
+      },
+      {
+        "site": "mal",
+        "id": "17317"
+      },
+      {
+        "site": "anidb",
+        "id": "7575"
+      }
+    ]
   }
 ]

--- a/data/items/1986/07.json
+++ b/data/items/1986/07.json
@@ -227,5 +227,127 @@
         "id": "3676"
       }
     ]
+  },
+  {
+    "title": "キャプテン翼 世界大決戦!! Jr.ワールドカップ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "足球小将:世界大决战!!少年世界杯"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-07-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-07-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "312258"
+      },
+      {
+        "site": "mal",
+        "id": "2121"
+      },
+      {
+        "site": "anidb",
+        "id": "3561"
+      }
+    ]
+  },
+  {
+    "title": "アモン・サーガ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "阿门英雄传奇"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-07-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-07-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "74553"
+      },
+      {
+        "site": "mal",
+        "id": "2249"
+      },
+      {
+        "site": "anidb",
+        "id": "1658"
+      }
+    ]
+  },
+  {
+    "title": "アイ・シティ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "爱之城"
+      ],
+      "en": [
+        "Ai City"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-07-25T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-07-25T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "55065"
+      },
+      {
+        "site": "mal",
+        "id": "5053"
+      },
+      {
+        "site": "anidb",
+        "id": "2902"
+      }
+    ]
+  },
+  {
+    "title": "ガルフォース ETERNAL STORY",
+    "titleTranslate": {
+      "zh-Hans": [
+        "银河女战士 ETERNAL STORY"
+      ],
+      "en": [
+        "Gall Force 1: Eternal Story"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-07-25T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-07-25T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "37512"
+      },
+      {
+        "site": "mal",
+        "id": "2060"
+      },
+      {
+        "site": "anidb",
+        "id": "760"
+      }
+    ]
   }
 ]

--- a/data/items/1986/08.json
+++ b/data/items/1986/08.json
@@ -214,5 +214,34 @@
         "id": "11537"
       }
     ]
+  },
+  {
+    "title": "11ぴきのねことあほうどり",
+    "titleTranslate": {
+      "zh-Hans": [
+        "11只猫和信天翁"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-08-22T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-08-22T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "424544"
+      },
+      {
+        "site": "mal",
+        "id": "6072"
+      },
+      {
+        "site": "anidb",
+        "id": "4945"
+      }
+    ]
   }
 ]

--- a/data/items/1986/11.json
+++ b/data/items/1986/11.json
@@ -78,5 +78,34 @@
         "id": "tv/4269/season/3"
       }
     ]
+  },
+  {
+    "title": "扉を開けて",
+    "titleTranslate": {
+      "zh-Hans": [
+        "开启那扇门"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-10-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-10-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "67736"
+      },
+      {
+        "site": "mal",
+        "id": "3192"
+      },
+      {
+        "site": "anidb",
+        "id": "2251"
+      }
+    ]
   }
 ]

--- a/data/items/1986/12.json
+++ b/data/items/1986/12.json
@@ -297,5 +297,59 @@
         "id": "3279"
       }
     ]
+  },
+  {
+    "title": "GREY デジタル・ターゲット",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-12-12T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-12-12T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "108294"
+      },
+      {
+        "site": "mal",
+        "id": "2423"
+      },
+      {
+        "site": "anidb",
+        "id": "1515"
+      }
+    ]
+  },
+  {
+    "title": "火の鳥 鳳凰編",
+    "titleTranslate": {
+      "zh-Hans": [
+        "火之鸟 凤凰篇"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1986-12-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1986-12-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "40935"
+      },
+      {
+        "site": "mal",
+        "id": "2997"
+      },
+      {
+        "site": "anidb",
+        "id": "2629"
+      }
+    ]
   }
 ]

--- a/data/items/1987/02.json
+++ b/data/items/1987/02.json
@@ -92,5 +92,34 @@
         "id": "1347"
       }
     ]
+  },
+  {
+    "title": "ウインダリア",
+    "titleTranslate": {
+      "zh-Hans": [
+        "渥大利亚"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-02-22T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-02-22T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "39292"
+      },
+      {
+        "site": "mal",
+        "id": "1130"
+      },
+      {
+        "site": "anidb",
+        "id": "1220"
+      }
+    ]
   }
 ]

--- a/data/items/1987/03.json
+++ b/data/items/1987/03.json
@@ -292,5 +292,88 @@
         "id": "1032"
       }
     ]
+  },
+  {
+    "title": "バツ&テリー",
+    "titleTranslate": {
+      "zh-Hans": [
+        "龙兄虎弟"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-03-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-03-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "88421"
+      },
+      {
+        "site": "mal",
+        "id": "16514"
+      },
+      {
+        "site": "anidb",
+        "id": "7058"
+      }
+    ]
+  },
+  {
+    "title": "プロゴルファー猿 甲賀秘境! 影の忍法ゴルファー参上!",
+    "titleTranslate": {
+      "zh-Hans": [
+        "球场小神将:甲贺秘境!影之忍法高尔夫球手参上"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-03-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-03-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "189445"
+      },
+      {
+        "site": "mal",
+        "id": "17321"
+      },
+      {
+        "site": "anidb",
+        "id": "7576"
+      }
+    ]
+  },
+  {
+    "title": "ブンナよ, 木からおりてこい",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-03-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-03-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "383136"
+      },
+      {
+        "site": "mal",
+        "id": "23611"
+      },
+      {
+        "site": "anidb",
+        "id": "7617"
+      }
+    ]
   }
 ]

--- a/data/items/1987/04.json
+++ b/data/items/1987/04.json
@@ -422,5 +422,37 @@
         "id": "10250"
       }
     ]
+  },
+  {
+    "title": "ほえろブンブン",
+    "titleTranslate": {
+      "zh-Hans": [
+        "怒吼吧,小狗!剧场版"
+      ],
+      "en": [
+        "Hoero Bunbun (Movie)"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-04-03T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-04-03T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "109624"
+      },
+      {
+        "site": "mal",
+        "id": "10509"
+      },
+      {
+        "site": "anidb",
+        "id": "3956"
+      }
+    ]
   }
 ]

--- a/data/items/1987/07.json
+++ b/data/items/1987/07.json
@@ -187,5 +187,88 @@
         "id": "2182"
       }
     ]
+  },
+  {
+    "title": "TWD EXPRESS ローリングテイクオフ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "TWD EXPRESS ROLLING TAKEOFF"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-07-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-07-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "110815"
+      },
+      {
+        "site": "mal",
+        "id": "12901"
+      },
+      {
+        "site": "anidb",
+        "id": "6811"
+      }
+    ]
+  },
+  {
+    "title": "マップス 伝説のさまよえる星人たち",
+    "titleTranslate": {
+      "zh-Hans": [
+        "星图传说 剧场版"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-07-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-07-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "80860"
+      },
+      {
+        "site": "mal",
+        "id": "3183"
+      },
+      {
+        "site": "anidb",
+        "id": "2081"
+      }
+    ]
+  },
+  {
+    "title": "Bugってハニー メガロム少女舞4622",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "231946"
+      },
+      {
+        "site": "mal",
+        "id": "31868"
+      },
+      {
+        "site": "anidb",
+        "id": "6601"
+      }
+    ]
   }
 ]

--- a/data/items/1987/08.json
+++ b/data/items/1987/08.json
@@ -56,5 +56,59 @@
         "id": "12745"
       }
     ]
+  },
+  {
+    "title": "あいつとララバイ 水曜日のシンデレラ",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-07-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-07-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "139344"
+      },
+      {
+        "site": "mal",
+        "id": "14183"
+      },
+      {
+        "site": "anidb",
+        "id": "7571"
+      }
+    ]
+  },
+  {
+    "title": "チロヌップのきつね",
+    "titleTranslate": {
+      "zh-Hans": [
+        "切洛努普的狐狸"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-08-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-08-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "111331"
+      },
+      {
+        "site": "mal",
+        "id": "17689"
+      },
+      {
+        "site": "anidb",
+        "id": "6695"
+      }
+    ]
   }
 ]

--- a/data/items/1987/10.json
+++ b/data/items/1987/10.json
@@ -414,5 +414,34 @@
         "id": "4211"
       }
     ]
+  },
+  {
+    "title": "勝利投手",
+    "titleTranslate": {
+      "zh-Hans": [
+        "胜利投手"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-10-23T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-10-23T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "108331"
+      },
+      {
+        "site": "mal",
+        "id": "19887"
+      },
+      {
+        "site": "anidb",
+        "id": "2412"
+      }
+    ]
   }
 ]

--- a/data/items/1987/11.json
+++ b/data/items/1987/11.json
@@ -31,5 +31,34 @@
         "id": "movie/880723"
       }
     ]
+  },
+  {
+    "title": "ゴキブリたちの黄昏",
+    "titleTranslate": {
+      "zh-Hans": [
+        "蟑螂的黄昏"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1987-11-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1987-11-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "49058"
+      },
+      {
+        "site": "mal",
+        "id": "4210"
+      },
+      {
+        "site": "anidb",
+        "id": "2406"
+      }
+    ]
   }
 ]

--- a/data/items/1988/07.json
+++ b/data/items/1988/07.json
@@ -381,5 +381,34 @@
         "id": "10200"
       }
     ]
+  },
+  {
+    "title": "白旗の少女 琉子",
+    "titleTranslate": {
+      "zh-Hans": [
+        "举白旗的少女 琉子"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1988-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1988-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220063"
+      },
+      {
+        "site": "mal",
+        "id": "9546"
+      },
+      {
+        "site": "anidb",
+        "id": "6385"
+      }
+    ]
   }
 ]

--- a/data/items/1988/09.json
+++ b/data/items/1988/09.json
@@ -1,0 +1,27 @@
+[
+  {
+    "title": "火の雨がふる",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1988-09-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1988-09-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "139353"
+      },
+      {
+        "site": "mal",
+        "id": "5929"
+      },
+      {
+        "site": "anidb",
+        "id": "3406"
+      }
+    ]
+  }
+]

--- a/data/items/1989/03.json
+++ b/data/items/1989/03.json
@@ -525,5 +525,71 @@
         "id": "12569"
       }
     ]
+  },
+  {
+    "title": "アニメ三銃士 アラミスの冒険",
+    "titleTranslate": {
+      "zh-Hans": [
+        "三个火枪手 阿拉密斯的冒险"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1989-03-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1989-03-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "458112"
+      },
+      {
+        "site": "mal",
+        "id": "2334"
+      },
+      {
+        "site": "anidb",
+        "id": "3639"
+      }
+    ]
+  },
+  {
+    "title": "ドラミちゃん ミニドラSOS!!!",
+    "titleTranslate": {
+      "zh-Hans": [
+        "哆啦美与迷你哆啦SOS"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1989-03-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1989-03-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "121740"
+      },
+      {
+        "site": "mal",
+        "id": "2647"
+      },
+      {
+        "site": "anidb",
+        "id": "7116"
+      },
+      {
+        "site": "aniList",
+        "id": "2647"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/326391"
+      }
+    ]
   }
 ]

--- a/data/items/1989/04.json
+++ b/data/items/1989/04.json
@@ -758,5 +758,34 @@
         "id": "2754"
       }
     ]
+  },
+  {
+    "title": "変幻退魔夜行 カルラ舞う! 奈良怨霊絵巻",
+    "titleTranslate": {
+      "zh-Hans": [
+        "变幻退魔夜行 奈良怨灵绘卷"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1989-04-07T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1989-04-07T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "78059"
+      },
+      {
+        "site": "mal",
+        "id": "3178"
+      },
+      {
+        "site": "anidb",
+        "id": "4316"
+      }
+    ]
   }
 ]

--- a/data/items/1989/05.json
+++ b/data/items/1989/05.json
@@ -1,0 +1,34 @@
+[
+  {
+    "title": "妖刀伝 劇場版",
+    "titleTranslate": {
+      "zh-Hans": [
+        "战国奇谭妖刀传 总集篇"
+      ],
+      "en": [
+        "Sengoku Kitan Youtouden Movie"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1989-05-26T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1989-05-26T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "325374"
+      },
+      {
+        "site": "mal",
+        "id": "1378"
+      },
+      {
+        "site": "anidb",
+        "id": "1036"
+      }
+    ]
+  }
+]

--- a/data/items/1989/10.json
+++ b/data/items/1989/10.json
@@ -720,5 +720,34 @@
         "id": "2569"
       }
     ]
+  },
+  {
+    "title": "ギャラガ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "惑星"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1989-10-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1989-10-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "89688"
+      },
+      {
+        "site": "mal",
+        "id": "1833"
+      },
+      {
+        "site": "anidb",
+        "id": "2457"
+      }
+    ]
   }
 ]

--- a/data/items/1989/11.json
+++ b/data/items/1989/11.json
@@ -34,5 +34,34 @@
         "id": "1276"
       }
     ]
+  },
+  {
+    "title": "伊勢湾台風物語",
+    "titleTranslate": {
+      "zh-Hans": [
+        "伊势湾台风物语"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1989-11-03T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1989-11-03T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "188856"
+      },
+      {
+        "site": "mal",
+        "id": "25305"
+      },
+      {
+        "site": "anidb",
+        "id": "5789"
+      }
+    ]
   }
 ]

--- a/data/items/1990/02.json
+++ b/data/items/1990/02.json
@@ -89,5 +89,34 @@
         "id": "1261"
       }
     ]
+  },
+  {
+    "title": "おじさん改造講座",
+    "titleTranslate": {
+      "zh-Hans": [
+        "大叔改造讲座"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://www.tms-e.co.jp/alltitles/1990s/064301.html",
+    "begin": "1990-02-23T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-02-23T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "421834"
+      },
+      {
+        "site": "mal",
+        "id": "23865"
+      },
+      {
+        "site": "anidb",
+        "id": "3137"
+      }
+    ]
   }
 ]

--- a/data/items/1990/03.json
+++ b/data/items/1990/03.json
@@ -336,5 +336,63 @@
         "id": "8227"
       }
     ]
+  },
+  {
+    "title": "チンプイ エリさま活動大写真",
+    "titleTranslate": {
+      "zh-Hans": [
+        "大耳鼠 惠理大人的活动写真"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-03-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-03-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "89691"
+      },
+      {
+        "site": "mal",
+        "id": "10040"
+      },
+      {
+        "site": "anidb",
+        "id": "5228"
+      }
+    ]
+  },
+  {
+    "title": "MAROKO 麿子",
+    "titleTranslate": {
+      "zh-Hans": [
+        "祖先大人万万岁 剧场版"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-03-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-03-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "54903"
+      },
+      {
+        "site": "mal",
+        "id": "4640"
+      },
+      {
+        "site": "anidb",
+        "id": "1866"
+      }
+    ]
   }
 ]

--- a/data/items/1990/04.json
+++ b/data/items/1990/04.json
@@ -326,5 +326,63 @@
         "id": "20243"
       }
     ]
+  },
+  {
+    "title": "ヘヴィ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "重拳出击"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-04-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-04-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "100479"
+      },
+      {
+        "site": "mal",
+        "id": "10964"
+      },
+      {
+        "site": "anidb",
+        "id": "5230"
+      }
+    ]
+  },
+  {
+    "title": "走れ!白いオオカミ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "奔跑吧!白狼"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-04-27T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-04-27T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "100492"
+      },
+      {
+        "site": "mal",
+        "id": "5936"
+      },
+      {
+        "site": "anidb",
+        "id": "3189"
+      }
+    ]
   }
 ]

--- a/data/items/1990/05.json
+++ b/data/items/1990/05.json
@@ -137,5 +137,34 @@
         "id": "3596"
       }
     ]
+  },
+  {
+    "title": "ベルサイユのばら 生命あるかぎり愛して",
+    "titleTranslate": {
+      "zh-Hans": [
+        "凡尔赛玫瑰 剧场版"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.tms-e.com/search/index.php?pdt_no=313",
+    "begin": "1990-05-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-05-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "275004"
+      },
+      {
+        "site": "mal",
+        "id": "3868"
+      },
+      {
+        "site": "anidb",
+        "id": "3542"
+      }
+    ]
   }
 ]

--- a/data/items/1990/07.json
+++ b/data/items/1990/07.json
@@ -423,5 +423,117 @@
         "id": "7396"
       }
     ]
+  },
+  {
+    "title": "キムの十字架",
+    "titleTranslate": {
+      "zh-Hans": [
+        "金的十字架"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "322643"
+      },
+      {
+        "site": "mal",
+        "id": "19941"
+      },
+      {
+        "site": "anidb",
+        "id": "5272"
+      }
+    ]
+  },
+  {
+    "title": "ハローキティのおやゆびひめ",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "89695"
+      },
+      {
+        "site": "mal",
+        "id": "32622"
+      },
+      {
+        "site": "anidb",
+        "id": "7780"
+      }
+    ]
+  },
+  {
+    "title": "女戦士エフェ&ジーラ グーデの紋章",
+    "titleTranslate": {
+      "zh-Hans": [
+        "女战士艾菲拉和吉利欧拉 古德的纹章"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-07-22T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-07-22T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "92937"
+      },
+      {
+        "site": "mal",
+        "id": "2069"
+      },
+      {
+        "site": "anidb",
+        "id": "2790"
+      }
+    ]
+  },
+  {
+    "title": "クロがいた夏",
+    "titleTranslate": {
+      "zh-Hans": [
+        "有小黑的夏天"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-07-25T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-07-25T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "80177"
+      },
+      {
+        "site": "mal",
+        "id": "3866"
+      },
+      {
+        "site": "anidb",
+        "id": "4133"
+      }
+    ]
   }
 ]

--- a/data/items/1990/08.json
+++ b/data/items/1990/08.json
@@ -137,5 +137,63 @@
         "id": "7090"
       }
     ]
+  },
+  {
+    "title": "「エイジ」",
+    "titleTranslate": {
+      "zh-Hans": [
+        "「英儿」"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-08-24T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-08-24T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "75239"
+      },
+      {
+        "site": "mal",
+        "id": "6076"
+      },
+      {
+        "site": "anidb",
+        "id": "4317"
+      }
+    ]
+  },
+  {
+    "title": "愛と剣のキャメロット まんが家マリナ タイムスリップ事件",
+    "titleTranslate": {
+      "zh-Hans": [
+        "圣剑风云"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-08-24T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-08-24T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "88293"
+      },
+      {
+        "site": "mal",
+        "id": "5931"
+      },
+      {
+        "site": "anidb",
+        "id": "4006"
+      }
+    ]
   }
 ]

--- a/data/items/1990/11.json
+++ b/data/items/1990/11.json
@@ -48,5 +48,34 @@
         "id": "1195"
       }
     ]
+  },
+  {
+    "title": "亜人戦士",
+    "titleTranslate": {
+      "zh-Hans": [
+        "亚人战士"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-11-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-11-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "100474"
+      },
+      {
+        "site": "mal",
+        "id": "17325"
+      },
+      {
+        "site": "anidb",
+        "id": "4182"
+      }
+    ]
   }
 ]

--- a/data/items/1990/12.json
+++ b/data/items/1990/12.json
@@ -47,5 +47,63 @@
         "id": "20821"
       }
     ]
+  },
+  {
+    "title": "戦争が終わった夏に 1945・樺太",
+    "titleTranslate": {
+      "zh-Hans": [
+        "在战争结束的夏天 1945·桦太"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-12-07T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-12-07T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "314445"
+      },
+      {
+        "site": "mal",
+        "id": "25035"
+      },
+      {
+        "site": "anidb",
+        "id": "8639"
+      }
+    ]
+  },
+  {
+    "title": "風の名はアムネジア",
+    "titleTranslate": {
+      "zh-Hans": [
+        "随风而逝的记忆"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1990-12-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1990-12-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "25424"
+      },
+      {
+        "site": "mal",
+        "id": "1793"
+      },
+      {
+        "site": "anidb",
+        "id": "200"
+      }
+    ]
   }
 ]

--- a/data/items/1991/03.json
+++ b/data/items/1991/03.json
@@ -447,5 +447,34 @@
         "id": "105193"
       }
     ]
+  },
+  {
+    "title": "うしろの正面だあれ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "猜猜我是谁"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1991-03-08T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1991-03-08T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "74297"
+      },
+      {
+        "site": "mal",
+        "id": "2753"
+      },
+      {
+        "site": "anidb",
+        "id": "3630"
+      }
+    ]
   }
 ]

--- a/data/items/1991/07.json
+++ b/data/items/1991/07.json
@@ -444,5 +444,59 @@
         "id": "7773"
       }
     ]
+  },
+  {
+    "title": "ZIGGY THE MOVIE それゆけ!R&R BAND",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1991-07-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1991-07-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "103895"
+      },
+      {
+        "site": "mal",
+        "id": "11093"
+      },
+      {
+        "site": "anidb",
+        "id": "6602"
+      }
+    ]
+  },
+  {
+    "title": "まじかる☆タルるートくん 燃えろ!友情の魔法大戦",
+    "titleTranslate": {
+      "zh-Hans": [
+        "幻法小魔星 燃烧吧! 友情的魔法大战"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1991-07-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1991-07-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "416533"
+      },
+      {
+        "site": "mal",
+        "id": "22981"
+      },
+      {
+        "site": "anidb",
+        "id": "2086"
+      }
+    ]
   }
 ]

--- a/data/items/1992/07.json
+++ b/data/items/1992/07.json
@@ -538,5 +538,95 @@
         "id": "7829"
       }
     ]
+  },
+  {
+    "title": "ぞう列車がやってきた",
+    "titleTranslate": {
+      "zh-Hans": [
+        "象列车来了"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1992-07-03T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1992-07-03T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220056"
+      },
+      {
+        "site": "mal",
+        "id": "11095"
+      },
+      {
+        "site": "anidb",
+        "id": "2715"
+      }
+    ]
+  },
+  {
+    "title": "せんぼんまつばら 川と生きる少年たち",
+    "titleTranslate": {
+      "zh-Hans": [
+        "千本松原 与河流生活的少年们"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1992-07-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1992-07-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "431619"
+      },
+      {
+        "site": "mal",
+        "id": "19167"
+      },
+      {
+        "site": "anidb",
+        "id": "6357"
+      }
+    ]
+  },
+  {
+    "title": "走れメロス",
+    "titleTranslate": {
+      "zh-Hans": [
+        "跑吧!美乐斯"
+      ],
+      "en": [
+        "Hashire Melos (Movie)"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1992-07-17T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1992-07-17T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "79176"
+      },
+      {
+        "site": "mal",
+        "id": "4876"
+      },
+      {
+        "site": "anidb",
+        "id": "2384"
+      }
+    ]
   }
 ]

--- a/data/items/1992/08.json
+++ b/data/items/1992/08.json
@@ -273,5 +273,63 @@
         "id": "6070"
       }
     ]
+  },
+  {
+    "title": "楽しいムーミン一家 ムーミン谷の彗星",
+    "titleTranslate": {
+      "zh-Hans": [
+        "姆明一族 姆明谷的彗星"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1992-08-07T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1992-08-07T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "171034"
+      },
+      {
+        "site": "mal",
+        "id": "2313"
+      },
+      {
+        "site": "anidb",
+        "id": "3570"
+      }
+    ]
+  },
+  {
+    "title": "トトイ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "托托伊"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1992-08-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1992-08-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "114309"
+      },
+      {
+        "site": "mal",
+        "id": "5535"
+      },
+      {
+        "site": "anidb",
+        "id": "5436"
+      }
+    ]
   }
 ]

--- a/data/items/1992/12.json
+++ b/data/items/1992/12.json
@@ -54,5 +54,34 @@
         "id": "3015"
       }
     ]
+  },
+  {
+    "title": "ちびまる子ちゃん わたしの好きな歌",
+    "titleTranslate": {
+      "zh-Hans": [
+        "樱桃小丸子:我最喜欢的歌"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1992-12-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1992-12-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "28167"
+      },
+      {
+        "site": "mal",
+        "id": "9348"
+      },
+      {
+        "site": "anidb",
+        "id": "5509"
+      }
+    ]
   }
 ]

--- a/data/items/1993/01.json
+++ b/data/items/1993/01.json
@@ -236,5 +236,34 @@
         "id": "3100"
       }
     ]
+  },
+  {
+    "title": "Ramayana: The Legend of Prince Rama",
+    "titleTranslate": {
+      "zh-Hans": [
+        "罗摩衍那:罗摩王子的传说"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1993-01-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1993-01-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "369749"
+      },
+      {
+        "site": "mal",
+        "id": "4921"
+      },
+      {
+        "site": "anidb",
+        "id": "5693"
+      }
+    ]
   }
 ]

--- a/data/items/1993/03.json
+++ b/data/items/1993/03.json
@@ -445,5 +445,34 @@
         "id": "9098"
       }
     ]
+  },
+  {
+    "title": "ドラミちゃん ハロー恐竜キッズ!!",
+    "titleTranslate": {
+      "zh-Hans": [
+        "哆啦美与哈啰小恐龙"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1993-03-05T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1993-03-05T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "121743"
+      },
+      {
+        "site": "mal",
+        "id": "2639"
+      },
+      {
+        "site": "anidb",
+        "id": "7011"
+      }
+    ]
   }
 ]

--- a/data/items/1993/07.json
+++ b/data/items/1993/07.json
@@ -496,5 +496,63 @@
         "id": "14231"
       }
     ]
+  },
+  {
+    "title": "お星さまのレール",
+    "titleTranslate": {
+      "zh-Hans": [
+        "星星的轨迹"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1993-07-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1993-07-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "63015"
+      },
+      {
+        "site": "mal",
+        "id": "1329"
+      },
+      {
+        "site": "anidb",
+        "id": "2794"
+      }
+    ]
+  },
+  {
+    "title": "劇場版 かいけつゾロリ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "剧场版 怪侠佐罗利"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1993-07-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1993-07-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "414761"
+      },
+      {
+        "site": "mal",
+        "id": "6965"
+      },
+      {
+        "site": "anidb",
+        "id": "5997"
+      }
+    ]
   }
 ]

--- a/data/items/1993/12.json
+++ b/data/items/1993/12.json
@@ -389,5 +389,92 @@
         "id": "526"
       }
     ]
+  },
+  {
+    "title": "Coo 遠い海から来たクー",
+    "titleTranslate": {
+      "zh-Hans": [
+        "深海的童話"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1993-12-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1993-12-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "83329"
+      },
+      {
+        "site": "mal",
+        "id": "2055"
+      },
+      {
+        "site": "anidb",
+        "id": "2801"
+      }
+    ]
+  },
+  {
+    "title": "蒼い記憶 満蒙開拓と少年たち",
+    "titleTranslate": {
+      "zh-Hans": [
+        "藏青色的记忆 满蒙开拓和少年们"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1993-12-17T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1993-12-17T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "518859"
+      },
+      {
+        "site": "mal",
+        "id": "17117"
+      },
+      {
+        "site": "anidb",
+        "id": "4179"
+      }
+    ]
+  },
+  {
+    "title": "MOTHER 最後の少女イヴ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "MOTHER 最后的少女EVE"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1993-12-25T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1993-12-25T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "211167"
+      },
+      {
+        "site": "mal",
+        "id": "1154"
+      },
+      {
+        "site": "anidb",
+        "id": "2479"
+      }
+    ]
   }
 ]

--- a/data/items/1994/01.json
+++ b/data/items/1994/01.json
@@ -254,5 +254,34 @@
         "id": "402"
       }
     ]
+  },
+  {
+    "title": "かっ飛ばせ! ドリーマーズ -カープ誕生物語-",
+    "titleTranslate": {
+      "zh-Hans": [
+        "打飞它吧!广岛东洋鲤鱼诞生物语"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1994-01-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1994-01-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "208186"
+      },
+      {
+        "site": "mal",
+        "id": "22111"
+      },
+      {
+        "site": "anidb",
+        "id": "8613"
+      }
+    ]
   }
 ]

--- a/data/items/1994/05.json
+++ b/data/items/1994/05.json
@@ -1,0 +1,31 @@
+[
+  {
+    "title": "土俵の鬼たち",
+    "titleTranslate": {
+      "zh-Hans": [
+        "土俵之鬼"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1994-05-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1994-05-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "112809"
+      },
+      {
+        "site": "mal",
+        "id": "17665"
+      },
+      {
+        "site": "anidb",
+        "id": "7493"
+      }
+    ]
+  }
+]

--- a/data/items/1994/07.json
+++ b/data/items/1994/07.json
@@ -418,5 +418,62 @@
         "id": "7559"
       }
     ]
+  },
+  {
+    "title": "餓狼伝説 THE MOTION PICTURE",
+    "titleTranslate": {
+      "zh-Hans": [
+        "饿狼传说 剧场版"
+      ],
+      "en": [
+        "Garou Densetsu: The Motion Picture"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1994-07-15T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1994-07-15T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "38426"
+      },
+      {
+        "site": "mal",
+        "id": "504"
+      },
+      {
+        "site": "anidb",
+        "id": "873"
+      }
+    ]
+  },
+  {
+    "title": "ライヤンツーリーのうた",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1994-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1994-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "476893"
+      },
+      {
+        "site": "mal",
+        "id": "9959"
+      },
+      {
+        "site": "anidb",
+        "id": "4186"
+      }
+    ]
   }
 ]

--- a/data/items/1994/08.json
+++ b/data/items/1994/08.json
@@ -221,5 +221,34 @@
         "id": "6472"
       }
     ]
+  },
+  {
+    "title": "GS美神 極楽大作戦!!",
+    "titleTranslate": {
+      "zh-Hans": [
+        "GS美神极乐大作战 剧场版"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1994-08-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1994-08-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "76805"
+      },
+      {
+        "site": "mal",
+        "id": "3037"
+      },
+      {
+        "site": "anidb",
+        "id": "1506"
+      }
+    ]
   }
 ]

--- a/data/items/1995/06.json
+++ b/data/items/1995/06.json
@@ -142,5 +142,34 @@
         "id": "1496"
       }
     ]
+  },
+  {
+    "title": "翔べ!ペガサス",
+    "titleTranslate": {
+      "zh-Hans": [
+        "飞翔吧!天马座"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1995-06-02T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1995-06-02T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "207972"
+      },
+      {
+        "site": "mal",
+        "id": "19049"
+      },
+      {
+        "site": "anidb",
+        "id": "8665"
+      }
+    ]
   }
 ]

--- a/data/items/1995/07.json
+++ b/data/items/1995/07.json
@@ -384,5 +384,34 @@
         "id": "7755"
       }
     ]
+  },
+  {
+    "title": "カッタ君物語",
+    "titleTranslate": {
+      "zh-Hans": [
+        "卡塔君物语"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1995-07-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1995-07-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "318281"
+      },
+      {
+        "site": "mal",
+        "id": "21101"
+      },
+      {
+        "site": "anidb",
+        "id": "7514"
+      }
+    ]
   }
 ]

--- a/data/items/1995/08.json
+++ b/data/items/1995/08.json
@@ -229,5 +229,34 @@
         "id": "1918"
       }
     ]
+  },
+  {
+    "title": "アンネの日記",
+    "titleTranslate": {
+      "zh-Hans": [
+        "安妮日记"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1995-08-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1995-08-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "116022"
+      },
+      {
+        "site": "mal",
+        "id": "3829"
+      },
+      {
+        "site": "anidb",
+        "id": "2652"
+      }
+    ]
   }
 ]

--- a/data/items/1996/03.json
+++ b/data/items/1996/03.json
@@ -328,5 +328,34 @@
         "id": "2566"
       }
     ]
+  },
+  {
+    "title": "チョッちゃん物語",
+    "titleTranslate": {
+      "zh-Hans": [
+        "风雨中的小豆豆"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1996-03-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1996-03-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "83172"
+      },
+      {
+        "site": "mal",
+        "id": "4201"
+      },
+      {
+        "site": "anidb",
+        "id": "4002"
+      }
+    ]
   }
 ]

--- a/data/items/1996/04.json
+++ b/data/items/1996/04.json
@@ -886,5 +886,66 @@
         "id": "2817"
       }
     ]
+  },
+  {
+    "title": "ドラゴンクエスト列伝 ロトの紋章",
+    "titleTranslate": {
+      "zh-Hans": [
+        "勇者斗恶龙:罗德的纹章"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://www.nippon-animation.co.jp/work/1747/",
+    "begin": "1996-04-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1996-04-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "317746"
+      },
+      {
+        "site": "mal",
+        "id": "7491"
+      },
+      {
+        "site": "anidb",
+        "id": "2095"
+      }
+    ]
+  },
+  {
+    "title": "天地無用! in LOVE",
+    "titleTranslate": {
+      "zh-Hans": [
+        "天地无用! in LOVE"
+      ],
+      "en": [
+        "Tenchi Muyou! in Love"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1996-04-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1996-04-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "36266"
+      },
+      {
+        "site": "mal",
+        "id": "1006"
+      },
+      {
+        "site": "anidb",
+        "id": "359"
+      }
+    ]
   }
 ]

--- a/data/items/1996/06.json
+++ b/data/items/1996/06.json
@@ -118,5 +118,30 @@
         "id": "2710"
       }
     ]
+  },
+  {
+    "title": "APO APOワールド ジャイアント馬場 90分1本勝負",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1996-06-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1996-06-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "315778"
+      },
+      {
+        "site": "mal",
+        "id": "22851"
+      },
+      {
+        "site": "anidb",
+        "id": "7188"
+      }
+    ]
   }
 ]

--- a/data/items/1996/07.json
+++ b/data/items/1996/07.json
@@ -426,5 +426,34 @@
         "id": "7557"
       }
     ]
+  },
+  {
+    "title": "エンジェルがとんだ日",
+    "titleTranslate": {
+      "zh-Hans": [
+        "天使飞起来的日子"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1996-07-26T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1996-07-26T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220052"
+      },
+      {
+        "site": "mal",
+        "id": "22959"
+      },
+      {
+        "site": "anidb",
+        "id": "8608"
+      }
+    ]
   }
 ]

--- a/data/items/1996/08.json
+++ b/data/items/1996/08.json
@@ -258,5 +258,63 @@
         "broadcast": "R/1996-08-03T00:00:00.000Z/P7D"
       }
     ]
+  },
+  {
+    "title": "マヤの一生",
+    "titleTranslate": {
+      "zh-Hans": [
+        "马亚的一生"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.mushi-pro.co.jp/2010/08/%E3%83%9E%E3%83%A4%E3%81%AE%E4%B8%80%E7%94%9F/",
+    "begin": "1996-08-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1996-08-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "310063"
+      },
+      {
+        "site": "mal",
+        "id": "25301"
+      },
+      {
+        "site": "anidb",
+        "id": "6358"
+      }
+    ]
+  },
+  {
+    "title": "賢治のトランク",
+    "titleTranslate": {
+      "zh-Hans": [
+        "贤治的皮箱"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1996-08-23T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1996-08-23T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "89707"
+      },
+      {
+        "site": "mal",
+        "id": "21099"
+      },
+      {
+        "site": "anidb",
+        "id": "7720"
+      }
+    ]
   }
 ]

--- a/data/items/1997/03.json
+++ b/data/items/1997/03.json
@@ -456,5 +456,34 @@
         "id": "tv/34085"
       }
     ]
+  },
+  {
+    "title": "機関車先生",
+    "titleTranslate": {
+      "zh-Hans": [
+        "机关车先生"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1997-03-28T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1997-03-28T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "109615"
+      },
+      {
+        "site": "mal",
+        "id": "23085"
+      },
+      {
+        "site": "anidb",
+        "id": "4300"
+      }
+    ]
   }
 ]

--- a/data/items/1997/04.json
+++ b/data/items/1997/04.json
@@ -922,5 +922,63 @@
         "id": "1106"
       }
     ]
+  },
+  {
+    "title": "ヘルメス-愛は風の如く",
+    "titleTranslate": {
+      "zh-Hans": [
+        "赫米斯-风之爱"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1997-04-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1997-04-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "68749"
+      },
+      {
+        "site": "mal",
+        "id": "6937"
+      },
+      {
+        "site": "anidb",
+        "id": "4275"
+      }
+    ]
+  },
+  {
+    "title": "天才えりちゃん金魚を食べた",
+    "titleTranslate": {
+      "zh-Hans": [
+        "天才绘理吃金鱼"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1997-04-25T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1997-04-25T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "129412"
+      },
+      {
+        "site": "mal",
+        "id": "18907"
+      },
+      {
+        "site": "anidb",
+        "id": "8653"
+      }
+    ]
   }
 ]

--- a/data/items/1997/07.json
+++ b/data/items/1997/07.json
@@ -599,5 +599,34 @@
         "id": "9455"
       }
     ]
+  },
+  {
+    "title": "どんぐりの家",
+    "titleTranslate": {
+      "zh-Hans": [
+        "橡木实之家"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1997-07-24T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1997-07-24T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "61103"
+      },
+      {
+        "site": "mal",
+        "id": "5916"
+      },
+      {
+        "site": "anidb",
+        "id": "4986"
+      }
+    ]
   }
 ]

--- a/data/items/1997/08.json
+++ b/data/items/1997/08.json
@@ -288,5 +288,34 @@
         "id": "1490"
       }
     ]
+  },
+  {
+    "title": "天地無用!真夏のイヴ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "天地无用! 盛夏的夜晚"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1997-08-01T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1997-08-01T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "56628"
+      },
+      {
+        "site": "mal",
+        "id": "1101"
+      },
+      {
+        "site": "anidb",
+        "id": "375"
+      }
+    ]
   }
 ]

--- a/data/items/1997/09.json
+++ b/data/items/1997/09.json
@@ -125,5 +125,63 @@
         "id": "5348"
       }
     ]
+  },
+  {
+    "title": "栄光へのシュプール 猪谷千春物語",
+    "titleTranslate": {
+      "zh-Hans": [
+        "光荣的轨迹 猪谷千春物语"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1997-09-12T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1997-09-12T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220074"
+      },
+      {
+        "site": "mal",
+        "id": "19943"
+      },
+      {
+        "site": "anidb",
+        "id": "6359"
+      }
+    ]
+  },
+  {
+    "title": "幕末のスパシーボ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "幕末的感谢"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1997-09-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1997-09-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "109474"
+      },
+      {
+        "site": "mal",
+        "id": "8092"
+      },
+      {
+        "site": "anidb",
+        "id": "7377"
+      }
+    ]
   }
 ]

--- a/data/items/1998/04.json
+++ b/data/items/1998/04.json
@@ -1385,5 +1385,63 @@
         "broadcast": "R/2023-02-01T03:00:00.000Z/P7D"
       }
     ]
+  },
+  {
+    "title": "魔法阿媽",
+    "titleTranslate": {
+      "zh-Hans": [
+        "魔法阿妈"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://mofaama.com/",
+    "begin": "1998-04-02T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1998-04-02T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "54579"
+      },
+      {
+        "site": "mal",
+        "id": "10149"
+      },
+      {
+        "site": "anidb",
+        "id": "8426"
+      }
+    ]
+  },
+  {
+    "title": "MAZE☆爆熱時空 天変脅威の大巨人",
+    "titleTranslate": {
+      "zh-Hans": [
+        "爆热时空 天变威胁的大巨人"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1998-04-24T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1998-04-24T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "280842"
+      },
+      {
+        "site": "mal",
+        "id": "8442"
+      },
+      {
+        "site": "anidb",
+        "id": "3374"
+      }
+    ]
   }
 ]

--- a/data/items/1998/12.json
+++ b/data/items/1998/12.json
@@ -139,5 +139,37 @@
         "id": "3491"
       }
     ]
+  },
+  {
+    "title": "ビーストウォーズII 超生命体トランスフォーマー ライオコンボイ危機一髪!",
+    "titleTranslate": {
+      "zh-Hans": [
+        "变形金刚:野兽之战2 白狮擎天柱千钧一发"
+      ],
+      "en": [
+        "Beast Wars Second Chou Seimeitai Transformers: Lio Convoy Kiki Ippatsu! Movie"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1998-12-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1998-12-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "415762"
+      },
+      {
+        "site": "mal",
+        "id": "5289"
+      },
+      {
+        "site": "anidb",
+        "id": "2978"
+      }
+    ]
   }
 ]

--- a/data/items/1999/04.json
+++ b/data/items/1999/04.json
@@ -1093,5 +1093,37 @@
         "id": "4926"
       }
     ]
+  },
+  {
+    "title": "天地無用! in LOVE2 遙かなる想い",
+    "titleTranslate": {
+      "zh-Hans": [
+        "天地无用! in LOVE 2:遥远的思念"
+      ],
+      "en": [
+        "Tenchi Muyou! in Love 2: Harukanaru Omoi"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1999-04-23T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1999-04-23T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "56627"
+      },
+      {
+        "site": "mal",
+        "id": "1144"
+      },
+      {
+        "site": "anidb",
+        "id": "376"
+      }
+    ]
   }
 ]

--- a/data/items/1999/05.json
+++ b/data/items/1999/05.json
@@ -33,5 +33,34 @@
         "id": "1899"
       }
     ]
+  },
+  {
+    "title": "ゼノ かぎりなき愛に",
+    "titleTranslate": {
+      "zh-Hans": [
+        "Zeno 为了无尽的爱"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "1999-05-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1999-05-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "316100"
+      },
+      {
+        "site": "mal",
+        "id": "4790"
+      },
+      {
+        "site": "anidb",
+        "id": "4752"
+      }
+    ]
   }
 ]

--- a/data/items/1999/07.json
+++ b/data/items/1999/07.json
@@ -768,5 +768,34 @@
         "id": "1513"
       }
     ]
+  },
+  {
+    "title": "め組の大吾 火事場のバカヤロー",
+    "titleTranslate": {
+      "zh-Hans": [
+        "消防员的故事"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://www.sunrise-inc.co.jp/work/detail.php?cid=145",
+    "begin": "1999-07-26T16:00:00.000Z",
+    "broadcast": "",
+    "end": "1999-07-26T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "82524"
+      },
+      {
+        "site": "mal",
+        "id": "3147"
+      },
+      {
+        "site": "anidb",
+        "id": "1572"
+      }
+    ]
   }
 ]

--- a/data/items/2000/02.json
+++ b/data/items/2000/02.json
@@ -181,5 +181,34 @@
         "id": "783"
       }
     ]
+  },
+  {
+    "title": "A・LI・CE",
+    "titleTranslate": {
+      "zh-Hans": [
+        "超越时空爱丽丝"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2000-02-04T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2000-02-04T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "112655"
+      },
+      {
+        "site": "mal",
+        "id": "3463"
+      },
+      {
+        "site": "anidb",
+        "id": "1719"
+      }
+    ]
   }
 ]

--- a/data/items/2000/07.json
+++ b/data/items/2000/07.json
@@ -756,5 +756,42 @@
         "id": "105255"
       }
     ]
+  },
+  {
+    "title": "風を見た少年",
+    "titleTranslate": {
+      "zh-Hans": [
+        "看见风的少年"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2000-07-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2000-07-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "62458"
+      },
+      {
+        "site": "mal",
+        "id": "757"
+      },
+      {
+        "site": "anidb",
+        "id": "388"
+      },
+      {
+        "site": "aniList",
+        "id": "757"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/77194"
+      }
+    ]
   }
 ]

--- a/data/items/2000/08.json
+++ b/data/items/2000/08.json
@@ -83,5 +83,37 @@
         "id": "543"
       }
     ]
+  },
+  {
+    "title": "ストリートファイターZERO - THE ANIMATION -",
+    "titleTranslate": {
+      "zh-Hans": [
+        "街头霸王ZERO"
+      ],
+      "en": [
+        "Street Fighter Zero The Animation"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2000-08-30T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2000-08-30T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "72834"
+      },
+      {
+        "site": "mal",
+        "id": "979"
+      },
+      {
+        "site": "anidb",
+        "id": "210"
+      }
+    ]
   }
 ]

--- a/data/items/2000/10.json
+++ b/data/items/2000/10.json
@@ -922,5 +922,37 @@
         "id": "7985"
       }
     ]
+  },
+  {
+    "title": "アレクサンダー戦記 劇場版",
+    "titleTranslate": {
+      "zh-Hans": [
+        "亚历山大战记 剧场版"
+      ],
+      "en": [
+        "Alexander Senki Movie"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2000-10-06T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2000-10-06T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "73802"
+      },
+      {
+        "site": "mal",
+        "id": "5157"
+      },
+      {
+        "site": "anidb",
+        "id": "7528"
+      }
+    ]
   }
 ]

--- a/data/items/2001/07.json
+++ b/data/items/2001/07.json
@@ -1137,5 +1137,67 @@
         "id": "7827"
       }
     ]
+  },
+  {
+    "title": "Blue Remains",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.dmf.co.jp/blueremains",
+    "begin": "2001-07-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2001-07-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "138692"
+      },
+      {
+        "site": "mal",
+        "id": "4733"
+      },
+      {
+        "site": "anidb",
+        "id": "2627"
+      }
+    ]
+  },
+  {
+    "title": "アリーテ姫",
+    "titleTranslate": {
+      "zh-Hans": [
+        "阿莱蒂公主"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.arete.jp/arete/index.html",
+    "begin": "2001-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2001-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "12282"
+      },
+      {
+        "site": "mal",
+        "id": "1028"
+      },
+      {
+        "site": "anidb",
+        "id": "1190"
+      },
+      {
+        "site": "aniList",
+        "id": "1028"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/59297"
+      }
+    ]
   }
 ]

--- a/data/items/2001/10.json
+++ b/data/items/2001/10.json
@@ -1054,5 +1054,37 @@
         "id": "7851"
       }
     ]
+  },
+  {
+    "title": "シャム猫 -ファーストミッション-",
+    "titleTranslate": {
+      "zh-Hans": [
+        "暹罗猫 第一次任务"
+      ],
+      "en": [
+        "The Siamese: First Mission"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2001-10-05T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2001-10-05T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "89711"
+      },
+      {
+        "site": "mal",
+        "id": "15399"
+      },
+      {
+        "site": "anidb",
+        "id": "5539"
+      }
+    ]
   }
 ]

--- a/data/items/2002/04.json
+++ b/data/items/2002/04.json
@@ -1400,5 +1400,37 @@
         "id": "139884"
       }
     ]
+  },
+  {
+    "title": "エクスドライバー the Movie",
+    "titleTranslate": {
+      "zh-Hans": [
+        "极速战警剧场版"
+      ],
+      "en": [
+        "eX-Driver the Movie"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2002-04-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2002-04-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "172156"
+      },
+      {
+        "site": "mal",
+        "id": "378"
+      },
+      {
+        "site": "anidb",
+        "id": "440"
+      }
+    ]
   }
 ]

--- a/data/items/2002/06.json
+++ b/data/items/2002/06.json
@@ -123,5 +123,34 @@
         "id": "movie/1023542"
       }
     ]
+  },
+  {
+    "title": "ギルステイン",
+    "titleTranslate": {
+      "zh-Hans": [
+        "兽星记基尔斯汀"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2002-06-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2002-06-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "158789"
+      },
+      {
+        "site": "mal",
+        "id": "11995"
+      },
+      {
+        "site": "anidb",
+        "id": "1855"
+      }
+    ]
   }
 ]

--- a/data/items/2002/08.json
+++ b/data/items/2002/08.json
@@ -442,5 +442,33 @@
         "broadcast": "R/2026-06-01T03:00:00.000Z/P7D"
       }
     ]
+  },
+  {
+    "title": "劇場版 ガイスターズ FRACTIONS OF THE EARTH",
+    "titleTranslate": {
+      "zh-Hans": [
+        "银河五虎将剧场版"
+      ],
+      "en": [
+        "Gekijouban Geisters: Fractions of the Earth"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2002-08-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2002-08-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "54043"
+      },
+      {
+        "site": "anidb",
+        "id": "8610"
+      }
+    ]
   }
 ]

--- a/data/items/2002/12.json
+++ b/data/items/2002/12.json
@@ -342,5 +342,34 @@
         "id": "7330"
       }
     ]
+  },
+  {
+    "title": "アテルイ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "阿弖流为"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.cinema-tohoku.co.jp/movie/aterui/index.html",
+    "begin": "2002-12-01T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2002-12-01T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "318344"
+      },
+      {
+        "site": "mal",
+        "id": "23523"
+      },
+      {
+        "site": "anidb",
+        "id": "8509"
+      }
+    ]
   }
 ]

--- a/data/items/2003/07.json
+++ b/data/items/2003/07.json
@@ -909,5 +909,34 @@
         "id": "2734"
       }
     ]
+  },
+  {
+    "title": "良寛さん",
+    "titleTranslate": {
+      "zh-Hans": [
+        "良宽"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2003-07-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2003-07-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220054"
+      },
+      {
+        "site": "mal",
+        "id": "30204"
+      },
+      {
+        "site": "anidb",
+        "id": "4115"
+      }
+    ]
   }
 ]

--- a/data/items/2003/12.json
+++ b/data/items/2003/12.json
@@ -405,5 +405,37 @@
         "id": "movie/355144"
       }
     ]
+  },
+  {
+    "title": "インターステラ5555:THE 5TORY OF THE 5ECRET 5TAR 5YSTEM",
+    "titleTranslate": {
+      "zh-Hans": [
+        "星际5555:异星梦系统秘传"
+      ],
+      "en": [
+        "Interstella5555: The 5tory of The 5ecret 5tar 5ystem"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.bacfilms.com/site/interstella/",
+    "begin": "2003-12-02T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2003-12-02T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "91628"
+      },
+      {
+        "site": "mal",
+        "id": "731"
+      },
+      {
+        "site": "anidb",
+        "id": "1153"
+      }
+    ]
   }
 ]

--- a/data/items/2004/07.json
+++ b/data/items/2004/07.json
@@ -1033,5 +1033,26 @@
         "id": "7551"
       }
     ]
+  },
+  {
+    "title": "DDDにおける池田爆発郎とwattの本名",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2004-07-30T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2004-07-30T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "320523"
+      },
+      {
+        "site": "anidb",
+        "id": "8643"
+      }
+    ]
   }
 ]

--- a/data/items/2005/01.json
+++ b/data/items/2005/01.json
@@ -1086,5 +1086,30 @@
         "id": "tv/45492"
       }
     ]
+  },
+  {
+    "title": "ハードル",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2005-01-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2005-01-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "220046"
+      },
+      {
+        "site": "mal",
+        "id": "16776"
+      },
+      {
+        "site": "anidb",
+        "id": "3307"
+      }
+    ]
   }
 ]

--- a/data/items/2005/04.json
+++ b/data/items/2005/04.json
@@ -1850,5 +1850,34 @@
         "id": "2178"
       }
     ]
+  },
+  {
+    "title": "緑玉紳士",
+    "titleTranslate": {
+      "zh-Hans": [
+        "绿玉绅士"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2005-04-02T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2005-04-02T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "324781"
+      },
+      {
+        "site": "mal",
+        "id": "33078"
+      },
+      {
+        "site": "anidb",
+        "id": "8743"
+      }
+    ]
   }
 ]

--- a/data/items/2005/06.json
+++ b/data/items/2005/06.json
@@ -179,5 +179,34 @@
         "id": "503"
       }
     ]
+  },
+  {
+    "title": "あした元気にな~れ!~半分のさつまいも~",
+    "titleTranslate": {
+      "zh-Hans": [
+        "明天也要精神百倍!~一半的甘薯~"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.ashita-genki.com/",
+    "begin": "2005-06-29T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2005-06-29T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "84587"
+      },
+      {
+        "site": "mal",
+        "id": "17493"
+      },
+      {
+        "site": "anidb",
+        "id": "3438"
+      }
+    ]
   }
 ]

--- a/data/items/2005/10.json
+++ b/data/items/2005/10.json
@@ -1670,5 +1670,34 @@
         "id": "3394"
       }
     ]
+  },
+  {
+    "title": "ストリートファイターZERO: ジェネレーションズ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "街头霸王ZERO:世代"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2005-10-24T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2005-10-24T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "72835"
+      },
+      {
+        "site": "mal",
+        "id": "950"
+      },
+      {
+        "site": "anidb",
+        "id": "3658"
+      }
+    ]
   }
 ]

--- a/data/items/2006/02.json
+++ b/data/items/2006/02.json
@@ -270,5 +270,59 @@
         "id": "777"
       }
     ]
+  },
+  {
+    "title": "サムシング グレート 地図にない町",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2006-02-03T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2006-02-03T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "332513"
+      },
+      {
+        "site": "mal",
+        "id": "23979"
+      },
+      {
+        "site": "anidb",
+        "id": "5026"
+      }
+    ]
+  },
+  {
+    "title": "死者の書",
+    "titleTranslate": {
+      "zh-Hans": [
+        "死者之书"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2006-02-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2006-02-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "315584"
+      },
+      {
+        "site": "mal",
+        "id": "7510"
+      },
+      {
+        "site": "anidb",
+        "id": "6193"
+      }
+    ]
   }
 ]

--- a/data/items/2006/12.json
+++ b/data/items/2006/12.json
@@ -507,5 +507,66 @@
         "id": "7547"
       }
     ]
+  },
+  {
+    "title": "劇場版 どうぶつの森",
+    "titleTranslate": {
+      "zh-Hans": [
+        "动物之森"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2006-12-15T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2006-12-15T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "2905"
+      },
+      {
+        "site": "mal",
+        "id": "2950"
+      },
+      {
+        "site": "anidb",
+        "id": "4590"
+      }
+    ]
+  },
+  {
+    "title": "TOKYO LOOP",
+    "titleTranslate": {
+      "zh-Hans": [
+        "回转东京"
+      ],
+      "en": [
+        "Tokyo Loop"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://www.imageforum.co.jp/tokyoloop/",
+    "begin": "2006-12-22T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2006-12-22T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "189665"
+      },
+      {
+        "site": "mal",
+        "id": "4761"
+      },
+      {
+        "site": "anidb",
+        "id": "8744"
+      }
+    ]
   }
 ]

--- a/data/items/2007/04.json
+++ b/data/items/2007/04.json
@@ -2891,5 +2891,42 @@
         "id": "tv/46392/season/3"
       }
     ]
+  },
+  {
+    "title": "ふろさと-JAPAN",
+    "titleTranslate": {
+      "zh-Hans": [
+        "故乡之歌"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.furusatojapan.com/",
+    "begin": "2007-04-06T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2007-04-06T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "139377"
+      },
+      {
+        "site": "mal",
+        "id": "3367"
+      },
+      {
+        "site": "anidb",
+        "id": "4588"
+      },
+      {
+        "site": "aniList",
+        "id": "3367"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/55555"
+      }
+    ]
   }
 ]

--- a/data/items/2007/05.json
+++ b/data/items/2007/05.json
@@ -198,5 +198,34 @@
         "id": "2832"
       }
     ]
+  },
+  {
+    "title": "新SOS大東京探検隊",
+    "titleTranslate": {
+      "zh-Hans": [
+        "新SOS大东京探险队"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.tokyotanken.com/index_f.html",
+    "begin": "2007-05-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2007-05-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "25485"
+      },
+      {
+        "site": "mal",
+        "id": "4471"
+      },
+      {
+        "site": "anidb",
+        "id": "5174"
+      }
+    ]
   }
 ]

--- a/data/items/2007/12.json
+++ b/data/items/2007/12.json
@@ -398,5 +398,59 @@
         "id": "4932"
       }
     ]
+  },
+  {
+    "title": "えいがでとーじょー! たまごっち ドキドキ! うちゅーのまいごっち!?",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2007-12-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2007-12-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "84048"
+      },
+      {
+        "site": "mal",
+        "id": "6518"
+      },
+      {
+        "site": "anidb",
+        "id": "7018"
+      }
+    ]
+  },
+  {
+    "title": "ねずみ物語 〜ジョージとジェラルドの冒険〜",
+    "titleTranslate": {
+      "zh-Hans": [
+        "老鼠物语 -乔治和杰拉尔德的冒险-"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2007-12-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2007-12-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "68968"
+      },
+      {
+        "site": "mal",
+        "id": "9789"
+      },
+      {
+        "site": "anidb",
+        "id": "5397"
+      }
+    ]
   }
 ]

--- a/data/items/2008/12.json
+++ b/data/items/2008/12.json
@@ -282,5 +282,30 @@
         "id": "5042"
       }
     ]
+  },
+  {
+    "title": "映画! たまごっち うちゅーいちハッピーな物語!?",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2008-12-19T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2008-12-19T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "84049"
+      },
+      {
+        "site": "mal",
+        "id": "6517"
+      },
+      {
+        "site": "anidb",
+        "id": "7017"
+      }
+    ]
   }
 ]

--- a/data/items/2009/01.json
+++ b/data/items/2009/01.json
@@ -1549,5 +1549,26 @@
         "id": "4970"
       }
     ]
+  },
+  {
+    "title": "ピューと吹く!ジャガー ~いま、吹きにゆきます~",
+    "titleTranslate": {
+      "zh-Hans": [
+        "搞怪吹笛手:立刻开吹"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2008-12-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2008-12-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "412353"
+      }
+    ]
   }
 ]

--- a/data/items/2009/06.json
+++ b/data/items/2009/06.json
@@ -542,5 +542,26 @@
         "id": "5386"
       }
     ]
+  },
+  {
+    "title": "エコファン",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2009-06-27T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2009-06-27T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "333894"
+      },
+      {
+        "site": "anidb",
+        "id": "8599"
+      }
+    ]
   }
 ]

--- a/data/items/2009/09.json
+++ b/data/items/2009/09.json
@@ -218,5 +218,66 @@
         "id": "6050"
       }
     ]
+  },
+  {
+    "title": "劇場版デュエル・マスターズ 黒月の神帝",
+    "titleTranslate": {
+      "zh-Hans": [
+        "剧场版决斗大师 黑月的神帝"
+      ],
+      "en": [
+        "Duel Masters Movie 2: Lunatic God Saga"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2009-09-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2009-09-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "397215"
+      },
+      {
+        "site": "mal",
+        "id": "6062"
+      },
+      {
+        "site": "anidb",
+        "id": "7167"
+      }
+    ]
+  },
+  {
+    "title": "東のエデン 総集編 Air Communication",
+    "titleTranslate": {
+      "zh-Hans": [
+        "东之伊甸 总集篇 Air Communication"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://juiz.jp/blog/",
+    "begin": "2009-09-25T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2009-09-25T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "3630"
+      },
+      {
+        "site": "mal",
+        "id": "6927"
+      },
+      {
+        "site": "anidb",
+        "id": "6763"
+      }
+    ]
   }
 ]

--- a/data/items/2009/10.json
+++ b/data/items/2009/10.json
@@ -2363,5 +2363,63 @@
         "id": "7183"
       }
     ]
+  },
+  {
+    "title": "仏陀再誕",
+    "titleTranslate": {
+      "zh-Hans": [
+        "佛陀再诞"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.buddha-saitan.jp/wb/index.html",
+    "begin": "2009-10-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2009-10-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "8466"
+      },
+      {
+        "site": "mal",
+        "id": "6985"
+      },
+      {
+        "site": "anidb",
+        "id": "6786"
+      }
+    ]
+  },
+  {
+    "title": "電信柱エレミの恋",
+    "titleTranslate": {
+      "zh-Hans": [
+        "电线杆艾雷米的恋爱"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://park11.wakwak.com/~sovat/e_j_common/roadshow/storypage.html",
+    "begin": "2009-10-30T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2009-10-30T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "160546"
+      },
+      {
+        "site": "mal",
+        "id": "7718"
+      },
+      {
+        "site": "anidb",
+        "id": "8525"
+      }
+    ]
   }
 ]

--- a/data/items/2009/12.json
+++ b/data/items/2009/12.json
@@ -361,5 +361,34 @@
         "id": "7144"
       }
     ]
+  },
+  {
+    "title": "人間失格 ディレクターズカット版",
+    "titleTranslate": {
+      "zh-Hans": [
+        "人间失格 剧场版"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.ntv.co.jp/bungaku/movie.html",
+    "begin": "2009-12-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2009-12-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "58054"
+      },
+      {
+        "site": "mal",
+        "id": "7651"
+      },
+      {
+        "site": "anidb",
+        "id": "7189"
+      }
+    ]
   }
 ]

--- a/data/items/2010/03.json
+++ b/data/items/2010/03.json
@@ -885,5 +885,34 @@
         "id": "8178"
       }
     ]
+  },
+  {
+    "title": "靠岸",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://portofreturn.pixnet.net/blog",
+    "begin": "2010-03-04T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2010-03-04T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "41487"
+      },
+      {
+        "site": "mal",
+        "id": "53230"
+      },
+      {
+        "site": "anidb",
+        "id": "9180"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/260707"
+      }
+    ]
   }
 ]

--- a/data/items/2010/05.json
+++ b/data/items/2010/05.json
@@ -236,5 +236,30 @@
         "id": "8297"
       }
     ]
+  },
+  {
+    "title": "ジュノー",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.junod.jp/",
+    "begin": "2010-05-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2010-05-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "184732"
+      },
+      {
+        "site": "mal",
+        "id": "9525"
+      },
+      {
+        "site": "anidb",
+        "id": "7882"
+      }
+    ]
   }
 ]

--- a/data/items/2010/07.json
+++ b/data/items/2010/07.json
@@ -1850,5 +1850,34 @@
         "id": "8101"
       }
     ]
+  },
+  {
+    "title": "赤毛のアン グリーンゲーブルズへの道",
+    "titleTranslate": {
+      "zh-Hans": [
+        "红发少女安妮 通往绿山墙之路"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://www.ghibli-museum.jp/anne/",
+    "begin": "2010-07-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2010-07-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "115768"
+      },
+      {
+        "site": "mal",
+        "id": "8950"
+      },
+      {
+        "site": "anidb",
+        "id": "7526"
+      }
+    ]
   }
 ]

--- a/data/items/2010/08.json
+++ b/data/items/2010/08.json
@@ -298,5 +298,42 @@
         "id": "10869"
       }
     ]
+  },
+  {
+    "title": "ルー=ガルー",
+    "titleTranslate": {
+      "zh-Hans": [
+        "应避忌的狼"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://lg-anime.com/",
+    "begin": "2010-08-27T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2010-08-27T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "10649"
+      },
+      {
+        "site": "mal",
+        "id": "7598"
+      },
+      {
+        "site": "anidb",
+        "id": "7093"
+      },
+      {
+        "site": "aniList",
+        "id": "7598"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/56362"
+      }
+    ]
   }
 ]

--- a/data/items/2011/05.json
+++ b/data/items/2011/05.json
@@ -263,5 +263,33 @@
         "id": "10191"
       }
     ]
+  },
+  {
+    "title": "TATSUMI",
+    "titleTranslate": {
+      "zh-Hans": [
+        "辰巳"
+      ],
+      "en": [
+        "Tatsumi"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2011-05-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2011-05-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "105789"
+      },
+      {
+        "site": "anidb",
+        "id": "9201"
+      }
+    ]
   }
 ]

--- a/data/items/2011/07.json
+++ b/data/items/2011/07.json
@@ -2232,5 +2232,30 @@
         "id": "8329"
       }
     ]
+  },
+  {
+    "title": "藏獒多吉",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2011-07-04T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2011-07-04T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "3369"
+      },
+      {
+        "site": "mal",
+        "id": "10629"
+      },
+      {
+        "site": "anidb",
+        "id": "8388"
+      }
+    ]
   }
 ]

--- a/data/items/2011/09.json
+++ b/data/items/2011/09.json
@@ -574,5 +574,34 @@
         "id": "10624"
       }
     ]
+  },
+  {
+    "title": "緑子/MIDORI-KO",
+    "titleTranslate": {
+      "zh-Hans": [
+        "绿子"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.midori-ko.com",
+    "begin": "2011-09-23T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2011-09-23T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "104011"
+      },
+      {
+        "site": "mal",
+        "id": "9990"
+      },
+      {
+        "site": "anidb",
+        "id": "8086"
+      }
+    ]
   }
 ]

--- a/data/items/2011/12.json
+++ b/data/items/2011/12.json
@@ -590,5 +590,34 @@
         "id": "1521"
       }
     ]
+  },
+  {
+    "title": "フレンズ もののけ島のナキ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "朋友:怪物岛的纳基"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2011-12-16T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2011-12-16T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "72268"
+      },
+      {
+        "site": "mal",
+        "id": "10115"
+      },
+      {
+        "site": "anidb",
+        "id": "8174"
+      }
+    ]
   }
 ]

--- a/data/items/2012/02.json
+++ b/data/items/2012/02.json
@@ -453,5 +453,63 @@
         "id": "8809"
       }
     ]
+  },
+  {
+    "title": "ドラゴンエイジ -ブラッドメイジの聖戦-",
+    "titleTranslate": {
+      "zh-Hans": [
+        "龙腾世纪 -血法师的圣战-"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.dragonagemovie.jp/",
+    "begin": "2012-02-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2012-02-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "29412"
+      },
+      {
+        "site": "mal",
+        "id": "11705"
+      },
+      {
+        "site": "anidb",
+        "id": "8557"
+      }
+    ]
+  },
+  {
+    "title": "ギョ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "鱼"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.animebunko.com/gyo/",
+    "begin": "2012-02-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2012-02-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "13345"
+      },
+      {
+        "site": "mal",
+        "id": "10417"
+      },
+      {
+        "site": "anidb",
+        "id": "8315"
+      }
+    ]
   }
 ]

--- a/data/items/2012/07.json
+++ b/data/items/2012/07.json
@@ -2339,5 +2339,67 @@
         "id": "9349"
       }
     ]
+  },
+  {
+    "title": "War of the Worlds: Goliath",
+    "titleTranslate": {
+      "zh-Hans": [
+        "世界大战:歌利亚"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2012-07-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2012-07-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "113718"
+      },
+      {
+        "site": "anidb",
+        "id": "13143"
+      }
+    ]
+  },
+  {
+    "title": "Starship Troopers: Invasion",
+    "titleTranslate": {
+      "zh-Hans": [
+        "星船伞兵:入侵"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.starshiptroopersinvasion-movie.com/",
+    "begin": "2012-07-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2012-07-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "40879"
+      },
+      {
+        "site": "mal",
+        "id": "14629"
+      },
+      {
+        "site": "anidb",
+        "id": "9083"
+      },
+      {
+        "site": "aniList",
+        "id": "14629"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/114478"
+      }
+    ]
   }
 ]

--- a/data/items/2012/10.json
+++ b/data/items/2012/10.json
@@ -3183,5 +3183,34 @@
         "id": "15177"
       }
     ]
+  },
+  {
+    "title": "神秘の法",
+    "titleTranslate": {
+      "zh-Hans": [
+        "神秘之法"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2012-10-05T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2012-10-05T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "50512"
+      },
+      {
+        "site": "mal",
+        "id": "13439"
+      },
+      {
+        "site": "anidb",
+        "id": "9081"
+      }
+    ]
   }
 ]

--- a/data/items/2012/11.json
+++ b/data/items/2012/11.json
@@ -437,5 +437,63 @@
         "id": "15439"
       }
     ]
+  },
+  {
+    "title": "花の詩女 ゴティックメード",
+    "titleTranslate": {
+      "zh-Hans": [
+        "GOTHICMADE 花之诗女"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://gothicmade.com/",
+    "begin": "2012-10-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2012-10-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "22598"
+      },
+      {
+        "site": "mal",
+        "id": "7781"
+      },
+      {
+        "site": "anidb",
+        "id": "8618"
+      }
+    ]
+  },
+  {
+    "title": "Mass Effect: Paragon Lost",
+    "titleTranslate": {
+      "zh-Hans": [
+        "质量效应:迷途楷模"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://masseffectparagonlost.com/",
+    "begin": "2012-11-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2012-11-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "68240"
+      },
+      {
+        "site": "mal",
+        "id": "13239"
+      },
+      {
+        "site": "anidb",
+        "id": "8674"
+      }
+    ]
   }
 ]

--- a/data/items/2013/04.json
+++ b/data/items/2013/04.json
@@ -3474,5 +3474,41 @@
         "id": "10633"
       }
     ]
+  },
+  {
+    "title": "映画はなかっぱ 花さけ!パッカ〜ん♪ 蝶の国の大冒険 ザッツ・はなかっぱミュージカル パンとごはん、どっちなの!?",
+    "titleTranslate": {
+      "zh-Hans": [
+        "剧场版花样河童 蝶之国的大冒险"
+      ],
+      "en": [
+        "Hanakappa Movie: Hanasake! Pakkaan♪ Chou no Kuni no Daibouken"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2013-04-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2013-04-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "204864"
+      },
+      {
+        "site": "mal",
+        "id": "17263"
+      },
+      {
+        "site": "anidb",
+        "id": "9527"
+      },
+      {
+        "site": "aniList",
+        "id": "17263"
+      }
+    ]
   }
 ]

--- a/data/items/2013/12.json
+++ b/data/items/2013/12.json
@@ -834,5 +834,42 @@
         "id": "20484"
       }
     ]
+  },
+  {
+    "title": "蝴蝶夢-梁山伯與祝英台",
+    "titleTranslate": {
+      "zh-Hans": [
+        "蝴蝶梦:梁山伯与祝英台"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://www.leon-and-jo.com.tw/",
+    "begin": "2013-12-30T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2013-12-30T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "110589"
+      },
+      {
+        "site": "mal",
+        "id": "52697"
+      },
+      {
+        "site": "anidb",
+        "id": "6753"
+      },
+      {
+        "site": "aniList",
+        "id": "108279"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/77968"
+      }
+    ]
   }
 ]

--- a/data/items/2014/03.json
+++ b/data/items/2014/03.json
@@ -942,5 +942,77 @@
         "id": "20550"
       }
     ]
+  },
+  {
+    "title": "劇場版 プリティーリズム・オールスターセレクション プリズムショー☆ベストテ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "剧场版 美妙旋律・全明星选拔 绫镜時尚秀☆BEST 10"
+      ],
+      "en": [
+        "Pretty Rhythm Movie: All Star Selection - Prism Show☆Best Ten"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://prettyrhythm-movie.jp/",
+    "begin": "2014-03-07T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2014-03-07T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "91273"
+      },
+      {
+        "site": "mal",
+        "id": "21707"
+      },
+      {
+        "site": "anidb",
+        "id": "10353"
+      }
+    ]
+  },
+  {
+    "title": "Marvel Avengers Confidential: Black Widow & Punishe",
+    "titleTranslate": {
+      "zh-Hans": [
+        "机密复仇者:黑寡妇与惩罚者"
+      ],
+      "en": [
+        "Avengers Confidential: Black Widow to Punisher"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2014-03-10T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2014-03-10T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "113067"
+      },
+      {
+        "site": "mal",
+        "id": "25457"
+      },
+      {
+        "site": "anidb",
+        "id": "10409"
+      },
+      {
+        "site": "aniList",
+        "id": "108815"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/257346"
+      }
+    ]
   }
 ]

--- a/data/items/2015/08.json
+++ b/data/items/2015/08.json
@@ -492,5 +492,42 @@
         "id": "12147"
       }
     ]
+  },
+  {
+    "title": "氷川丸ものがたり",
+    "titleTranslate": {
+      "zh-Hans": [
+        "冰川丸的故事"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2015-08-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2015-08-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "309101"
+      },
+      {
+        "site": "mal",
+        "id": "31235"
+      },
+      {
+        "site": "anidb",
+        "id": "11369"
+      },
+      {
+        "site": "aniList",
+        "id": "104984"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/1225556"
+      }
+    ]
   }
 ]

--- a/data/items/2015/10.json
+++ b/data/items/2015/10.json
@@ -5152,5 +5152,34 @@
         "id": "104162"
       }
     ]
+  },
+  {
+    "title": "UFO学園の秘密",
+    "titleTranslate": {
+      "zh-Hans": [
+        "UFO学园的秘密"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://hspicturesstudio.jp/laws-of-universe-0/?no=2",
+    "begin": "2015-10-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2015-10-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "131626"
+      },
+      {
+        "site": "mal",
+        "id": "30850"
+      },
+      {
+        "site": "anidb",
+        "id": "11263"
+      }
+    ]
   }
 ]

--- a/data/items/2015/11.json
+++ b/data/items/2015/11.json
@@ -512,5 +512,34 @@
         "id": "119941"
       }
     ]
+  },
+  {
+    "title": "FW:ハマトラ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "FW:滨虎"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://hamatorapj.com/fw/",
+    "begin": "2015-11-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2015-11-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "127716"
+      },
+      {
+        "site": "mal",
+        "id": "30290"
+      },
+      {
+        "site": "anidb",
+        "id": "11727"
+      }
+    ]
   }
 ]

--- a/data/items/2015/12.json
+++ b/data/items/2015/12.json
@@ -696,5 +696,34 @@
         "id": "tv/61374/season/0/episode/2"
       }
     ]
+  },
+  {
+    "title": "アリス・イン・ドリームランド",
+    "titleTranslate": {
+      "zh-Hans": [
+        "爱丽丝梦游仙境"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2015-12-18T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2015-12-18T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "151993"
+      },
+      {
+        "site": "mal",
+        "id": "31941"
+      },
+      {
+        "site": "anidb",
+        "id": "11733"
+      }
+    ]
   }
 ]

--- a/data/items/2016/01.json
+++ b/data/items/2016/01.json
@@ -3845,5 +3845,34 @@
         "id": "34847"
       }
     ]
+  },
+  {
+    "title": "未来に向けて 防災を考える",
+    "titleTranslate": {
+      "zh-Hans": [
+        "防灾为未来"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2015-12-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2015-12-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "310074"
+      },
+      {
+        "site": "mal",
+        "id": "33980"
+      },
+      {
+        "site": "anidb",
+        "id": "12367"
+      }
+    ]
   }
 ]

--- a/data/items/2016/08.json
+++ b/data/items/2016/08.json
@@ -654,5 +654,42 @@
         "id": "98092"
       }
     ]
+  },
+  {
+    "title": "ルドルフとイッパイアッテナ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "黑猫鲁道夫"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://rudolf-ippaiattena.com/",
+    "begin": "2016-08-05T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2016-08-05T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "142263"
+      },
+      {
+        "site": "mal",
+        "id": "31373"
+      },
+      {
+        "site": "anidb",
+        "id": "11467"
+      },
+      {
+        "site": "aniList",
+        "id": "102058"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/429005"
+      }
+    ]
   }
 ]

--- a/data/items/2016/12.json
+++ b/data/items/2016/12.json
@@ -1026,5 +1026,37 @@
         "id": "62375"
       }
     ]
+  },
+  {
+    "title": "モンスターストライク THE MOVIE はじまりの場所へ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "怪物弹珠 THE MOVIE 前往起始之地"
+      ],
+      "en": [
+        "Monster Strike The Movie: Hajimari no Basho e"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://anime-movie.monster-strike.com/sp/",
+    "begin": "2016-12-09T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2016-12-09T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "187935"
+      },
+      {
+        "site": "mal",
+        "id": "33724"
+      },
+      {
+        "site": "anidb",
+        "id": "12284"
+      }
+    ]
   }
 ]

--- a/data/items/2017/03.json
+++ b/data/items/2017/03.json
@@ -810,5 +810,30 @@
         "id": "21843"
       }
     ]
+  },
+  {
+    "title": "ゴーちゃん。~モコとちんじゅうの森の仲間たち~",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2017-03-04T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2017-03-04T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "208313"
+      },
+      {
+        "site": "mal",
+        "id": "34527"
+      },
+      {
+        "site": "anidb",
+        "id": "12638"
+      }
+    ]
   }
 ]

--- a/data/items/2017/10.json
+++ b/data/items/2017/10.json
@@ -4944,5 +4944,34 @@
         "id": "14114"
       }
     ]
+  },
+  {
+    "title": "DCスーパーヒーローズvs鷹の爪団",
+    "titleTranslate": {
+      "zh-Hans": [
+        "DC超级英雄 vs 鹰之爪团"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://dc-taka.com/",
+    "begin": "2017-10-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2017-10-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "211797"
+      },
+      {
+        "site": "mal",
+        "id": "35219"
+      },
+      {
+        "site": "anidb",
+        "id": "13016"
+      }
+    ]
   }
 ]

--- a/data/items/2017/12.json
+++ b/data/items/2017/12.json
@@ -670,5 +670,34 @@
         "id": "100656"
       }
     ]
+  },
+  {
+    "title": "COCOLORS",
+    "titleTranslate": {
+      "en": [
+        "Cocolors"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://gasolinemask.com/nishiki/cocolors",
+    "begin": "2017-12-01T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2017-12-01T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "194107"
+      },
+      {
+        "site": "mal",
+        "id": "34167"
+      },
+      {
+        "site": "anidb",
+        "id": "12457"
+      }
+    ]
   }
 ]

--- a/data/items/2018/10.json
+++ b/data/items/2018/10.json
@@ -5392,5 +5392,37 @@
         "broadcast": "R/2018-10-05T16:00:00.000Z/P7D"
       }
     ]
+  },
+  {
+    "title": "モンスターストライク THE MOVIE ソラノカナタ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "怪物弹珠 THE MOVIE 空之彼方"
+      ],
+      "en": [
+        "Monster Strike the Movie: Sora no Kanata"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://anime-movie.monster-strike.com/",
+    "begin": "2018-10-04T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2018-10-04T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "248152"
+      },
+      {
+        "site": "mal",
+        "id": "38021"
+      },
+      {
+        "site": "anidb",
+        "id": "14108"
+      }
+    ]
   }
 ]

--- a/data/items/2020/02.json
+++ b/data/items/2020/02.json
@@ -595,5 +595,34 @@
         "id": "15431"
       }
     ]
+  },
+  {
+    "title": "映画 ねこねこ日本史 龍馬のはちゃめちゃタイムトラベルぜよ!",
+    "titleTranslate": {
+      "en": [
+        "Neko Neko Nihonshi Movie: Ryouma no Hachamecha Time Travel ze yo!"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "http://neco-neco-movie.com/",
+    "begin": "2020-02-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2020-02-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "291054"
+      },
+      {
+        "site": "mal",
+        "id": "40425"
+      },
+      {
+        "site": "anidb",
+        "id": "15104"
+      }
+    ]
   }
 ]

--- a/data/items/2020/11.json
+++ b/data/items/2020/11.json
@@ -491,5 +491,34 @@
         "id": "125491"
       }
     ]
+  },
+  {
+    "title": "日本沈没2020 劇場編集版 -シズマヌキボウ-",
+    "titleTranslate": {
+      "zh-Hans": [
+        "日本沉没2020 剧场剪辑版 -不沉的希望-"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2020-11-12T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2020-11-12T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "314069"
+      },
+      {
+        "site": "mal",
+        "id": "44585"
+      },
+      {
+        "site": "anidb",
+        "id": "16547"
+      }
+    ]
   }
 ]

--- a/data/items/2021/06.json
+++ b/data/items/2021/06.json
@@ -944,5 +944,26 @@
         "id": "127958"
       }
     ]
+  },
+  {
+    "title": "トゥルーノース",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://www.true-north.jp",
+    "begin": "2021-06-03T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2021-06-03T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "349071"
+      },
+      {
+        "site": "mal",
+        "id": "53118"
+      }
+    ]
   }
 ]

--- a/data/items/2021/10.json
+++ b/data/items/2021/10.json
@@ -5262,5 +5262,84 @@
         "id": "tv/126340/season/7"
       }
     ]
+  },
+  {
+    "title": "リクはよわくない",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://riku-movie.com/",
+    "begin": "2021-09-30T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2021-09-30T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "332654"
+      },
+      {
+        "site": "mal",
+        "id": "48703"
+      },
+      {
+        "site": "anidb",
+        "id": "16197"
+      }
+    ]
+  },
+  {
+    "title": "宇宙の法―エローヒム編―",
+    "titleTranslate": {
+      "zh-Hans": [
+        "宇宙之法 伊罗兴篇"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://laws-of-universe.hspicturesstudio.jp/",
+    "begin": "2021-10-07T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2021-10-07T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "351112"
+      },
+      {
+        "site": "mal",
+        "id": "48951"
+      },
+      {
+        "site": "anidb",
+        "id": "16414"
+      }
+    ]
+  },
+  {
+    "title": "劇場版オトッペ パパ ・ドント・クライ",
+    "titleTranslate": {
+      "en": [
+        "Otoppe Movie: Papa, Don't Cry"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2021-10-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2021-10-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "333263"
+      },
+      {
+        "site": "anidb",
+        "id": "16076"
+      }
+    ]
   }
 ]

--- a/data/items/2021/11.json
+++ b/data/items/2021/11.json
@@ -480,5 +480,63 @@
         "id": "154974"
       }
     ]
+  },
+  {
+    "title": "幾多の北",
+    "titleTranslate": {
+      "zh-Hans": [
+        "万千北方"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2021-10-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2021-10-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "388988"
+      },
+      {
+        "site": "mal",
+        "id": "50427"
+      },
+      {
+        "site": "anidb",
+        "id": "17763"
+      }
+    ]
+  },
+  {
+    "title": "映画 妖怪ウォッチ♪ ケータとオレっちの出会い編だニャン♪ワ、ワタクシも〜♪♪",
+    "titleTranslate": {
+      "en": [
+        "Youkai Watch ♪ Movie 7: Keita to Orecchi no Deai Hen da Nyan ♪ Wa, Watakushi mo ♪♪"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2021-11-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2021-11-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "368821"
+      },
+      {
+        "site": "mal",
+        "id": "50191"
+      },
+      {
+        "site": "anidb",
+        "id": "16922"
+      }
+    ]
   }
 ]

--- a/data/items/2022/06.json
+++ b/data/items/2022/06.json
@@ -575,5 +575,34 @@
         "id": "movie/963194"
       }
     ]
+  },
+  {
+    "title": "それいけ!アンパンマン ドロリンとバケ〜るカーニバル",
+    "titleTranslate": {
+      "zh-Hans": [
+        "面包超人 多洛林与妖怪嘉年华"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://anpan-movie.com/2022/",
+    "begin": "2022-06-23T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2022-06-23T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "480879"
+      },
+      {
+        "site": "mal",
+        "id": "52452"
+      },
+      {
+        "site": "anidb",
+        "id": "17121"
+      }
+    ]
   }
 ]

--- a/data/items/2022/10.json
+++ b/data/items/2022/10.json
@@ -5224,5 +5224,34 @@
         "id": "156001"
       }
     ]
+  },
+  {
+    "title": "GUARDY GIRLS",
+    "titleTranslate": {
+      "en": [
+        "Guardy Girls"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2022-10-13T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2022-10-13T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "409249"
+      },
+      {
+        "site": "mal",
+        "id": "56828"
+      },
+      {
+        "site": "anidb",
+        "id": "17740"
+      }
+    ]
   }
 ]

--- a/data/items/2023/01.json
+++ b/data/items/2023/01.json
@@ -5954,5 +5954,34 @@
         "id": "155997"
       }
     ]
+  },
+  {
+    "title": "妖怪ウォッチ♪ ジバニャンVSコマさん もんげー大決戦だニャン",
+    "titleTranslate": {
+      "en": [
+        "Youkai Watch ♪ Movie 8: Jibanyan vs. Komasan - Monge Daikessen da Nyan"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2023-01-12T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2023-01-12T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "409032"
+      },
+      {
+        "site": "mal",
+        "id": "53634"
+      },
+      {
+        "site": "anidb",
+        "id": "17727"
+      }
+    ]
   }
 ]

--- a/data/items/2023/11.json
+++ b/data/items/2023/11.json
@@ -858,5 +858,34 @@
         "id": "163363"
       }
     ]
+  },
+  {
+    "title": "火の鳥 エデンの花",
+    "titleTranslate": {
+      "zh-Hans": [
+        "火之鸟 伊甸之花"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://happinet-phantom.com/hinotori-eden/",
+    "begin": "2023-11-02T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2023-11-02T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "445678"
+      },
+      {
+        "site": "mal",
+        "id": "55970"
+      },
+      {
+        "site": "anidb",
+        "id": "18113"
+      }
+    ]
   }
 ]

--- a/data/items/2023/12.json
+++ b/data/items/2023/12.json
@@ -596,5 +596,30 @@
         "broadcast": "R/2024-08-11T15:00:00.000Z/P7D"
       }
     ]
+  },
+  {
+    "title": "死が美しいなんて誰が言った",
+    "titleTranslate": {
+      "zh-Hans": [
+        "谁说死亡是美好的"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "",
+    "begin": "2023-12-21T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2023-12-21T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "500050"
+      },
+      {
+        "site": "mal",
+        "id": "57500"
+      }
+    ]
   }
 ]

--- a/data/items/2024/01.json
+++ b/data/items/2024/01.json
@@ -5418,5 +5418,34 @@
         "broadcast": ""
       }
     ]
+  },
+  {
+    "title": "傷物語-こよみヴァンプ-",
+    "titleTranslate": {
+      "zh-Hans": [
+        "伤物语-历吸血鬼-"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://www.kizumonogatari-movie.com/",
+    "begin": "2024-01-11T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2024-01-11T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "454045"
+      },
+      {
+        "site": "mal",
+        "id": "56609"
+      },
+      {
+        "site": "anidb",
+        "id": "18187"
+      }
+    ]
   }
 ]

--- a/data/items/2024/08.json
+++ b/data/items/2024/08.json
@@ -520,5 +520,34 @@
         "id": "63877"
       }
     ]
+  },
+  {
+    "title": "ゼーガペイン STA",
+    "titleTranslate": {
+      "zh-Hans": [
+        "ZEGAPAIN STA"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://zegapain.net/sta/",
+    "begin": "2024-08-15T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2024-08-15T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "452392"
+      },
+      {
+        "site": "mal",
+        "id": "56488"
+      },
+      {
+        "site": "anidb",
+        "id": "18176"
+      }
+    ]
   }
 ]

--- a/data/items/2025/01.json
+++ b/data/items/2025/01.json
@@ -5476,5 +5476,37 @@
         "id": "movie/1021679"
       }
     ]
+  },
+  {
+    "title": "メイクアガール",
+    "titleTranslate": {
+      "zh-Hans": [
+        "伊人制造"
+      ],
+      "en": [
+        "Make a Girl"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://make-a-girl.com/",
+    "begin": "2025-01-30T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2025-01-30T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "398556"
+      },
+      {
+        "site": "mal",
+        "id": "54740"
+      },
+      {
+        "site": "anidb",
+        "id": "18460"
+      }
+    ]
   }
 ]

--- a/data/items/2025/02.json
+++ b/data/items/2025/02.json
@@ -336,5 +336,58 @@
         "broadcast": "R/2026-02-06T04:00:00.000Z/P7D"
       }
     ]
+  },
+  {
+    "title": "映画 ヒプノシスマイク -Division Rap Battle-",
+    "titleTranslate": {
+      "zh-Hans": [
+        "电影 催眠麦克风"
+      ],
+      "en": [
+        "Hypnosis Mic: Division Rap Battle Movie"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://hypnosismic-movie.com/",
+    "begin": "2025-02-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2025-02-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "523821"
+      },
+      {
+        "site": "mal",
+        "id": "60273"
+      },
+      {
+        "site": "anidb",
+        "id": "19076"
+      }
+    ]
+  },
+  {
+    "title": "親鸞 人生の目的",
+    "titleTranslate": {},
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://shinran-life-movie.jp/",
+    "begin": "2025-02-27T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2025-02-27T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "511571"
+      },
+      {
+        "site": "mal",
+        "id": "59729"
+      }
+    ]
   }
 ]

--- a/data/items/2025/03.json
+++ b/data/items/2025/03.json
@@ -639,5 +639,34 @@
         "id": "movie/1452267"
       }
     ]
+  },
+  {
+    "title": "ニンジャバットマン対ヤクザリーグ",
+    "titleTranslate": {
+      "zh-Hans": [
+        "忍者蝙蝠侠对极道联盟"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://wwws.warnerbros.co.jp/batman-ninja/",
+    "begin": "2025-03-20T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2025-03-20T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "497110"
+      },
+      {
+        "site": "mal",
+        "id": "58964"
+      },
+      {
+        "site": "anidb",
+        "id": "18664"
+      }
+    ]
   }
 ]

--- a/data/items/2025/12.json
+++ b/data/items/2025/12.json
@@ -432,5 +432,34 @@
         "broadcast": ""
       }
     ]
+  },
+  {
+    "title": "ペリリュー -楽園のゲルニカ-",
+    "titleTranslate": {
+      "zh-Hans": [
+        "贝里琉岛 -乐园的格尔尼卡"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://peleliu-movie.jp/",
+    "begin": "2025-12-04T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2025-12-04T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "332677"
+      },
+      {
+        "site": "mal",
+        "id": "48701"
+      },
+      {
+        "site": "anidb",
+        "id": "16193"
+      }
+    ]
   }
 ]

--- a/data/items/2026/01.json
+++ b/data/items/2026/01.json
@@ -6036,5 +6036,42 @@
         "broadcast": "R/2026-05-31T15:00:00.000Z/P7D"
       }
     ]
+  },
+  {
+    "title": "クスノキの番人",
+    "titleTranslate": {
+      "zh-Hans": [
+        "祈念守护人"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://kusunoki-movie.com/",
+    "begin": "2026-01-29T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-01-29T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "550937"
+      },
+      {
+        "site": "mal",
+        "id": "61418"
+      },
+      {
+        "site": "anidb",
+        "id": "19276"
+      },
+      {
+        "site": "aniList",
+        "id": "189956"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/1461201"
+      }
+    ]
   }
 ]

--- a/data/items/2026/02.json
+++ b/data/items/2026/02.json
@@ -437,5 +437,41 @@
         "id": "movie/1363979"
       }
     ]
+  },
+  {
+    "title": "映画ドラえもん 新・のび太の海底鬼岩城",
+    "titleTranslate": {
+      "zh-Hans": [
+        "哆啦A梦:新・大雄的海底鬼岩城"
+      ],
+      "en": [
+        "Doraemon Movie 45: Shin Nobita no Kaitei Kiganjou"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://doraeiga.com/2026/",
+    "begin": "2026-02-26T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-02-26T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "583519"
+      },
+      {
+        "site": "mal",
+        "id": "62508"
+      },
+      {
+        "site": "aniList",
+        "id": "198368"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/1542261"
+      }
+    ]
   }
 ]

--- a/data/items/2026/03.json
+++ b/data/items/2026/03.json
@@ -417,5 +417,42 @@
         "id": "4049"
       }
     ]
+  },
+  {
+    "title": "花緑青が明ける日に",
+    "titleTranslate": {
+      "zh-Hans": [
+        "花绿青绽放的黎明"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://hanaroku.asmik-ace.co.jp/",
+    "begin": "2026-03-05T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-03-05T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "491656"
+      },
+      {
+        "site": "mal",
+        "id": "58735"
+      },
+      {
+        "site": "anidb",
+        "id": "18597"
+      },
+      {
+        "site": "aniList",
+        "id": "177132"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/1279865"
+      }
+    ]
   }
 ]

--- a/data/items/2026/04.json
+++ b/data/items/2026/04.json
@@ -7103,5 +7103,30 @@
         "id": "tv/96117/season/1/episode/124"
       }
     ]
+  },
+  {
+    "title": "KILLTUBE",
+    "titleTranslate": {
+      "en": [
+        "Killtube"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://killtu.be/",
+    "begin": "2026-03-31T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-03-31T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "489223"
+      },
+      {
+        "site": "mal",
+        "id": "58756"
+      }
+    ]
   }
 ]

--- a/data/items/2026/05.json
+++ b/data/items/2026/05.json
@@ -151,5 +151,74 @@
         "id": "movie/1675042"
       }
     ]
+  },
+  {
+    "title": "劇場版 魔法科高校の劣等生 四葉継承編",
+    "titleTranslate": {
+      "zh-Hans": [
+        "剧场版 魔法科高校的劣等生 四叶继承篇"
+      ],
+      "en": [
+        "Mahouka Koukou no Rettousei Movie: Yotsuba Keishou-hen"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://mahouka.jp/yotsuba/",
+    "begin": "2026-05-07T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-05-07T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "501729"
+      },
+      {
+        "site": "mal",
+        "id": "59174"
+      },
+      {
+        "site": "anidb",
+        "id": "18720"
+      },
+      {
+        "site": "aniList",
+        "id": "178707"
+      },
+      {
+        "site": "tmdb",
+        "id": "movie/1310387"
+      }
+    ]
+  },
+  {
+    "title": "機動警察パトレイバー EZY File 1",
+    "titleTranslate": {
+      "zh-Hans": [
+        "机动警察 EZY 第一章"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://ezy.patlabor.tokyo",
+    "begin": "2026-05-14T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-05-14T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "217071"
+      },
+      {
+        "site": "mal",
+        "id": "59889"
+      },
+      {
+        "site": "anidb",
+        "id": "13226"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- 补全漏抓的日本商业长片（片长 ≥ 40 分钟）**226** 部，年份 1959–2026。
- 只收录 BangumiExtLinker / Wikidata 能**唯一**对上 bangumi id 的条目
- 每条都有 bangumi id。外站 ID 同样只填唯一硬连接
  - bangumi: 226
  - MAL: 217
  - AniDB: 220
  - AniList: 16
  - TMDB: 15
- 其中 217 条在 Bangumi 上是「剧场版」；8 条标成 OVA、1 条 WEB，但是影院上映的长片，身份仍是硬映射。
- 例子：[クスノキの番人](https://bgm.tv/subject/550937)（2026-01-30）
  - MAL: [61418](https://myanimelist.net/anime/61418)
  - AniList: [189956](https://anilist.co/anime/189956)
  - AniDB: [19276](https://anidb.net/anime/19276)
  - TMDB: [movie/1461201](https://www.themoviedb.org/movie/1461201)

