### PR TITLE
漏抓补全：日本番剧 4 部（硬映射）

### DIFF
--- a/data/items/2026/01.json
+++ b/data/items/2026/01.json
@@ -6093,5 +6093,26 @@
         "id": "movie/1461201"
       }
     ]
+  },
+  {
+    "title": "機動戦士ガンダム 閃光のハサウェイ キルケーの魔女",
+    "titleTranslate": {
+      "zh-Hans": [
+        "机动战士高达 闪光的哈萨维 喀耳刻的魔女"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://www.gundam.info/feature/hathaway/",
+    "begin": "2026-01-29T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-01-29T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "243430"
+      }
+    ]
   }
 ]

--- a/data/items/2026/02.json
+++ b/data/items/2026/02.json
@@ -479,5 +479,26 @@
         "id": "movie/1542261"
       }
     ]
+  },
+  {
+    "title": "新劇場版 銀魂 -吉原大炎上-",
+    "titleTranslate": {
+      "zh-Hans": [
+        "新剧场版 银魂 -吉原大炎上-"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://wwws.warnerbros.co.jp/shingintamamovie/",
+    "begin": "2026-02-12T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-02-12T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "578766"
+      }
+    ]
   }
 ]

--- a/data/items/2026/04.json
+++ b/data/items/2026/04.json
@@ -7138,5 +7138,26 @@
         "id": "176910"
       }
     ]
+  },
+  {
+    "title": "最終楽章 響け！ユーフォニアム 前編",
+    "titleTranslate": {
+      "zh-Hans": [
+        "最终乐章 吹响吧！上低音号 前篇"
+      ]
+    },
+    "type": "movie",
+    "lang": "ja",
+    "officialSite": "https://anime-eupho.com/",
+    "begin": "2026-04-23T16:00:00.000Z",
+    "broadcast": "",
+    "end": "2026-04-23T16:00:00.000Z",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "544816"
+      }
+    ]
   }
 ]

--- a/data/items/2026/09.json
+++ b/data/items/2026/09.json
@@ -1,0 +1,23 @@
+[
+  {
+    "title": "怪獣8号 鳴海の平日",
+    "titleTranslate": {
+      "zh-Hans": [
+        "怪兽8号 鸣海的日常"
+      ]
+    },
+    "type": "web",
+    "lang": "ja",
+    "officialSite": "https://kaiju-no8.net/",
+    "begin": "2026-09-04T16:00:00.000Z",
+    "broadcast": "",
+    "end": "",
+    "comment": "",
+    "sites": [
+      {
+        "site": "bangumi",
+        "id": "616694"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- 补全漏抓 **4** 部（仅硬映射 ID）

### 怪獣8号 鳴海の平日
- bangumi: [616694](https://bgm.tv/subject/616694)

### 最終楽章 響け！ユーフォニアム 前編
- bangumi: [544816](https://bgm.tv/subject/544816)

### 新劇場版 銀魂 -吉原大炎上-
- bangumi: [578766](https://bgm.tv/subject/578766)

### 機動戦士ガンダム 閃光のハサウェイ キルケーの魔女
- bangumi: [243430](https://bgm.tv/subject/243430)
